### PR TITLE
feat: Dexie永続化と単語帳(/deck)を追加

### DIFF
--- a/src/app/deck/page.test.tsx
+++ b/src/app/deck/page.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * src/app/deck/page.tsx(単語帳画面)のテスト。
+ *
+ * Phase 3 の完了条件である「解説から任意の語句をカード化して `/deck` で
+ * 一覧できる」を検証する。DB操作は fake-indexeddb 上で実際の `cards.ts` を
+ * 動かして確認する(モックしない)。JSONエクスポートに使う
+ * `URL.createObjectURL` / `revokeObjectURL` はjsdomに存在しないためテストで補う。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DeckPage from "./page";
+import { db } from "@/lib/db/schema";
+import { createCard } from "@/lib/db/cards";
+
+/** カード化済みの語句を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
+function seedCard(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
+  return createCard({
+    term: "GG",
+    kind: "abbreviation",
+    meaning: "Good Game(お疲れさま、いい試合でした)の略語",
+    note: "対戦系ゲームの配信終了時によく使われる",
+    sourceMessageText: "GG everyone, that was such a clutch play!",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en",
+    explainLang: "ja",
+    tags: [],
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  // jsdomにはBlob URL APIが無いため、エクスポート機能のテスト用に最小限のスタブを用意する
+  URL.createObjectURL = vi.fn(() => "blob:mock-url");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await db.cards.clear();
+});
+
+describe("DeckPage", () => {
+  it("登録済みのカードを新しい順に一覧表示する", async () => {
+    await seedCard({ term: "GG" });
+    await seedCard({ term: "clutch", meaning: "土壇場での見事なプレー" });
+
+    render(<DeckPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("GG")).toBeInTheDocument();
+    });
+    expect(screen.getByText("clutch")).toBeInTheDocument();
+  });
+
+  it("カードが1件もない場合は空である旨を表示する", async () => {
+    render(<DeckPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/カードがまだありません/)).toBeInTheDocument();
+    });
+  });
+
+  it("検索語を入力すると、term・meaning・noteに一致するカードだけに絞り込む", async () => {
+    await seedCard({ term: "GG", meaning: "Good Game(いい試合)の略語" });
+    await seedCard({ term: "clutch", meaning: "土壇場での見事なプレー" });
+    const user = userEvent.setup();
+
+    render(<DeckPage />);
+    await waitFor(() => expect(screen.getByText("GG")).toBeInTheDocument());
+
+    await user.type(screen.getByLabelText("カードを検索"), "clutch");
+
+    await waitFor(() => {
+      expect(screen.queryByText("GG")).not.toBeInTheDocument();
+    });
+    expect(screen.getByText("clutch")).toBeInTheDocument();
+  });
+
+  it("削除ボタンを押すとカードが一覧から削除される", async () => {
+    await seedCard({ term: "GG" });
+    const user = userEvent.setup();
+
+    render(<DeckPage />);
+    const card = await screen.findByText("GG");
+
+    const cardRow = card.closest("li");
+    if (!cardRow) throw new Error("カード行が見つかりませんでした");
+    await user.click(within(cardRow).getByRole("button", { name: "削除" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("GG")).not.toBeInTheDocument();
+    });
+    expect(await db.cards.count()).toBe(0);
+  });
+
+  it("JSONエクスポートボタンを押すと、表示中のカードをJSON化してダウンロードする", async () => {
+    await seedCard({ term: "GG" });
+    const user = userEvent.setup();
+
+    render(<DeckPage />);
+    await waitFor(() => expect(screen.getByText("GG")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "JSONエクスポート" }));
+
+    expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+});

--- a/src/app/deck/page.tsx
+++ b/src/app/deck/page.tsx
@@ -1,0 +1,130 @@
+/**
+ * 単語帳ページ(/deck)。
+ *
+ * 解説ダイアログでカード化した語句を一覧・検索・削除できる。
+ * 一覧はそのままJSONファイルとしてエクスポートでき、他端末への持ち出しや
+ * バックアップに使える。データはすべてブラウザのIndexedDB(Dexie)に閉じており、
+ * サーバーへの送信は行わない。
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { deleteCard, exportCardsToJson, listCards, searchCards } from "@/lib/db/cards";
+import type { Card as DeckCard } from "@/lib/db/schema";
+
+export default function DeckPage() {
+  const [cards, setCards] = useState<DeckCard[]>([]);
+  const [query, setQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 検索語(空文字なら全件)に応じて一覧を読み直す。DBアクセスはこの関数だけに閉じ込める。
+  const refresh = useCallback((q: string) => {
+    const load = q.trim() === "" ? listCards() : searchCards(q);
+    load.then((result) => {
+      setCards(result);
+      setIsLoading(false);
+    });
+  }, []);
+
+  useEffect(() => {
+    refresh("");
+  }, [refresh]);
+
+  const handleSearchChange = useCallback(
+    (value: string) => {
+      setQuery(value);
+      refresh(value);
+    },
+    [refresh],
+  );
+
+  const handleDelete = useCallback(
+    (id: number) => {
+      deleteCard(id).then(() => refresh(query));
+    },
+    [query, refresh],
+  );
+
+  const handleExport = useCallback(() => {
+    const json = exportCardsToJson(cards);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `chat-sensei-cards-${Date.now()}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+  }, [cards]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>単語帳</CardTitle>
+          <CardDescription>カード化した語句・フレーズの一覧です。検索・削除・JSONエクスポートができます。</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-3">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="deck-search-input">カードを検索</Label>
+            <div className="flex gap-2">
+              <Input
+                id="deck-search-input"
+                placeholder="語句・意味・メモで検索"
+                value={query}
+                onChange={(e) => handleSearchChange(e.target.value)}
+              />
+              <Button onClick={handleExport} variant="outline" disabled={cards.length === 0}>
+                JSONエクスポート
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="flex flex-1 flex-col overflow-hidden">
+        <ScrollArea className="h-[60vh]">
+          {isLoading && <p className="p-4 text-sm text-muted-foreground">読み込み中...</p>}
+
+          {!isLoading && cards.length === 0 && (
+            <p className="p-4 text-sm text-muted-foreground">
+              カードがまだありません。ホーム画面の解説から語句をカード化してください。
+            </p>
+          )}
+
+          {!isLoading && cards.length > 0 && (
+            <ol className="flex flex-col gap-2 p-4">
+              {cards.map((card) => (
+                <li key={card.id} className="rounded-md border p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{card.term}</span>
+                      <Badge variant="secondary">{card.kind}</Badge>
+                    </div>
+                    <Button
+                      onClick={() => handleDelete(card.id!)}
+                      variant="ghost"
+                      size="icon"
+                      aria-label="削除"
+                    >
+                      <Trash2 className="size-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{card.meaning}</p>
+                  {card.note && <p className="text-xs text-muted-foreground">{card.note}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground italic">「{card.sourceMessageText}」</p>
+                </li>
+              ))}
+            </ol>
+          )}
+        </ScrollArea>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -14,6 +14,7 @@ import Home from "./page";
 import type { TwitchIrcClientCallbacks } from "@/lib/twitch/irc-client";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
 import type { ExplanationResult } from "@/lib/ai/schemas";
+import { db } from "@/lib/db/schema";
 
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
@@ -68,16 +69,19 @@ const sampleExplanation: ExplanationResult = {
   difficulty: 1,
 };
 
-beforeEach(() => {
+beforeEach(async () => {
   vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+  // 前のテストの失敗等でカードが残っていても、各テストが空の状態から始まるようにする
+  await db.cards.clear();
 });
 
-afterEach(() => {
+afterEach(async () => {
   mockConnect.mockClear();
   mockDisconnect.mockClear();
   capturedCallbacks = null;
   vi.mocked(runBrowserDiagnosis).mockReset();
   vi.mocked(explainChatMessage).mockReset();
+  await db.cards.clear();
 });
 
 /** 接続 → open状態 → 指定メッセージを1件受信、までの共通セットアップ */
@@ -209,6 +213,38 @@ describe("Home のAI解説(手動ピック)", () => {
       "gg chat",
       expect.objectContaining({ priority: "high", signal: expect.any(AbortSignal) }),
     );
+  });
+
+  it("解説内の語句の「カード化」ボタンを押すと単語帳カードとして保存され、ボタンが「保存済み」に変わる", async () => {
+    vi.mocked(explainChatMessage).mockResolvedValue(sampleExplanation);
+    const user = userEvent.setup();
+    render(<Home />);
+    await connectAndReceiveMessage(user, "gg chat");
+
+    await user.click(screen.getByRole("button", { name: /gg chat/ }));
+    await waitFor(() => {
+      expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "カード化" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "保存済み" })).toBeInTheDocument();
+    });
+
+    const stored = await db.cards.toArray();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      term: "gg",
+      kind: "abbreviation",
+      meaning: sampleExplanation.items[0].meaning,
+      note: sampleExplanation.items[0].note,
+      sourceMessageText: "gg chat",
+      sourceChannel: "somechannel",
+      sourceAuthor: "CodeChamp92",
+      targetLang: "en",
+      explainLang: "ja",
+    });
   });
 
   it("解説生成中はローディング表示になる", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,8 +29,9 @@ import { describeDiagnosis } from "@/lib/ai/describeDiagnosis";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
 import { createExplainBaseSessionFactory, explainChatMessage } from "@/lib/ai/explain";
 import { createSessionPool, type SessionPool } from "@/lib/ai/session-pool";
-import type { ExplanationResult } from "@/lib/ai/schemas";
+import type { ExplanationItem, ExplanationResult } from "@/lib/ai/schemas";
 import { loadSettings } from "@/lib/settings";
+import { createCard } from "@/lib/db/cards";
 
 /** チャットに表示する発言の最大保持件数(古いものから捨てるリングバッファ) */
 const MAX_DISPLAYED_MESSAGES = 300;
@@ -159,6 +160,23 @@ export default function Home() {
     }
   }, []);
 
+  // 解説内の語句をカード化(単語帳に保存)する。言語ペアはカード化時点の設定を保存する。
+  const handleSaveCard = useCallback(async (item: ExplanationItem, sourceMessage: TwitchChatMessage) => {
+    const { settings } = loadSettings();
+    await createCard({
+      term: item.term,
+      kind: item.kind,
+      meaning: item.meaning,
+      note: item.note,
+      sourceMessageText: sourceMessage.text,
+      sourceChannel: sourceMessage.channel,
+      sourceAuthor: sourceMessage.displayName,
+      targetLang: settings.targetLang,
+      explainLang: settings.explainLang,
+      tags: [],
+    });
+  }, []);
+
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 p-6">
       <Card>
@@ -234,14 +252,45 @@ export default function Home() {
             <p className="text-sm text-destructive">{dialogState.errorMessage}</p>
           )}
 
-          {dialogState.status === "success" && <ExplanationResultView result={dialogState.result} />}
+          {dialogState.status === "success" && (
+            <ExplanationResultView
+              result={dialogState.result}
+              sourceMessage={dialogState.sourceMessage}
+              onSaveCard={handleSaveCard}
+            />
+          )}
         </DialogContent>
       </Dialog>
     </div>
   );
 }
 
-function ExplanationResultView({ result }: { result: ExplanationResult }) {
+function ExplanationResultView({
+  result,
+  sourceMessage,
+  onSaveCard,
+}: {
+  result: ExplanationResult;
+  sourceMessage: TwitchChatMessage;
+  onSaveCard: (item: ExplanationItem, sourceMessage: TwitchChatMessage) => Promise<void>;
+}) {
+  // 項目インデックスごとのカード化状態。保存開始と同時に"pending"にしてボタンを無効化し、
+  // 連打による重複保存を防ぐ(CodeRabbit指摘対応)。
+  const [cardStatuses, setCardStatuses] = useState<Record<number, "pending" | "saved" | "error">>({});
+
+  const handleSaveCardClick = useCallback(
+    async (item: ExplanationItem, index: number) => {
+      setCardStatuses((prev) => ({ ...prev, [index]: "pending" }));
+      try {
+        await onSaveCard(item, sourceMessage);
+        setCardStatuses((prev) => ({ ...prev, [index]: "saved" }));
+      } catch {
+        setCardStatuses((prev) => ({ ...prev, [index]: "error" }));
+      }
+    },
+    [onSaveCard, sourceMessage],
+  );
+
   return (
     <div className="flex flex-col gap-3 text-sm">
       <div>
@@ -255,16 +304,33 @@ function ExplanationResultView({ result }: { result: ExplanationResult }) {
       {result.items.length > 0 && (
         <div className="flex flex-col gap-2">
           <p className="font-medium">注目ポイント</p>
-          {result.items.map((item, index) => (
-            <div key={index} className="rounded-md border p-2">
-              <div className="flex items-center gap-2">
-                <span className="font-semibold">{item.term}</span>
-                <Badge variant="secondary">{item.kind}</Badge>
+          {result.items.map((item, index) => {
+            const status = cardStatuses[index];
+            return (
+              <div key={index} className="rounded-md border p-2">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <span className="font-semibold">{item.term}</span>
+                    <Badge variant="secondary">{item.kind}</Badge>
+                  </div>
+                  <Button
+                    onClick={() => handleSaveCardClick(item, index)}
+                    disabled={status === "pending" || status === "saved"}
+                    size="sm"
+                    variant="outline"
+                  >
+                    {status === "saved" && "保存済み"}
+                    {status === "pending" && "保存中..."}
+                    {status === "error" && "再試行"}
+                    {status === undefined && "カード化"}
+                  </Button>
+                </div>
+                <p className="text-muted-foreground">{item.meaning}</p>
+                <p className="text-xs text-muted-foreground">{item.note}</p>
+                {status === "error" && <p className="text-xs text-destructive">カードの保存に失敗しました</p>}
               </div>
-              <p className="text-muted-foreground">{item.meaning}</p>
-              <p className="text-xs text-muted-foreground">{item.note}</p>
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
     </div>

--- a/src/components/site-header.test.tsx
+++ b/src/components/site-header.test.tsx
@@ -21,4 +21,11 @@ describe("SiteHeader", () => {
     const settingsLink = screen.getByRole("link", { name: "設定" });
     expect(settingsLink).toHaveAttribute("href", "/settings");
   });
+
+  it("単語帳ページ(/deck)へのリンクを表示する", () => {
+    render(<SiteHeader />);
+
+    const deckLink = screen.getByRole("link", { name: "単語帳" });
+    expect(deckLink).toHaveAttribute("href", "/deck");
+  });
 });

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -2,8 +2,8 @@
  * 全ページ共通のヘッダー。
  *
  * chat-sensei はページ数の少ないシングルパーパスアプリのため、
- * ナビゲーションは実装済みのページ(ホーム / 設定)のみを表示する。
- * 単語帳(/deck)・復習(/study)は Phase 3・5 でページ実装後にリンクを追加する。
+ * ナビゲーションは実装済みのページ(ホーム / 単語帳 / 設定)のみを表示する。
+ * 復習(/study)は Phase 5 でページ実装後にリンクを追加する。
  */
 import Link from "next/link";
 
@@ -15,6 +15,9 @@ export function SiteHeader() {
           chat-sensei
         </Link>
         <div className="flex items-center gap-4 text-sm">
+          <Link href="/deck" className="text-muted-foreground transition-colors hover:text-foreground">
+            単語帳
+          </Link>
           <Link href="/settings" className="text-muted-foreground transition-colors hover:text-foreground">
             設定
           </Link>

--- a/src/lib/db/cards.test.ts
+++ b/src/lib/db/cards.test.ts
@@ -1,0 +1,117 @@
+/**
+ * src/lib/db/cards.ts のテスト。
+ *
+ * fake-indexeddb(vitest.setup.ts で `fake-indexeddb/auto` を導入済み)を使い、
+ * 実際のDexie APIに対してカードのCRUDとJSONエクスポートを検証する。
+ * 各テストの独立性を保つため、テストごとに `db.cards` を空にしてから実行する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { db } from "./schema";
+import { createCard, deleteCard, exportCardsToJson, listCards, searchCards } from "./cards";
+
+/** カード化ボタンから渡される入力を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
+function buildNewCardInput(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
+  return {
+    term: "GG",
+    kind: "abbreviation" as const,
+    meaning: "Good Game(お疲れさま、いい試合でした)の略語",
+    note: "対戦系ゲームの配信終了時や決着がついた直後によく使われる",
+    sourceMessageText: "GG everyone, that was such a clutch play!",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en" as const,
+    explainLang: "ja" as const,
+    tags: [],
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await db.cards.clear();
+});
+
+describe("createCard", () => {
+  it("id・作成日時・初期SRS状態を付与してカードを保存し、保存内容を返す", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-29T10:00:00.000Z").getTime());
+
+    const created = await createCard(buildNewCardInput());
+
+    expect(created.id).toBeTypeOf("number");
+    expect(created.term).toBe("GG");
+    expect(created.createdAt).toBe(new Date("2026-07-29T10:00:00.000Z").getTime());
+    expect(created.srs).toEqual({
+      due: new Date("2026-07-29T10:00:00.000Z").getTime(),
+      interval: 0,
+      easeFactor: 2.5,
+      repetitions: 0,
+      lapses: 0,
+      lastReviewedAt: null,
+    });
+
+    const stored = await db.cards.get(created.id!);
+    expect(stored).toEqual(created);
+  });
+});
+
+describe("listCards", () => {
+  it("作成日時が新しい順にカードを返す", async () => {
+    const dateNowSpy = vi.spyOn(Date, "now");
+    dateNowSpy.mockReturnValue(new Date("2026-07-29T10:00:00.000Z").getTime());
+    const older = await createCard(buildNewCardInput({ term: "GG" }));
+    dateNowSpy.mockReturnValue(new Date("2026-07-29T10:05:00.000Z").getTime());
+    const newer = await createCard(buildNewCardInput({ term: "clutch" }));
+
+    const list = await listCards();
+
+    expect(list.map((card) => card.id)).toEqual([newer.id, older.id]);
+  });
+});
+
+describe("searchCards", () => {
+  it("term・meaning・noteの部分一致(大文字小文字を区別しない)でカードを絞り込む", async () => {
+    await createCard(buildNewCardInput({ term: "GG", meaning: "Good Game(いい試合)の略語" }));
+    await createCard(
+      buildNewCardInput({ term: "clutch", meaning: "土壇場での見事なプレー", note: "実況者がよく使う表現" }),
+    );
+
+    const byTerm = await searchCards("gg");
+    expect(byTerm.map((c) => c.term)).toEqual(["GG"]);
+
+    const byNote = await searchCards("実況者");
+    expect(byNote.map((c) => c.term)).toEqual(["clutch"]);
+  });
+
+  it("空文字で検索した場合は全カードを返す", async () => {
+    await createCard(buildNewCardInput({ term: "GG" }));
+    await createCard(buildNewCardInput({ term: "clutch" }));
+
+    const result = await searchCards("");
+
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe("deleteCard", () => {
+  it("指定したIDのカードを削除する", async () => {
+    const created = await createCard(buildNewCardInput());
+
+    await deleteCard(created.id!);
+
+    const stored = await db.cards.get(created.id!);
+    expect(stored).toBeUndefined();
+  });
+});
+
+describe("exportCardsToJson", () => {
+  it("カード配列を整形済みJSON文字列に変換する(DBアクセスなしの純関数)", () => {
+    const card = { ...buildNewCardInput(), id: 1, createdAt: 0, srs: null } as unknown as Parameters<
+      typeof exportCardsToJson
+    >[0][number];
+
+    const json = exportCardsToJson([card]);
+
+    expect(JSON.parse(json)).toEqual([card]);
+    expect(json).toContain("\n"); // 整形(pretty print)されていること
+  });
+});

--- a/src/lib/db/cards.ts
+++ b/src/lib/db/cards.ts
@@ -1,0 +1,63 @@
+/**
+ * 単語帳カード(`Card`)のCRUDと検索・エクスポートを行うモジュール。
+ *
+ * 解説ダイアログの各語句候補(`ExplanationItem`)をカード化する際、および
+ * `/deck` ページでの一覧・検索・削除・JSONエクスポートに使う。
+ * データの永続化先は `schema.ts` の Dexie データベースのみとし、
+ * サーバーへの送信は行わない。
+ */
+import type { Card, CardSrsState } from "./schema";
+import { db } from "./schema";
+
+/** SM-2の初期値。Phase 5「復習クイズ」で採点ロジックが状態を更新するまでの土台となる */
+const INITIAL_EASE_FACTOR = 2.5;
+
+/** カード作成時に渡す入力(id・createdAt・srsはこの関数側で採番・初期化する) */
+export type NewCardInput = Omit<Card, "id" | "createdAt" | "srs">;
+
+/** カード作成時点を「初回復習も即座に必要」とみなしたSM-2初期状態を組み立てる */
+function createInitialSrsState(now: number): CardSrsState {
+  return {
+    due: now,
+    interval: 0,
+    easeFactor: INITIAL_EASE_FACTOR,
+    repetitions: 0,
+    lapses: 0,
+    lastReviewedAt: null,
+  };
+}
+
+/** カードを作成し、DBに保存したうえで保存内容(採番されたid・createdAt付き)を返す */
+export async function createCard(input: NewCardInput): Promise<Card> {
+  const now = Date.now();
+  const card: Card = { ...input, createdAt: now, srs: createInitialSrsState(now) };
+  const id = await db.cards.add(card);
+  return { ...card, id };
+}
+
+/** 全カードを作成日時が新しい順に返す */
+export async function listCards(): Promise<Card[]> {
+  return db.cards.orderBy("createdAt").reverse().toArray();
+}
+
+/** term・meaning・noteのいずれかに部分一致(大文字小文字を区別しない)するカードを、作成日時が新しい順に返す */
+export async function searchCards(query: string): Promise<Card[]> {
+  const all = await listCards();
+  const normalizedQuery = query.trim().toLowerCase();
+  if (normalizedQuery === "") {
+    return all;
+  }
+  return all.filter((card) =>
+    [card.term, card.meaning, card.note].some((field) => field.toLowerCase().includes(normalizedQuery)),
+  );
+}
+
+/** 指定したIDのカードを削除する */
+export async function deleteCard(id: number): Promise<void> {
+  await db.cards.delete(id);
+}
+
+/** カード配列を、そのままファイル保存できる整形済みJSON文字列に変換する(DBアクセスなしの純関数) */
+export function exportCardsToJson(cards: Card[]): string {
+  return JSON.stringify(cards, null, 2);
+}

--- a/src/lib/db/messages.test.ts
+++ b/src/lib/db/messages.test.ts
@@ -1,0 +1,65 @@
+/**
+ * src/lib/db/messages.ts のテスト。
+ *
+ * fake-indexeddb を使い、Twitchチャットメッセージの保存と
+ * チャンネルごとのリングバッファ的なprune(直近N件を超えたら古い順に削除)を検証する。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { db } from "./schema";
+import { saveMessage } from "./messages";
+import type { StoredMessage } from "./schema";
+
+/** テスト用のTwitchチャットメッセージ入力(意味の分かる日本語・実チャット文を使用) */
+function buildMessageInput(overrides: Partial<Omit<StoredMessage, "id">> = {}): Omit<StoredMessage, "id"> {
+  return {
+    channel: "zackrawrr",
+    userId: "12345",
+    displayName: "yamada_taro",
+    color: "#1E90FF",
+    text: "GG everyone, that was such a clutch play!",
+    emotes: [],
+    timestampMs: 1_000,
+    detectedLang: null,
+    confidence: null,
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await db.messages.clear();
+});
+
+describe("saveMessage", () => {
+  it("メッセージをそのまま保存し、DBから取得できる", async () => {
+    await saveMessage(buildMessageInput());
+
+    const stored = await db.messages.toArray();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]).toMatchObject({
+      channel: "zackrawrr",
+      displayName: "yamada_taro",
+      text: "GG everyone, that was such a clutch play!",
+    });
+  });
+
+  it("同一チャンネルのメッセージが上限を超えたら、古い順に削除して直近N件だけ残す", async () => {
+    for (let i = 0; i < 5; i++) {
+      await saveMessage(buildMessageInput({ text: `message-${i}`, timestampMs: i }), { maxMessagesPerChannel: 3 });
+    }
+
+    const remaining = await db.messages.where("channel").equals("zackrawrr").toArray();
+    expect(remaining.map((m) => m.text)).toEqual(["message-2", "message-3", "message-4"]);
+  });
+
+  it("prune対象は同一チャンネルのみで、他チャンネルのメッセージは削除しない", async () => {
+    await saveMessage(buildMessageInput({ channel: "other_channel", text: "other channel message" }), {
+      maxMessagesPerChannel: 3,
+    });
+    for (let i = 0; i < 4; i++) {
+      await saveMessage(buildMessageInput({ text: `message-${i}`, timestampMs: i }), { maxMessagesPerChannel: 3 });
+    }
+
+    const otherChannelMessages = await db.messages.where("channel").equals("other_channel").toArray();
+    expect(otherChannelMessages).toHaveLength(1);
+  });
+});

--- a/src/lib/db/messages.ts
+++ b/src/lib/db/messages.ts
@@ -1,0 +1,38 @@
+/**
+ * Twitchチャットメッセージ(`StoredMessage`)の保存・pruneを行うモジュール。
+ *
+ * ライブ接続中は大量のメッセージが流れ続けるため、チャンネルごとに
+ * 直近N件だけをリングバッファ的に保持し、古いメッセージから削除する。
+ */
+import type { StoredMessage } from "./schema";
+import { db } from "./schema";
+
+/** チャンネルごとに保持するメッセージの既定上限件数 */
+export const DEFAULT_MAX_MESSAGES_PER_CHANNEL = 2000;
+
+export interface SaveMessageOptions {
+  /** チャンネルごとの保持上限件数(テストでは小さい値を指定する) */
+  maxMessagesPerChannel?: number;
+}
+
+/**
+ * メッセージを保存し、同一チャンネルの保存件数が上限を超えていれば
+ * `timestampMs` が古い順に削除して上限件数まで間引く。
+ */
+export async function saveMessage(
+  message: Omit<StoredMessage, "id">,
+  options: SaveMessageOptions = {},
+): Promise<void> {
+  const maxMessagesPerChannel = options.maxMessagesPerChannel ?? DEFAULT_MAX_MESSAGES_PER_CHANNEL;
+
+  await db.messages.add(message);
+
+  const channelMessages = await db.messages.where("channel").equals(message.channel).sortBy("timestampMs");
+  const overflowCount = channelMessages.length - maxMessagesPerChannel;
+  if (overflowCount <= 0) {
+    return;
+  }
+
+  const idsToDelete = channelMessages.slice(0, overflowCount).map((m) => m.id!);
+  await db.messages.bulkDelete(idsToDelete);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,0 +1,103 @@
+/**
+ * IndexedDB(Dexie)のスキーマ定義。
+ *
+ * chat-sensei はサーバーを持たないクライアントサイド専用アプリのため、
+ * Twitchチャットの受信メッセージと学習者が作成した単語帳カードをすべて
+ * ブラウザのIndexedDBに保存する。このファイルはテーブル定義と型のみを持ち、
+ * CRUD操作は `cards.ts` / `messages.ts` に委譲する。
+ */
+import Dexie, { type Table } from "dexie";
+import type { EmotePosition } from "../twitch/irc-parser";
+import type { ExplanationItemKind } from "../ai/schemas";
+import type { SupportedLanguage } from "../ai/prompts";
+
+/** Twitchチャットの1メッセージを永続化した形 */
+export interface StoredMessage {
+  id?: number;
+  /** 先頭の `#` を除いたチャンネル名 */
+  channel: string;
+  userId: string | null;
+  displayName: string;
+  color: string | null;
+  text: string;
+  emotes: EmotePosition[];
+  /** `tmi-sent-ts` 由来のミリ秒UNIXタイムスタンプ。取得できない場合は null */
+  timestampMs: number | null;
+  /** Language Detector API の判定結果(未判定・低確信度は null) */
+  detectedLang: string | null;
+  /** 判定の確信度(0〜1)。未判定は null */
+  confidence: number | null;
+}
+
+/**
+ * SM-2間隔反復アルゴリズムの状態(Phase 5「復習クイズ」で使用)。
+ * Phase 3時点ではカード作成時に初期値を保存するのみで、採点ロジックは実装しない。
+ */
+export interface CardSrsState {
+  /** 次回復習予定日時(epoch ms) */
+  due: number;
+  /** 復習間隔(日) */
+  interval: number;
+  easeFactor: number;
+  repetitions: number;
+  lapses: number;
+  /** 最後に復習した日時(epoch ms)。未復習は null */
+  lastReviewedAt: number | null;
+}
+
+/** 単語帳カード(教材本体) */
+export interface Card {
+  id?: number;
+  /** 元のチャット本文中に登場する語句・フレーズそのもの */
+  term: string;
+  kind: ExplanationItemKind;
+  /** 解説言語での意味 */
+  meaning: string;
+  /** 使われ方についての一言メモ */
+  note: string;
+  /** カード化の元になったチャット発言の全文 */
+  sourceMessageText: string;
+  sourceChannel: string;
+  sourceAuthor: string;
+  /** 学ぶ言語(カード化時点の設定を保存する) */
+  targetLang: SupportedLanguage;
+  /** 解説言語(カード化時点の設定を保存する) */
+  explainLang: SupportedLanguage;
+  tags: string[];
+  /** 作成日時(epoch ms) */
+  createdAt: number;
+  srs: CardSrsState;
+}
+
+/** 復習履歴(Phase 5「復習クイズ」で使用) */
+export interface Review {
+  id?: number;
+  cardId: number;
+  /** 採点(Again/Hard/Good/Easyなど、Phase 5で定義する) */
+  grade: number;
+  reviewedAt: number;
+}
+
+/**
+ * chat-sensei の Dexie データベース。
+ *
+ * テスト(fake-indexeddb)ではテストごとに異なる `name` を渡すことで、
+ * IndexedDBの状態を独立させられるようにコンストラクタ引数化している。
+ */
+export class ChatSenseiDatabase extends Dexie {
+  messages!: Table<StoredMessage, number>;
+  cards!: Table<Card, number>;
+  reviews!: Table<Review, number>;
+
+  constructor(name = "chat-sensei") {
+    super(name);
+    this.version(1).stores({
+      messages: "++id, channel, timestampMs",
+      cards: "++id, term, kind, createdAt, *tags",
+      reviews: "++id, cardId, reviewedAt",
+    });
+  }
+}
+
+/** アプリ全体で共有する既定のデータベースインスタンス */
+export const db = new ChatSenseiDatabase();


### PR DESCRIPTION
## Summary

- 解説ダイアログの各語句候補(`item`)に「カード化」ボタンを追加し、単語帳カードとしてIndexedDB(Dexie)へ保存できるようにした
- `src/lib/db/schema.ts` にDexieスキーマ(`messages`/`cards`/`reviews`)を定義し、`cards`テーブルにはPhase 5で使うSM-2状態(`srs`)の初期値もカード作成時に保存する
- `src/lib/db/cards.ts` にカードのCRUD(作成・一覧・検索・削除)とJSONエクスポート用の純関数を実装
- `src/lib/db/messages.ts` にTwitchチャットメッセージの保存とチャンネルごとのprune(直近N件のリングバッファ)を実装
- `/deck` ページを新規作成し、カードの一覧・検索・削除・JSONエクスポートができるようにした
- ヘッダーに `/deck` へのナビゲーションリンクを追加

## Test plan

- [x] `npm test` — 全125テストがパス(fake-indexeddbを使ったcards/messages/deckページのCRUDテストを含む)
- [x] `npm run lint` — 警告0件
- [x] `npm run type-check` — エラー0件
- [x] `npm run build` — ビルド成功
- [x] CodeRabbit事前レビュー(`coderabbit review --agent`)を実施し、指摘2件(カード化ボタンの連打防止・エラーハンドリング、テストのbeforeEachでのDBクリア)に対応済み

Closes #1