### PR TITLE
feat: 自動抽出パイプライン(message-filter → triage → 低優先キュー)を追加

### DIFF
--- a/src/app/deck/page.test.tsx
+++ b/src/app/deck/page.test.tsx
@@ -12,6 +12,7 @@ import userEvent from "@testing-library/user-event";
 import DeckPage from "./page";
 import { db } from "@/lib/db/schema";
 import { createCard } from "@/lib/db/cards";
+import { createCandidate } from "@/lib/db/candidates";
 
 /** カード化済みの語句を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
 function seedCard(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
@@ -30,6 +31,23 @@ function seedCard(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
   });
 }
 
+/** 自動抽出パイプラインが生成した候補を模したテストデータ */
+function seedCandidate(overrides: Partial<Parameters<typeof createCandidate>[0]> = {}) {
+  return createCandidate({
+    term: "clutch",
+    kind: "word",
+    meaning: "土壇場での見事なプレー",
+    note: "対戦ゲームの実況・チャットでよく使われる",
+    sourceMessageText: "that was such a clutch play honestly",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en",
+    explainLang: "ja",
+    tags: [],
+    ...overrides,
+  });
+}
+
 beforeEach(() => {
   // jsdomにはBlob URL APIが無いため、エクスポート機能のテスト用に最小限のスタブを用意する
   URL.createObjectURL = vi.fn(() => "blob:mock-url");
@@ -39,6 +57,7 @@ beforeEach(() => {
 afterEach(async () => {
   vi.restoreAllMocks();
   await db.cards.clear();
+  await db.candidates.clear();
 });
 
 describe("DeckPage", () => {
@@ -106,5 +125,66 @@ describe("DeckPage", () => {
 
     expect(URL.createObjectURL).toHaveBeenCalledWith(expect.any(Blob));
     expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+});
+
+describe("DeckPage の自動抽出候補レビュー", () => {
+  it("候補が1件もない場合は空である旨を表示する", async () => {
+    render(<DeckPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/候補はありません/)).toBeInTheDocument();
+    });
+  });
+
+  it("候補を一覧表示する(語句・意味・メモ・元の発言)", async () => {
+    await seedCandidate();
+
+    render(<DeckPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("clutch")).toBeInTheDocument();
+    });
+    expect(screen.getByText("土壇場での見事なプレー")).toBeInTheDocument();
+    expect(screen.getByText("対戦ゲームの実況・チャットでよく使われる")).toBeInTheDocument();
+    expect(screen.getByText(/that was such a clutch play honestly/)).toBeInTheDocument();
+  });
+
+  it("採用ボタンを押すと候補が単語帳(cards)へ移動し、一覧から消える", async () => {
+    const candidate = await seedCandidate();
+    const user = userEvent.setup();
+
+    render(<DeckPage />);
+    const term = await screen.findByText("clutch");
+
+    const candidateRow = term.closest("li");
+    if (!candidateRow) throw new Error("候補行が見つかりませんでした");
+    await user.click(within(candidateRow).getByRole("button", { name: "採用" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/候補はありません/)).toBeInTheDocument();
+    });
+    const cards = await db.cards.toArray();
+    expect(cards).toHaveLength(1);
+    expect(cards[0].term).toBe("clutch");
+    const remainingCandidate = await db.candidates.get(candidate.id!);
+    expect(remainingCandidate).toBeUndefined();
+  });
+
+  it("却下ボタンを押すと候補が削除され、単語帳には保存されない", async () => {
+    await seedCandidate();
+    const user = userEvent.setup();
+
+    render(<DeckPage />);
+    const term = await screen.findByText("clutch");
+
+    const candidateRow = term.closest("li");
+    if (!candidateRow) throw new Error("候補行が見つかりませんでした");
+    await user.click(within(candidateRow).getByRole("button", { name: "却下" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/候補はありません/)).toBeInTheDocument();
+    });
+    expect(await db.cards.count()).toBe(0);
   });
 });

--- a/src/app/deck/page.tsx
+++ b/src/app/deck/page.tsx
@@ -17,7 +17,8 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { deleteCard, exportCardsToJson, listCards, searchCards } from "@/lib/db/cards";
-import type { Card as DeckCard } from "@/lib/db/schema";
+import { acceptCandidate, listCandidates, rejectCandidate } from "@/lib/db/candidates";
+import type { Card as DeckCard, Candidate } from "@/lib/db/schema";
 
 export default function DeckPage() {
   const [cards, setCards] = useState<DeckCard[]>([]);
@@ -63,6 +64,38 @@ export default function DeckPage() {
     URL.revokeObjectURL(url);
   }, [cards]);
 
+  // --- 自動抽出の候補レビュー(採用/却下) ---
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+  const [isLoadingCandidates, setIsLoadingCandidates] = useState(true);
+
+  const refreshCandidates = useCallback(() => {
+    listCandidates().then((result) => {
+      setCandidates(result);
+      setIsLoadingCandidates(false);
+    });
+  }, []);
+
+  useEffect(() => {
+    refreshCandidates();
+  }, [refreshCandidates]);
+
+  const handleAcceptCandidate = useCallback(
+    (id: number) => {
+      acceptCandidate(id).then(() => {
+        refresh(query);
+        refreshCandidates();
+      });
+    },
+    [query, refresh, refreshCandidates],
+  );
+
+  const handleRejectCandidate = useCallback(
+    (id: number) => {
+      rejectCandidate(id).then(() => refreshCandidates());
+    },
+    [refreshCandidates],
+  );
+
   return (
     <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 p-6">
       <Card>
@@ -85,6 +118,48 @@ export default function DeckPage() {
               </Button>
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>自動抽出の候補</CardTitle>
+          <CardDescription>
+            AIが自動抽出した語句の候補です。採用すると単語帳に保存され、却下すると破棄されます。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2">
+          {isLoadingCandidates && <p className="text-sm text-muted-foreground">読み込み中...</p>}
+
+          {!isLoadingCandidates && candidates.length === 0 && (
+            <p className="text-sm text-muted-foreground">候補はありません。</p>
+          )}
+
+          {!isLoadingCandidates && candidates.length > 0 && (
+            <ol className="flex flex-col gap-2">
+              {candidates.map((candidate) => (
+                <li key={candidate.id} className="rounded-md border p-3">
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="font-semibold">{candidate.term}</span>
+                      <Badge variant="secondary">{candidate.kind}</Badge>
+                    </div>
+                    <div className="flex gap-1">
+                      <Button onClick={() => handleAcceptCandidate(candidate.id!)} size="sm" variant="outline">
+                        採用
+                      </Button>
+                      <Button onClick={() => handleRejectCandidate(candidate.id!)} size="sm" variant="ghost">
+                        却下
+                      </Button>
+                    </div>
+                  </div>
+                  <p className="text-sm text-muted-foreground">{candidate.meaning}</p>
+                  {candidate.note && <p className="text-xs text-muted-foreground">{candidate.note}</p>}
+                  <p className="mt-1 text-xs text-muted-foreground italic">「{candidate.sourceMessageText}」</p>
+                </li>
+              ))}
+            </ol>
+          )}
         </CardContent>
       </Card>
 

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -40,8 +40,14 @@ vi.mock("@/lib/ai/explain", async () => {
   return { ...actual, explainChatMessage: vi.fn() };
 });
 
+vi.mock("@/lib/ai/auto-extraction", () => ({
+  createAutoExtractionPipeline: vi.fn(),
+}));
+
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
 import { explainChatMessage } from "@/lib/ai/explain";
+import { createAutoExtractionPipeline } from "@/lib/ai/auto-extraction";
+import { saveSettings } from "@/lib/settings";
 
 /** 全項目利用可能な基準診断結果 */
 const readyDiagnosis: EnvironmentDiagnosis = {
@@ -71,6 +77,8 @@ const sampleExplanation: ExplanationResult = {
 
 beforeEach(async () => {
   vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+  // 自動抽出は既定でモック化し、明示的にテストしないケースでは何もしないダミーを返す
+  vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage: vi.fn().mockResolvedValue(undefined) });
   // 前のテストの失敗等でカードが残っていても、各テストが空の状態から始まるようにする
   await db.cards.clear();
 });
@@ -81,6 +89,8 @@ afterEach(async () => {
   capturedCallbacks = null;
   vi.mocked(runBrowserDiagnosis).mockReset();
   vi.mocked(explainChatMessage).mockReset();
+  vi.mocked(createAutoExtractionPipeline).mockReset();
+  window.localStorage.clear();
   await db.cards.clear();
 });
 
@@ -335,5 +345,87 @@ describe("Home のAI解説(手動ピック)", () => {
     await waitFor(() => {
       expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
     });
+  });
+});
+
+describe("Home の自動抽出(バックグラウンド)", () => {
+  it("自動抽出が無効(デフォルト設定)の場合、発言を受信してもパイプラインを呼ばない", async () => {
+    const processMessage = vi.fn();
+    vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await connectAndReceiveMessage(user, "that was such a clutch play honestly");
+
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it("自動抽出が有効な場合、受信した発言と設定をパイプラインに渡す", async () => {
+    saveSettings({
+      targetLang: "en",
+      explainLang: "ja",
+      autoExtraction: { enabled: true, strictness: "strict" },
+    });
+    const processMessage = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await connectAndReceiveMessage(user, "that was such a clutch play honestly");
+
+    await waitFor(() => {
+      expect(processMessage).toHaveBeenCalledTimes(1);
+    });
+    expect(processMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ text: "that was such a clutch play honestly" }),
+      expect.objectContaining({
+        strictness: "strict",
+        targetLang: "en",
+        explainLang: "ja",
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it("Prompt APIが利用できない場合は、自動抽出が有効でもパイプラインを呼ばない", async () => {
+    vi.mocked(runBrowserDiagnosis).mockResolvedValue(notReadyDiagnosis);
+    saveSettings({
+      targetLang: "en",
+      explainLang: "ja",
+      autoExtraction: { enabled: true, strictness: "normal" },
+    });
+    const processMessage = vi.fn();
+    vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await connectAndReceiveMessage(user, "that was such a clutch play honestly");
+
+    expect(processMessage).not.toHaveBeenCalled();
+  });
+
+  it("切断すると、自動抽出に渡したAbortSignalを中断する", async () => {
+    saveSettings({
+      targetLang: "en",
+      explainLang: "ja",
+      autoExtraction: { enabled: true, strictness: "normal" },
+    });
+    let capturedSignal: AbortSignal | undefined;
+    const processMessage = vi.fn().mockImplementation((_message: unknown, options: { signal?: AbortSignal }) => {
+      capturedSignal = options.signal;
+      return new Promise(() => {}); // 中断だけを検証するため永久に未解決
+    });
+    vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage });
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await connectAndReceiveMessage(user, "that was such a clutch play honestly");
+    await waitFor(() => {
+      expect(capturedSignal).toBeDefined();
+    });
+
+    await user.click(await screen.findByRole("button", { name: "切断する" }));
+
+    expect(capturedSignal?.aborted).toBe(true);
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,6 +29,7 @@ import { describeDiagnosis } from "@/lib/ai/describeDiagnosis";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
 import { createExplainBaseSessionFactory, explainChatMessage } from "@/lib/ai/explain";
 import { createSessionPool, type SessionPool } from "@/lib/ai/session-pool";
+import { createAutoExtractionPipeline, type AutoExtractionPipeline } from "@/lib/ai/auto-extraction";
 import type { ExplanationItem, ExplanationResult } from "@/lib/ai/schemas";
 import { loadSettings } from "@/lib/settings";
 import { createCard } from "@/lib/db/cards";
@@ -63,8 +64,48 @@ export default function Home() {
   const [messages, setMessages] = useState<TwitchChatMessage[]>([]);
   const clientRef = useRef<TwitchIrcClient | null>(null);
 
+  // --- AI解説(手動ピック)・自動抽出(バックグラウンド)で共有する参照 ---
+  const [aiDiagnosis, setAiDiagnosis] = useState<EnvironmentDiagnosis | null>(null);
+  // getClient()のonEventはマウント時の1回しか再生成されないクロージャのため、
+  // 最新のaiDiagnosisをrefにも同期しておき、自動抽出の実行可否をそこから判定する。
+  const aiDiagnosisRef = useRef<EnvironmentDiagnosis | null>(null);
+  const sessionPoolRef = useRef<SessionPool | null>(null);
+  const autoExtractionPipelineRef = useRef<AutoExtractionPipeline | null>(null);
+  const autoExtractionAbortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    aiDiagnosisRef.current = aiDiagnosis;
+  }, [aiDiagnosis]);
+
+  useEffect(() => {
+    runBrowserDiagnosis()
+      .then((diagnosis) => setAiDiagnosis(diagnosis))
+      .catch(() => setAiDiagnosis(null));
+  }, []);
+
+  // セッションプールは設定(言語ペア)を使って初回利用時に一度だけ生成する。
+  // 手動ピック(explain, high優先度)と自動抽出(triage/explain, low優先度)はこのプールを共有し、
+  // Prompt APIの呼び出しを常に直列化する。
+  const getSessionPool = useCallback((): SessionPool => {
+    if (!sessionPoolRef.current) {
+      const { settings } = loadSettings();
+      sessionPoolRef.current = createSessionPool({
+        createBaseSession: createExplainBaseSessionFactory(settings.targetLang, settings.explainLang),
+      });
+    }
+    return sessionPoolRef.current;
+  }, []);
+
+  const getAutoExtractionPipeline = useCallback((): AutoExtractionPipeline => {
+    if (!autoExtractionPipelineRef.current) {
+      autoExtractionPipelineRef.current = createAutoExtractionPipeline({ sessionPool: getSessionPool() });
+    }
+    return autoExtractionPipelineRef.current;
+  }, [getSessionPool]);
+
   // クライアントは初回レンダリング時に一度だけ生成する。
   // setState群はReactが安定した参照を保証するため、コールバック内で使っても古いクロージャの問題は起きない。
+  // (refに保持したgetAutoExtractionPipeline/aiDiagnosisRefも、呼び出し時点で最新の値を参照する)
   const getClient = useCallback((): TwitchIrcClient => {
     if (!clientRef.current) {
       clientRef.current = createTwitchIrcClient({
@@ -77,47 +118,47 @@ export default function Home() {
               ? next.slice(next.length - MAX_DISPLAYED_MESSAGES)
               : next;
           });
+
+          const { settings } = loadSettings();
+          if (settings.autoExtraction.enabled && aiDiagnosisRef.current?.overallReady) {
+            getAutoExtractionPipeline()
+              .processMessage(event.message, {
+                strictness: settings.autoExtraction.strictness,
+                targetLang: settings.targetLang,
+                explainLang: settings.explainLang,
+                signal: autoExtractionAbortControllerRef.current?.signal,
+              })
+              .catch(() => {
+                // 自動抽出はベストエフォートのバックグラウンド処理のため、
+                // 個別発言の失敗(Prompt APIエラー・中断)はUIに通知せず読み捨てる
+              });
+          }
         },
       });
     }
     return clientRef.current;
-  }, []);
+  }, [getAutoExtractionPipeline]);
 
   const handleConnect = useCallback(() => {
     const channel = channelInput.trim();
     if (!channel) return;
     setMessages([]);
+    // チャンネルを切り替えるので、前のチャンネルに紐づく自動抽出ジョブを中断する
+    autoExtractionAbortControllerRef.current?.abort();
+    autoExtractionAbortControllerRef.current = new AbortController();
     getClient().connect(channel);
   }, [channelInput, getClient]);
 
   const handleDisconnect = useCallback(() => {
+    autoExtractionAbortControllerRef.current?.abort();
     getClient().disconnect();
   }, [getClient]);
 
   const connected = isConnectingOrConnected(connectionState);
 
   // --- AI解説(手動ピック) ---
-  const [aiDiagnosis, setAiDiagnosis] = useState<EnvironmentDiagnosis | null>(null);
-  const sessionPoolRef = useRef<SessionPool | null>(null);
   const explainAbortControllerRef = useRef<AbortController | null>(null);
   const [dialogState, setDialogState] = useState<ExplanationDialogState>({ status: "idle" });
-
-  useEffect(() => {
-    runBrowserDiagnosis()
-      .then((diagnosis) => setAiDiagnosis(diagnosis))
-      .catch(() => setAiDiagnosis(null));
-  }, []);
-
-  // セッションプールは設定(言語ペア)を使って初回クリック時に一度だけ生成する。
-  const getSessionPool = useCallback((): SessionPool => {
-    if (!sessionPoolRef.current) {
-      const { settings } = loadSettings();
-      sessionPoolRef.current = createSessionPool({
-        createBaseSession: createExplainBaseSessionFactory(settings.targetLang, settings.explainLang),
-      });
-    }
-    return sessionPoolRef.current;
-  }, []);
 
   const handleMessageClick = useCallback(
     (message: TwitchChatMessage) => {

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -134,6 +134,7 @@ describe("SettingsPage", () => {
       expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "{}")).toEqual({
         targetLang: "es",
         explainLang: "de",
+        autoExtraction: { enabled: false, strictness: "normal" },
       });
     });
 
@@ -148,6 +149,53 @@ describe("SettingsPage", () => {
 
       expect(screen.getByText(/学ぶ言語と解説言語には異なる言語を指定してください/)).toBeInTheDocument();
       expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
+    });
+  });
+
+  describe("自動抽出設定", () => {
+    it("デフォルトでは無効、フィルタの厳しさは標準を選択済みで表示する", () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+
+      render(<SettingsPage />);
+
+      expect(screen.getByRole("switch", { name: "自動抽出を有効にする" })).not.toBeChecked();
+      expect(screen.getByLabelText("フィルタの厳しさ")).toHaveValue("normal");
+    });
+
+    it("保存されていた自動抽出設定を読み込んでUIに反映する", async () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+      window.localStorage.setItem(
+        SETTINGS_STORAGE_KEY,
+        JSON.stringify({
+          targetLang: "en",
+          explainLang: "ja",
+          autoExtraction: { enabled: true, strictness: "loose" },
+        }),
+      );
+
+      render(<SettingsPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("switch", { name: "自動抽出を有効にする" })).toBeChecked();
+      });
+      expect(screen.getByLabelText("フィルタの厳しさ")).toHaveValue("loose");
+    });
+
+    it("自動抽出を有効にしてフィルタの厳しさを変更し保存すると、LocalStorageに反映される", async () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+      const user = userEvent.setup();
+
+      render(<SettingsPage />);
+
+      await user.click(screen.getByRole("switch", { name: "自動抽出を有効にする" }));
+      await user.selectOptions(screen.getByLabelText("フィルタの厳しさ"), "strict");
+      await user.click(screen.getByRole("button", { name: "保存する" }));
+
+      expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "{}")).toEqual({
+        targetLang: "en",
+        explainLang: "ja",
+        autoExtraction: { enabled: true, strictness: "strict" },
+      });
     });
   });
 });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -16,15 +16,19 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
 import { describeDiagnosis, type DiagnosisMessage } from "@/lib/ai/describeDiagnosis";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/lib/ai/prompts";
+import { AUTO_EXTRACTION_STRICTNESS_LEVELS, type AutoExtractionStrictness } from "@/lib/twitch/message-filter";
 import {
+  AUTO_EXTRACTION_STRICTNESS_DISPLAY_NAMES,
   DEFAULT_SETTINGS,
   LANGUAGE_DISPLAY_NAMES,
   loadSettings,
   saveSettings,
   settingsSchema,
+  type Settings,
 } from "@/lib/settings";
 
 type DiagnosisState =
@@ -80,9 +84,7 @@ export default function SettingsPage() {
     fetchDiagnosis();
   }, [fetchDiagnosis]);
 
-  const [languagePair, setLanguagePair] = useState<{ targetLang: SupportedLanguage; explainLang: SupportedLanguage }>(
-    DEFAULT_SETTINGS,
-  );
+  const [settingsForm, setSettingsForm] = useState<Settings>(DEFAULT_SETTINGS);
   const [wasCorrupted, setWasCorrupted] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savedNotice, setSavedNotice] = useState(false);
@@ -94,14 +96,14 @@ export default function SettingsPage() {
   useEffect(() => {
     Promise.resolve().then(() => {
       const result = loadSettings();
-      setLanguagePair(result.settings);
+      setSettingsForm(result.settings);
       setWasCorrupted(result.wasCorrupted);
     });
   }, []);
 
-  const handleSaveLanguagePair = useCallback(() => {
+  const handleSaveSettings = useCallback(() => {
     setSavedNotice(false);
-    const validation = settingsSchema.safeParse(languagePair);
+    const validation = settingsSchema.safeParse(settingsForm);
     if (!validation.success) {
       setSaveError(validation.error.issues[0]?.message ?? "設定が不正です");
       return;
@@ -109,7 +111,7 @@ export default function SettingsPage() {
     saveSettings(validation.data);
     setSaveError(null);
     setSavedNotice(true);
-  }, [languagePair]);
+  }, [settingsForm]);
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6">
@@ -175,9 +177,9 @@ export default function SettingsPage() {
             <select
               id="target-lang-select"
               className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
-              value={languagePair.targetLang}
+              value={settingsForm.targetLang}
               onChange={(e) =>
-                setLanguagePair((prev) => ({ ...prev, targetLang: e.target.value as SupportedLanguage }))
+                setSettingsForm((prev) => ({ ...prev, targetLang: e.target.value as SupportedLanguage }))
               }
             >
               {SUPPORTED_LANGUAGES.map((lang) => (
@@ -193,14 +195,62 @@ export default function SettingsPage() {
             <select
               id="explain-lang-select"
               className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
-              value={languagePair.explainLang}
+              value={settingsForm.explainLang}
               onChange={(e) =>
-                setLanguagePair((prev) => ({ ...prev, explainLang: e.target.value as SupportedLanguage }))
+                setSettingsForm((prev) => ({ ...prev, explainLang: e.target.value as SupportedLanguage }))
               }
             >
               {SUPPORTED_LANGUAGES.map((lang) => (
                 <option key={lang} value={lang}>
                   {LANGUAGE_DISPLAY_NAMES[lang]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>自動抽出</CardTitle>
+          <CardDescription>
+            チャットを眺めているだけで、学習価値の高い発言をAIが自動で見つけ、単語帳の候補として貯めます。
+            候補は /deck でレビューして採用/却下してください(判定にもGemini
+            Nanoを使うため、手動ピックより低い優先度で処理されます)。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          <div className="flex items-center justify-between gap-2">
+            <Label htmlFor="auto-extraction-enabled-switch">自動抽出を有効にする</Label>
+            <Switch
+              id="auto-extraction-enabled-switch"
+              checked={settingsForm.autoExtraction.enabled}
+              onCheckedChange={(enabled) =>
+                setSettingsForm((prev) => ({ ...prev, autoExtraction: { ...prev.autoExtraction, enabled } }))
+              }
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="auto-extraction-strictness-select">フィルタの厳しさ</Label>
+            <select
+              id="auto-extraction-strictness-select"
+              className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+              value={settingsForm.autoExtraction.strictness}
+              disabled={!settingsForm.autoExtraction.enabled}
+              onChange={(e) =>
+                setSettingsForm((prev) => ({
+                  ...prev,
+                  autoExtraction: {
+                    ...prev.autoExtraction,
+                    strictness: e.target.value as AutoExtractionStrictness,
+                  },
+                }))
+              }
+            >
+              {AUTO_EXTRACTION_STRICTNESS_LEVELS.map((level) => (
+                <option key={level} value={level}>
+                  {AUTO_EXTRACTION_STRICTNESS_DISPLAY_NAMES[level]}
                 </option>
               ))}
             </select>
@@ -220,7 +270,7 @@ export default function SettingsPage() {
             </Alert>
           )}
 
-          <Button onClick={handleSaveLanguagePair} className="self-start">
+          <Button onClick={handleSaveSettings} className="self-start">
             保存する
           </Button>
         </CardContent>

--- a/src/lib/ai/auto-extraction.test.ts
+++ b/src/lib/ai/auto-extraction.test.ts
@@ -1,0 +1,158 @@
+/**
+ * src/lib/ai/auto-extraction.ts のテスト。
+ *
+ * message-filter(除去) → triage(学習価値判定) → explain(解説生成) → candidates保存、
+ * という自動抽出パイプライン全体の振る舞いを検証する。
+ * `LanguageModel` は実際には呼び出さず、`SessionPool` をフェイクに差し替える。
+ * フェイクの `prompt` は `responseConstraint.type` を見て、triage呼び出し(boolean)か
+ * explain呼び出し(object)かを判別し、対応する結果を返す。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createAutoExtractionPipeline, type ProcessMessageOptions } from "./auto-extraction";
+import { createSessionPool, type SessionPool } from "./session-pool";
+import { db } from "../db/schema";
+import type { TwitchChatMessage } from "../twitch/irc-parser";
+
+/** テスト対象のチャット発言を組み立てるヘルパー(意味の分かる実在しそうなチャット文を使用) */
+function buildMessage(overrides: Partial<TwitchChatMessage> = {}): TwitchChatMessage {
+  return {
+    id: "msg-1",
+    channel: "zackrawrr",
+    userId: "111",
+    username: "yamada_taro",
+    displayName: "山田太郎",
+    color: "#1E90FF",
+    text: "that was such a clutch play honestly",
+    isAction: false,
+    emotes: [],
+    badges: [],
+    timestampMs: 1690000000000,
+    ...overrides,
+  };
+}
+
+/** テスト用の最小限のSessionPoolフェイク。responseConstraintの型でtriage/explainの呼び出しを判別する */
+function createFakeSessionPool(options: { triageResult: boolean; explanationJson?: string }) {
+  const fakeSession = {
+    prompt: vi.fn(async (_input: string, promptOptions?: { responseConstraint?: { type?: string } }) => {
+      if (promptOptions?.responseConstraint?.type === "boolean") {
+        return JSON.stringify(options.triageResult);
+      }
+      return (
+        options.explanationJson ?? JSON.stringify({ translation: "t", literal: "l", items: [], difficulty: 1 })
+      );
+    }),
+  };
+  const enqueue = vi.fn(async (_priority: "high" | "low", run: (session: unknown) => Promise<string>) =>
+    run(fakeSession),
+  );
+  return { enqueue } as unknown as SessionPool & { enqueue: typeof enqueue };
+}
+
+const baseOptions: ProcessMessageOptions = {
+  strictness: "normal",
+  targetLang: "en",
+  explainLang: "ja",
+};
+
+afterEach(async () => {
+  await db.candidates.clear();
+});
+
+describe("createAutoExtractionPipeline", () => {
+  it("botの発言はフィルタで除去され、triage/explainは呼ばれず候補も保存されない", async () => {
+    const pool = createFakeSessionPool({ triageResult: true });
+    const pipeline = createAutoExtractionPipeline({ sessionPool: pool });
+
+    await pipeline.processMessage(buildMessage({ username: "Nightbot" }), baseOptions);
+
+    expect(pool.enqueue).not.toHaveBeenCalled();
+    expect(await db.candidates.count()).toBe(0);
+  });
+
+  it("フィルタを通過してもtriageがfalseの場合はexplainを呼ばず、候補も保存されない", async () => {
+    const pool = createFakeSessionPool({ triageResult: false });
+    const pipeline = createAutoExtractionPipeline({ sessionPool: pool });
+
+    await pipeline.processMessage(buildMessage(), baseOptions);
+
+    expect(pool.enqueue).toHaveBeenCalledTimes(1); // triageのみ
+    expect(await db.candidates.count()).toBe(0);
+  });
+
+  it("フィルタを通過しtriageがtrueの場合はexplainの結果を各語句候補として保存する", async () => {
+    const explanationJson = JSON.stringify({
+      translation: "土壇場での見事なプレーだった、正直",
+      literal: "それはとても土壇場のプレーだった、正直",
+      items: [
+        { term: "clutch", kind: "word", meaning: "土壇場での見事なプレー", note: "対戦ゲームでよく使われる" },
+        { term: "honestly", kind: "word", meaning: "正直なところ", note: "文末で強調に使われる" },
+      ],
+      difficulty: 2,
+    });
+    const pool = createFakeSessionPool({ triageResult: true, explanationJson });
+    const pipeline = createAutoExtractionPipeline({ sessionPool: pool });
+    const message = buildMessage({
+      text: "that was such a clutch play honestly",
+      channel: "zackrawrr",
+      displayName: "山田太郎",
+    });
+
+    await pipeline.processMessage(message, baseOptions);
+
+    expect(pool.enqueue).toHaveBeenCalledTimes(2); // triage → explain
+    const candidates = await db.candidates.toArray();
+    expect(candidates).toHaveLength(2);
+    expect(candidates.map((c) => c.term)).toEqual(["clutch", "honestly"]);
+    expect(candidates[0]).toMatchObject({
+      meaning: "土壇場での見事なプレー",
+      note: "対戦ゲームでよく使われる",
+      sourceMessageText: "that was such a clutch play honestly",
+      sourceChannel: "zackrawrr",
+      sourceAuthor: "山田太郎",
+      targetLang: "en",
+      explainLang: "ja",
+      tags: [],
+    });
+  });
+
+  it("直近の発言と同一本文の場合は重複として除去され、2回目はtriageすら呼ばれない", async () => {
+    const pool = createFakeSessionPool({ triageResult: true });
+    const pipeline = createAutoExtractionPipeline({ sessionPool: pool });
+    const message = buildMessage({ text: "another totally unique chat message" });
+
+    await pipeline.processMessage(message, baseOptions);
+    await pipeline.processMessage(message, baseOptions);
+
+    // 1回目はtriage→explainで2回、2回目は重複除去されるため呼ばれない
+    expect(pool.enqueue).toHaveBeenCalledTimes(2);
+  });
+
+  it("直近の重複判定バッファは指定件数を超えると古い発言から対象外になる", async () => {
+    const pool = createFakeSessionPool({ triageResult: true });
+    const pipeline = createAutoExtractionPipeline({ sessionPool: pool, recentTextsBufferSize: 1 });
+
+    await pipeline.processMessage(buildMessage({ text: "first unique message here" }), baseOptions);
+    await pipeline.processMessage(buildMessage({ text: "second unique message here" }), baseOptions);
+    // バッファ長1のため、この時点で記憶されているのは直前の"second..."のみで、
+    // "first..."の重複は検出されない(=フィルタを通過し、triage→explainが呼ばれる)
+    await pipeline.processMessage(buildMessage({ text: "first unique message here" }), baseOptions);
+
+    expect(pool.enqueue).toHaveBeenCalledTimes(6); // 3発言 × (triage + explain)
+  });
+
+  it("中断済みのsignalを渡した場合はエラーになり、候補は保存されない", async () => {
+    const realPool = createSessionPool({
+      createBaseSession: async () => ({ prompt: vi.fn(), clone: vi.fn(), destroy: vi.fn() }),
+    });
+    const pipeline = createAutoExtractionPipeline({ sessionPool: realPool });
+    const controller = new AbortController();
+    controller.abort();
+
+    await expect(
+      pipeline.processMessage(buildMessage(), { ...baseOptions, signal: controller.signal }),
+    ).rejects.toThrow();
+
+    expect(await db.candidates.count()).toBe(0);
+  });
+});

--- a/src/lib/ai/auto-extraction.ts
+++ b/src/lib/ai/auto-extraction.ts
@@ -1,0 +1,95 @@
+/**
+ * 自動抽出パイプライン: message-filter → triage → explain → candidates保存を束ねる
+ * オーケストレーション層。
+ *
+ * ライブチャットの発言を1件ずつ `processMessage` に渡すと、以下を順に行う。
+ * 1. `message-filter.ts` でノイズを除去する(LLM不使用)
+ * 2. 通過した発言のみ `triage.ts` で学習価値をLLM判定する(低優先度)
+ * 3. `true` と判定された発言のみ `explain.ts` で本解説を生成する(低優先度)
+ * 4. 生成された各語句候補を `candidates` テーブルに保存する
+ *
+ * triage・explainは、手動ピック(高優先度)と同じ `SessionPool` を呼び出し側から
+ * 受け取って共有する(design: 単一セッション + 優先度付き直列キュー)。
+ * 直近の重複判定用のリングバッファは内部状態として保持するため、
+ * 接続中のチャンネルにつき1つのインスタンスを使い回す想定。
+ */
+import { evaluateAutoExtractionCandidate, type AutoExtractionStrictness } from "../twitch/message-filter";
+import type { TwitchChatMessage } from "../twitch/irc-parser";
+import { createCandidate } from "../db/candidates";
+import { explainChatMessage } from "./explain";
+import { triageChatMessage } from "./triage";
+import type { SessionPool } from "./session-pool";
+import type { SupportedLanguage } from "./prompts";
+
+/** 直近の重複判定に使うリングバッファの既定保持件数 */
+const DEFAULT_RECENT_TEXTS_BUFFER_SIZE = 50;
+
+export interface AutoExtractionPipelineDeps {
+  /** 手動ピックと共有する SessionPool(単一セッションの優先度付き直列キュー) */
+  sessionPool: SessionPool;
+  /** 重複判定用リングバッファの最大保持件数。省略時 50 */
+  recentTextsBufferSize?: number;
+}
+
+export interface ProcessMessageOptions {
+  strictness: AutoExtractionStrictness;
+  /** カード候補として保存する際に埋め込む、生成時点の言語ペア */
+  targetLang: SupportedLanguage;
+  explainLang: SupportedLanguage;
+  signal?: AbortSignal;
+}
+
+export interface AutoExtractionPipeline {
+  /** 1件のチャット発言を自動抽出パイプラインに投入する */
+  processMessage(message: TwitchChatMessage, options: ProcessMessageOptions): Promise<void>;
+}
+
+export function createAutoExtractionPipeline(deps: AutoExtractionPipelineDeps): AutoExtractionPipeline {
+  const bufferSize = deps.recentTextsBufferSize ?? DEFAULT_RECENT_TEXTS_BUFFER_SIZE;
+  const recentTexts: string[] = [];
+
+  function rememberText(text: string): void {
+    recentTexts.push(text);
+    if (recentTexts.length > bufferSize) {
+      recentTexts.shift();
+    }
+  }
+
+  return {
+    async processMessage(message, options) {
+      const rejection = evaluateAutoExtractionCandidate(message, {
+        strictness: options.strictness,
+        recentTexts,
+      });
+      rememberText(message.text);
+      if (rejection) {
+        return;
+      }
+
+      const worthLearning = await triageChatMessage(deps.sessionPool, message.text, { signal: options.signal });
+      if (!worthLearning) {
+        return;
+      }
+
+      const explanation = await explainChatMessage(deps.sessionPool, message.text, {
+        priority: "low",
+        signal: options.signal,
+      });
+
+      for (const item of explanation.items) {
+        await createCandidate({
+          term: item.term,
+          kind: item.kind,
+          meaning: item.meaning,
+          note: item.note,
+          sourceMessageText: message.text,
+          sourceChannel: message.channel,
+          sourceAuthor: message.displayName,
+          targetLang: options.targetLang,
+          explainLang: options.explainLang,
+          tags: [],
+        });
+      }
+    },
+  };
+}

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -6,7 +6,12 @@
  * 純関数を検証する。
  */
 import { describe, expect, it } from "vitest";
-import { buildExplainSystemPrompt, buildExplainUserPrompt, SUPPORTED_LANGUAGES } from "./prompts";
+import {
+  buildExplainSystemPrompt,
+  buildExplainUserPrompt,
+  buildTriageUserPrompt,
+  SUPPORTED_LANGUAGES,
+} from "./prompts";
 
 describe("SUPPORTED_LANGUAGES", () => {
   it("Prompt APIが対応する5言語(en/ja/es/de/fr)を含む", () => {
@@ -51,5 +56,20 @@ describe("buildExplainUserPrompt", () => {
     const prompt = buildExplainUserPrompt("gg no re chat");
 
     expect(prompt).toContain("gg no re chat");
+  });
+});
+
+describe("buildTriageUserPrompt", () => {
+  it("チャット本文をそのまま埋め込んだユーザープロンプトを組み立てる", () => {
+    const prompt = buildTriageUserPrompt("gg no re chat");
+
+    expect(prompt).toContain("gg no re chat");
+  });
+
+  it("真偽値での回答を明示的に指示する", () => {
+    const prompt = buildTriageUserPrompt("gg no re chat");
+
+    expect(prompt).toMatch(/true/i);
+    expect(prompt).toMatch(/false/i);
   });
 });

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -55,3 +55,14 @@ export function buildExplainSystemPrompt(targetLang: SupportedLanguage, explainL
 export function buildExplainUserPrompt(chatMessageText: string): string {
   return `Chat message to analyze: "${chatMessageText}"`;
 }
+
+/**
+ * 自動抽出パイプラインのtriage(学習価値判定)用ユーザープロンプトを組み立てる。
+ * triage は explain と同じベースセッション(1セッションのみという設計)を共有するため、
+ * システムプロンプトを切り替えず、このユーザープロンプト内でタスクを完結させる。
+ * `responseConstraint` が真偽値を強制するため出力形式自体は壊れないが、
+ * 判定基準を明示することで真偽の精度を上げる狙いがある。
+ */
+export function buildTriageUserPrompt(chatMessageText: string): string {
+  return `You will judge ONE chat message that actually appeared in a live Twitch stream. Decide whether it contains something worth teaching a language learner, such as slang, an abbreviation, an idiom, a notable emote usage, or a notable grammar point. Respond true if it does. Respond false if it is just plain conversation, a greeting, or noise with nothing new to learn. Chat message to judge: "${chatMessageText}"`;
+}

--- a/src/lib/ai/schemas.test.ts
+++ b/src/lib/ai/schemas.test.ts
@@ -6,7 +6,12 @@
  * JSON Schema を組み立てられることを検証する。
  */
 import { describe, expect, it } from "vitest";
-import { buildExplanationResponseConstraint, explanationSchema } from "./schemas";
+import {
+  buildExplanationResponseConstraint,
+  buildTriageResponseConstraint,
+  explanationSchema,
+  triageResultSchema,
+} from "./schemas";
 
 describe("explanationSchema", () => {
   it("正しい形のオブジェクトをパースできる", () => {
@@ -70,6 +75,32 @@ describe("buildExplanationResponseConstraint", () => {
 
   it("メタ情報の$schemaフィールドは含まない(Prompt APIの想定外のため)", () => {
     const constraint = buildExplanationResponseConstraint() as Record<string, unknown>;
+
+    expect(constraint.$schema).toBeUndefined();
+  });
+});
+
+describe("triageResultSchema", () => {
+  it("真偽値をパースできる", () => {
+    expect(triageResultSchema.parse(true)).toBe(true);
+    expect(triageResultSchema.parse(false)).toBe(false);
+  });
+
+  it("真偽値以外はパースエラーになる", () => {
+    expect(() => triageResultSchema.parse("true")).toThrow();
+    expect(() => triageResultSchema.parse(1)).toThrow();
+  });
+});
+
+describe("buildTriageResponseConstraint", () => {
+  it("真偽値のみを許すJSON Schemaオブジェクトを返す", () => {
+    const constraint = buildTriageResponseConstraint();
+
+    expect(constraint).toEqual({ type: "boolean" });
+  });
+
+  it("メタ情報の$schemaフィールドは含まない(Prompt APIの想定外のため)", () => {
+    const constraint = buildTriageResponseConstraint() as Record<string, unknown>;
 
     expect(constraint.$schema).toBeUndefined();
   });

--- a/src/lib/ai/schemas.ts
+++ b/src/lib/ai/schemas.ts
@@ -43,3 +43,19 @@ export function buildExplanationResponseConstraint(): Record<string, unknown> {
   delete jsonSchema.$schema;
   return jsonSchema;
 }
+
+/**
+ * triage(自動抽出パイプラインにおける学習価値判定)の応答スキーマ。
+ * `explainChatMessage` と同様、`JSON.parse` した Prompt API の応答をここで検証する。
+ */
+export const triageResultSchema = z.boolean();
+
+/**
+ * triage用の `responseConstraint`(真偽値のみを許すJSON Schema)を組み立てる。
+ * `buildExplanationResponseConstraint` と同じく `$schema` メタ情報は取り除く。
+ */
+export function buildTriageResponseConstraint(): Record<string, unknown> {
+  const jsonSchema: Record<string, unknown> = { ...z.toJSONSchema(triageResultSchema) };
+  delete jsonSchema.$schema;
+  return jsonSchema;
+}

--- a/src/lib/ai/triage.test.ts
+++ b/src/lib/ai/triage.test.ts
@@ -1,0 +1,67 @@
+/**
+ * src/lib/ai/triage.ts のテスト。
+ *
+ * `triageChatMessage`: SessionPool経由で「学習者にとって学ぶ価値があるか」を
+ * 真偽値で判定し、Gemini Nanoが返したJSON文字列をzodで検証するところまでを検証する。
+ * explain.test.tsと同様、`LanguageModel`はブラウザ組み込みAPIのため実際には呼び出さず、
+ * SessionPoolのフェイクで置き換える。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { triageChatMessage } from "./triage";
+import type { SessionPool } from "./session-pool";
+
+/** テスト用の最小限の SessionPool フェイク。enqueue の run をそのまま呼び出す */
+function createFakeSessionPool(promptResult: string) {
+  const enqueue = vi.fn(async (_priority: "high" | "low", run: (session: unknown) => Promise<string>) => {
+    const fakeSession = { prompt: vi.fn(async () => promptResult) };
+    return run(fakeSession);
+  });
+  return { enqueue } as unknown as SessionPool & { enqueue: typeof enqueue };
+}
+
+describe("triageChatMessage", () => {
+  it("Gemini Nanoがtrueを返した場合はtrueを返す", async () => {
+    const pool = createFakeSessionPool("true");
+
+    const result = await triageChatMessage(pool, "that clip was so clutch, gg");
+
+    expect(result).toBe(true);
+  });
+
+  it("Gemini Nanoがfalseを返した場合はfalseを返す", async () => {
+    const pool = createFakeSessionPool("false");
+
+    const result = await triageChatMessage(pool, "hello everyone");
+
+    expect(result).toBe(false);
+  });
+
+  it("常に低優先度('low')でenqueueする(自動抽出は手動ピックより優先度が低いため)", async () => {
+    const pool = createFakeSessionPool("true");
+
+    await triageChatMessage(pool, "hello");
+
+    expect(pool.enqueue).toHaveBeenCalledWith("low", expect.any(Function), undefined);
+  });
+
+  it("signalを指定した場合はそのままenqueueに渡す", async () => {
+    const pool = createFakeSessionPool("true");
+    const controller = new AbortController();
+
+    await triageChatMessage(pool, "hello", { signal: controller.signal });
+
+    expect(pool.enqueue).toHaveBeenCalledWith("low", expect.any(Function), controller.signal);
+  });
+
+  it("応答がJSONとして解釈できない場合は分かりやすいエラーを投げる", async () => {
+    const pool = createFakeSessionPool("これはJSONではない文字列です");
+
+    await expect(triageChatMessage(pool, "hello")).rejects.toThrow();
+  });
+
+  it("応答が真偽値でない場合はエラーを投げる(自由文パースへのフォールバックはしない)", async () => {
+    const pool = createFakeSessionPool(JSON.stringify({ worthLearning: true }));
+
+    await expect(triageChatMessage(pool, "hello")).rejects.toThrow();
+  });
+});

--- a/src/lib/ai/triage.ts
+++ b/src/lib/ai/triage.ts
@@ -1,0 +1,46 @@
+/**
+ * 自動抽出パイプラインの2段階目。message-filter.ts を通過した発言に対し、
+ * Gemini Nano(Prompt API)へ `responseConstraint: { type: "boolean" }` で
+ * 「学習者にとって学ぶ価値があるか」を判定させるオーケストレーション層。
+ *
+ * explain.ts と同じ `SessionPool`(単一セッションの優先度付き直列キュー)を
+ * 呼び出し側から受け取って共有し、Prompt API の呼び出しは常に低優先度("low")で
+ * enqueueする(手動ピックによる解説生成が常に優先される設計のため)。
+ */
+import { buildTriageUserPrompt } from "./prompts";
+import { buildTriageResponseConstraint, triageResultSchema } from "./schemas";
+import type { SessionPool } from "./session-pool";
+
+export interface TriageOptions {
+  signal?: AbortSignal;
+}
+
+/**
+ * チャット本文が学習者にとって学ぶ価値があるかを判定する。
+ * Prompt API の応答は必ず JSON 文字列(`"true"` / `"false"`)として返るため、
+ * `JSON.parse` → `triageResultSchema.parse` の順で検証し、いずれかに失敗した場合は
+ * エラーを投げる(あいまいな自由文解析へのフォールバックはしない)。
+ */
+export async function triageChatMessage(
+  sessionPool: SessionPool,
+  chatMessageText: string,
+  options: TriageOptions = {},
+): Promise<boolean> {
+  const raw = await sessionPool.enqueue(
+    "low",
+    (session) =>
+      session.prompt(buildTriageUserPrompt(chatMessageText), {
+        responseConstraint: buildTriageResponseConstraint(),
+      }),
+    options.signal,
+  );
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした: ${raw}`, { cause: error });
+  }
+
+  return triageResultSchema.parse(parsed);
+}

--- a/src/lib/db/candidates.test.ts
+++ b/src/lib/db/candidates.test.ts
@@ -1,0 +1,110 @@
+/**
+ * src/lib/db/candidates.ts のテスト。
+ *
+ * fake-indexeddb(vitest.setup.ts で `fake-indexeddb/auto` を導入済み)を使い、
+ * 自動抽出パイプラインが生成した候補(Candidate)のCRUDと、
+ * 採用(cardsへ移動)・却下(削除のみ)を検証する。
+ * 各テストの独立性を保つため、テストごとに `db.candidates` / `db.cards` を空にしてから実行する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { db } from "./schema";
+import { acceptCandidate, createCandidate, listCandidates, rejectCandidate } from "./candidates";
+
+/** 自動抽出パイプラインが生成する候補入力を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
+function buildNewCandidateInput(overrides: Partial<Parameters<typeof createCandidate>[0]> = {}) {
+  return {
+    term: "clutch",
+    kind: "word" as const,
+    meaning: "土壇場での見事なプレー",
+    note: "対戦ゲームの実況・チャットでよく使われる",
+    sourceMessageText: "that was such a clutch play honestly",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en" as const,
+    explainLang: "ja" as const,
+    tags: [],
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await db.candidates.clear();
+  await db.cards.clear();
+});
+
+describe("createCandidate", () => {
+  it("id・作成日時を付与して候補を保存し、保存内容を返す", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-29T10:00:00.000Z").getTime());
+
+    const created = await createCandidate(buildNewCandidateInput());
+
+    expect(created.id).toBeTypeOf("number");
+    expect(created.term).toBe("clutch");
+    expect(created.createdAt).toBe(new Date("2026-07-29T10:00:00.000Z").getTime());
+
+    const stored = await db.candidates.get(created.id!);
+    expect(stored).toEqual(created);
+  });
+});
+
+describe("listCandidates", () => {
+  it("作成日時が新しい順に候補を返す", async () => {
+    const dateNowSpy = vi.spyOn(Date, "now");
+    dateNowSpy.mockReturnValue(new Date("2026-07-29T10:00:00.000Z").getTime());
+    const older = await createCandidate(buildNewCandidateInput({ term: "clutch" }));
+    dateNowSpy.mockReturnValue(new Date("2026-07-29T10:05:00.000Z").getTime());
+    const newer = await createCandidate(buildNewCandidateInput({ term: "GG" }));
+
+    const list = await listCandidates();
+
+    expect(list.map((candidate) => candidate.id)).toEqual([newer.id, older.id]);
+  });
+});
+
+describe("acceptCandidate", () => {
+  it("候補を単語帳(cards)に保存し、候補自体は削除する", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(new Date("2026-07-29T10:00:00.000Z").getTime());
+    const candidate = await createCandidate(buildNewCandidateInput());
+
+    const card = await acceptCandidate(candidate.id!);
+
+    expect(card.term).toBe("clutch");
+    expect(card.meaning).toBe("土壇場での見事なプレー");
+    expect(card.srs).toEqual({
+      due: new Date("2026-07-29T10:00:00.000Z").getTime(),
+      interval: 0,
+      easeFactor: 2.5,
+      repetitions: 0,
+      lapses: 0,
+      lastReviewedAt: null,
+    });
+
+    const storedCards = await db.cards.toArray();
+    expect(storedCards).toHaveLength(1);
+    expect(storedCards[0].term).toBe("clutch");
+
+    const storedCandidate = await db.candidates.get(candidate.id!);
+    expect(storedCandidate).toBeUndefined();
+  });
+
+  it("存在しない候補IDを指定した場合はエラーを投げ、cardsには何も保存されない", async () => {
+    await expect(acceptCandidate(99999)).rejects.toThrow();
+
+    const storedCards = await db.cards.toArray();
+    expect(storedCards).toHaveLength(0);
+  });
+});
+
+describe("rejectCandidate", () => {
+  it("候補を削除するのみで、単語帳(cards)には保存しない", async () => {
+    const candidate = await createCandidate(buildNewCandidateInput());
+
+    await rejectCandidate(candidate.id!);
+
+    const storedCandidate = await db.candidates.get(candidate.id!);
+    expect(storedCandidate).toBeUndefined();
+    const storedCards = await db.cards.toArray();
+    expect(storedCards).toHaveLength(0);
+  });
+});

--- a/src/lib/db/candidates.ts
+++ b/src/lib/db/candidates.ts
@@ -1,0 +1,60 @@
+/**
+ * 自動抽出パイプライン(Phase 4)が生成した「カード候補」(`Candidate`)のCRUDと、
+ * 採用(単語帳への保存)・却下(削除)を行うモジュール。
+ *
+ * 自動抽出は誤判定を含みうるため `cards` へ直接保存せず、いったん `candidates` に
+ * 貯め、利用者が `/deck` のレビューUIで採用/却下してから初めて単語帳(`cards`)に入る。
+ * 採用時のSRS初期化ロジックは `cards.ts` の `createCard` をそのまま再利用し、重複させない。
+ */
+import type { Card, Candidate } from "./schema";
+import { db } from "./schema";
+import { createCard } from "./cards";
+
+/** 候補作成時に渡す入力(id・createdAtはこの関数側で採番・初期化する) */
+export type NewCandidateInput = Omit<Candidate, "id" | "createdAt">;
+
+/** 候補を作成し、DBに保存したうえで保存内容(採番されたid・createdAt付き)を返す */
+export async function createCandidate(input: NewCandidateInput): Promise<Candidate> {
+  const candidate: Candidate = { ...input, createdAt: Date.now() };
+  const id = await db.candidates.add(candidate);
+  return { ...candidate, id };
+}
+
+/** 全候補を作成日時が新しい順に返す */
+export async function listCandidates(): Promise<Candidate[]> {
+  return db.candidates.orderBy("createdAt").reverse().toArray();
+}
+
+/**
+ * 候補を採用する: 単語帳(cards)へ保存し、候補自体を削除する。
+ * 「保存できたが候補が消えずに残る」といった中途半端な状態を避けるため、
+ * ひとつのDexieトランザクションとして不可分に実行する。
+ */
+export async function acceptCandidate(id: number): Promise<Card> {
+  return db.transaction("rw", db.candidates, db.cards, async () => {
+    const candidate = await db.candidates.get(id);
+    if (!candidate) {
+      throw new Error(`候補が見つかりません(id: ${id})`);
+    }
+
+    const card = await createCard({
+      term: candidate.term,
+      kind: candidate.kind,
+      meaning: candidate.meaning,
+      note: candidate.note,
+      sourceMessageText: candidate.sourceMessageText,
+      sourceChannel: candidate.sourceChannel,
+      sourceAuthor: candidate.sourceAuthor,
+      targetLang: candidate.targetLang,
+      explainLang: candidate.explainLang,
+      tags: candidate.tags,
+    });
+    await db.candidates.delete(id);
+    return card;
+  });
+}
+
+/** 候補を却下する: 単語帳には保存せず削除する */
+export async function rejectCandidate(id: number): Promise<void> {
+  await db.candidates.delete(id);
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -79,6 +79,34 @@ export interface Review {
 }
 
 /**
+ * 自動抽出パイプライン(Phase 4)が生成した、レビュー待ちのカード候補。
+ * 誤判定を含みうるため `cards` へ直接保存せず、利用者が `/deck` のレビューUIで
+ * 採用(`cards`へ移動)/却下(削除)するまでここに留め置く。
+ * SRS状態(`srs`)は採用されて `Card` になった時点で初めて初期化するため、ここには持たない。
+ */
+export interface Candidate {
+  id?: number;
+  /** 元のチャット本文中に登場する語句・フレーズそのもの */
+  term: string;
+  kind: ExplanationItemKind;
+  /** 解説言語での意味 */
+  meaning: string;
+  /** 使われ方についての一言メモ */
+  note: string;
+  /** カード化の元になったチャット発言の全文 */
+  sourceMessageText: string;
+  sourceChannel: string;
+  sourceAuthor: string;
+  /** 学ぶ言語(生成時点の設定を保存する) */
+  targetLang: SupportedLanguage;
+  /** 解説言語(生成時点の設定を保存する) */
+  explainLang: SupportedLanguage;
+  tags: string[];
+  /** 生成日時(epoch ms) */
+  createdAt: number;
+}
+
+/**
  * chat-sensei の Dexie データベース。
  *
  * テスト(fake-indexeddb)ではテストごとに異なる `name` を渡すことで、
@@ -88,6 +116,7 @@ export class ChatSenseiDatabase extends Dexie {
   messages!: Table<StoredMessage, number>;
   cards!: Table<Card, number>;
   reviews!: Table<Review, number>;
+  candidates!: Table<Candidate, number>;
 
   constructor(name = "chat-sensei") {
     super(name);
@@ -95,6 +124,14 @@ export class ChatSenseiDatabase extends Dexie {
       messages: "++id, channel, timestampMs",
       cards: "++id, term, kind, createdAt, *tags",
       reviews: "++id, cardId, reviewedAt",
+    });
+    // Phase 4: 自動抽出パイプラインのレビュー待ちカード候補を保存するテーブルを追加する。
+    // 既存ユーザーのデータを保持したまま移行できるよう、version(1)は変更せず新バージョンを積む。
+    this.version(2).stores({
+      messages: "++id, channel, timestampMs",
+      cards: "++id, term, kind, createdAt, *tags",
+      reviews: "++id, cardId, reviewedAt",
+      candidates: "++id, term, kind, createdAt",
     });
   }
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -21,11 +21,22 @@ describe("loadSettings", () => {
   });
 
   it("保存された正常な設定を復元する", () => {
-    saveSettings({ targetLang: "es", explainLang: "ja" });
+    saveSettings({
+      targetLang: "es",
+      explainLang: "ja",
+      autoExtraction: { enabled: false, strictness: "normal" },
+    });
 
     const result = loadSettings();
 
-    expect(result).toEqual({ settings: { targetLang: "es", explainLang: "ja" }, wasCorrupted: false });
+    expect(result).toEqual({
+      settings: {
+        targetLang: "es",
+        explainLang: "ja",
+        autoExtraction: { enabled: false, strictness: "normal" },
+      },
+      wasCorrupted: false,
+    });
   });
 
   it("JSONとして壊れたデータの場合はデフォルトに戻し、壊れていたことを伝える", () => {
@@ -61,6 +72,58 @@ describe("loadSettings", () => {
 
 describe("saveSettings", () => {
   it("学ぶ言語と解説言語が同じ場合は保存を拒否する(モジュール側でも二重に防止する)", () => {
-    expect(() => saveSettings({ targetLang: "en", explainLang: "en" })).toThrow();
+    expect(() =>
+      saveSettings({
+        targetLang: "en",
+        explainLang: "en",
+        autoExtraction: { enabled: false, strictness: "normal" },
+      }),
+    ).toThrow();
+  });
+});
+
+describe("自動抽出設定(autoExtraction)", () => {
+  it("保存されたデータが無い場合はデフォルトで無効(strictness: normal)を返す", () => {
+    const result = loadSettings();
+
+    expect(result.settings.autoExtraction).toEqual({ enabled: false, strictness: "normal" });
+  });
+
+  it("autoExtractionを含まない旧バージョンの保存データは、後方互換としてデフォルト値を補って読み込む(壊れているとは扱わない)", () => {
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ targetLang: "es", explainLang: "ja" }));
+
+    const result = loadSettings();
+
+    expect(result).toEqual({
+      settings: {
+        targetLang: "es",
+        explainLang: "ja",
+        autoExtraction: { enabled: false, strictness: "normal" },
+      },
+      wasCorrupted: false,
+    });
+  });
+
+  it("autoExtractionを含む設定を保存・復元できる", () => {
+    saveSettings({
+      targetLang: "en",
+      explainLang: "ja",
+      autoExtraction: { enabled: true, strictness: "strict" },
+    });
+
+    const result = loadSettings();
+
+    expect(result.settings.autoExtraction).toEqual({ enabled: true, strictness: "strict" });
+  });
+
+  it("strictnessが対応値以外の場合はデフォルト設定に戻す", () => {
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ targetLang: "en", explainLang: "ja", autoExtraction: { enabled: true, strictness: "extreme" } }),
+    );
+
+    const result = loadSettings();
+
+    expect(result).toEqual({ settings: DEFAULT_SETTINGS, wasCorrupted: true });
   });
 });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -9,8 +9,19 @@
  */
 import { z } from "zod";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "./ai/prompts";
+import { AUTO_EXTRACTION_STRICTNESS_LEVELS } from "./twitch/message-filter";
 
 export const SETTINGS_STORAGE_KEY = "chat-sensei:settings";
+
+/**
+ * 自動抽出(Phase 4)のオン/オフとフィルタの厳しさ。
+ * `.default()` を指定し、旧バージョン(このフィールドを持たない保存データ)を
+ * 「壊れている」とはみなさず、デフォルト値を補って読み込めるようにする。
+ */
+const autoExtractionSettingsSchema = z.object({
+  enabled: z.boolean().default(false),
+  strictness: z.enum(AUTO_EXTRACTION_STRICTNESS_LEVELS).default("normal"),
+});
 
 export const settingsSchema = z
   .object({
@@ -18,6 +29,8 @@ export const settingsSchema = z
     targetLang: z.enum(SUPPORTED_LANGUAGES),
     /** 解説言語(AIが生成する解説の言語) */
     explainLang: z.enum(SUPPORTED_LANGUAGES),
+    /** 自動抽出パイプラインの設定 */
+    autoExtraction: autoExtractionSettingsSchema.default({ enabled: false, strictness: "normal" }),
   })
   .refine((data) => data.targetLang !== data.explainLang, {
     message: "学ぶ言語と解説言語には異なる言語を指定してください",
@@ -26,7 +39,21 @@ export const settingsSchema = z
 
 export type Settings = z.infer<typeof settingsSchema>;
 
-export const DEFAULT_SETTINGS: Settings = { targetLang: "en", explainLang: "ja" };
+export const DEFAULT_SETTINGS: Settings = {
+  targetLang: "en",
+  explainLang: "ja",
+  autoExtraction: { enabled: false, strictness: "normal" },
+};
+
+/** 抽出強度セレクトに表示する日本語ラベル */
+export const AUTO_EXTRACTION_STRICTNESS_DISPLAY_NAMES: Record<
+  (typeof AUTO_EXTRACTION_STRICTNESS_LEVELS)[number],
+  string
+> = {
+  loose: "緩い(短い発言も拾う)",
+  normal: "標準",
+  strict: "厳しい(長めの発言のみ)",
+};
 
 /** 設定画面のセレクトボックスに表示する、各言語のネイティブ表記 */
 export const LANGUAGE_DISPLAY_NAMES: Record<SupportedLanguage, string> = {

--- a/src/lib/twitch/message-filter.test.ts
+++ b/src/lib/twitch/message-filter.test.ts
@@ -1,0 +1,115 @@
+/**
+ * src/lib/twitch/message-filter.ts のテスト。
+ *
+ * 自動抽出パイプラインの最初の関門である `evaluateAutoExtractionCandidate` を検証する。
+ * bot発言・!コマンド・emoteのみ・URLのみ・極端に短い発言・直近の重複が、
+ * それぞれ正しい理由(reason)で除去されること、いずれにも該当しない発言は
+ * 通過(null)することを確認する。
+ */
+import { describe, expect, it } from "vitest";
+import type { TwitchChatMessage } from "./irc-parser";
+import { evaluateAutoExtractionCandidate } from "./message-filter";
+
+/** テスト対象のチャット発言を組み立てるヘルパー(意味の分かる実在しそうなチャット文を使用) */
+function buildMessage(overrides: Partial<TwitchChatMessage> = {}): TwitchChatMessage {
+  return {
+    id: "msg-1",
+    channel: "zackrawrr",
+    userId: "111",
+    username: "yamada_taro",
+    displayName: "山田太郎",
+    color: "#1E90FF",
+    text: "that was such a clutch play honestly",
+    isAction: false,
+    emotes: [],
+    badges: [],
+    timestampMs: 1690000000000,
+    ...overrides,
+  };
+}
+
+describe("evaluateAutoExtractionCandidate", () => {
+  it("通常の発言は理由なし(null)で通過する", () => {
+    const message = buildMessage();
+
+    expect(evaluateAutoExtractionCandidate(message)).toBeNull();
+  });
+
+  it("既知のbotユーザー名(大文字小文字を区別しない)の発言は'bot'として除去される", () => {
+    const message = buildMessage({ username: "Nightbot", text: "Now playing: Lo-Fi Beats" });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBe("bot");
+  });
+
+  it("!から始まる発言は'command'として除去される", () => {
+    const message = buildMessage({ text: "!discord" });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBe("command");
+  });
+
+  it("前後の空白を除いた本文がemoteだけで構成される発言は'emote-only'として除去される", () => {
+    const message = buildMessage({ text: " Kappa ", emotes: [{ id: "25", start: 1, end: 5 }] });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBe("emote-only");
+  });
+
+  it("テキストとemoteが混在する発言は通過する", () => {
+    // "hello Kappa" のうち "Kappa"(6-10)だけがemote、残り"hello"は本文として十分な長さがある
+    const message = buildMessage({ text: "hello Kappa", emotes: [{ id: "25", start: 6, end: 10 }] });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBeNull();
+  });
+
+  it("URLだけの発言は'url-only'として除去される", () => {
+    const message = buildMessage({ text: "https://example.com/stream-highlights" });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBe("url-only");
+  });
+
+  it("URLとテキストが混在する発言は通過する", () => {
+    const message = buildMessage({ text: "check this out https://example.com/clip" });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBeNull();
+  });
+
+  it("既定(strictness省略時 = normal)では4文字未満の発言は'too-short'として除去される", () => {
+    const message = buildMessage({ text: "gg " });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBe("too-short");
+  });
+
+  it("strictnessをlooseにすると、より短い発言でも通過する", () => {
+    const message = buildMessage({ text: "gg" });
+
+    expect(evaluateAutoExtractionCandidate(message, { strictness: "loose" })).toBeNull();
+  });
+
+  it("strictnessをstrictにすると、normalでは通過する発言も'too-short'として除去される", () => {
+    const message = buildMessage({ text: "nice one" }); // 8文字
+
+    expect(evaluateAutoExtractionCandidate(message, { strictness: "normal" })).toBeNull();
+    expect(evaluateAutoExtractionCandidate(message, { strictness: "strict" })).toBe("too-short");
+  });
+
+  it("直近の発言一覧に同一本文(前後空白・大文字小文字を無視)が含まれる場合は'duplicate'として除去される", () => {
+    const message = buildMessage({ text: " Hello World " });
+
+    expect(
+      evaluateAutoExtractionCandidate(message, { recentTexts: ["hello world", "gg everyone"] }),
+    ).toBe("duplicate");
+  });
+
+  it("直近の発言一覧に含まれていなければ重複とみなさない", () => {
+    const message = buildMessage({ text: "totally different message here" });
+
+    expect(
+      evaluateAutoExtractionCandidate(message, { recentTexts: ["hello world", "gg everyone"] }),
+    ).toBeNull();
+  });
+
+  it("複数の除去理由に該当する場合はbotが最優先で判定される", () => {
+    const message = buildMessage({ username: "Moobot", text: "!" });
+
+    expect(evaluateAutoExtractionCandidate(message)).toBe("bot");
+  });
+});

--- a/src/lib/twitch/message-filter.ts
+++ b/src/lib/twitch/message-filter.ts
@@ -1,0 +1,114 @@
+/**
+ * 自動抽出パイプラインの最初の関門として、Twitchチャット発言をGemini Nano(Prompt API)に
+ * 渡す前にコードだけで足切りする純関数群。LLMは一切使用しない。
+ *
+ * 除去対象: bot発言・`!`始まりのコマンド・emoteのみ・URLのみ・極端に短い発言・直近の重複。
+ * Nanoの呼び出しコストを抑えるため、この段階を通過した発言だけが triage.ts に渡される。
+ */
+import { splitMessageIntoSegments } from "./emotes";
+import type { TwitchChatMessage } from "./irc-parser";
+
+/** 自動抽出の強度(フィルタの厳しさ)。厳しいほど「極端に短い発言」とみなす閾値が上がる */
+export const AUTO_EXTRACTION_STRICTNESS_LEVELS = ["loose", "normal", "strict"] as const;
+export type AutoExtractionStrictness = (typeof AUTO_EXTRACTION_STRICTNESS_LEVELS)[number];
+
+/** 抽出強度ごとの最短文字数(前後の空白を除いた本文がこれ未満なら"too-short"として除去する) */
+export const MIN_MESSAGE_LENGTH_BY_STRICTNESS: Record<AutoExtractionStrictness, number> = {
+  loose: 2,
+  normal: 4,
+  strict: 10,
+};
+
+/** 発言が自動抽出候補から除去された理由 */
+export const FILTER_REJECTION_REASONS = [
+  "bot",
+  "command",
+  "emote-only",
+  "url-only",
+  "too-short",
+  "duplicate",
+] as const;
+export type FilterRejectionReason = (typeof FILTER_REJECTION_REASONS)[number];
+
+/**
+ * 配信ツール系の定番Botとして広く知られたユーザー名(すべて小文字)。
+ * Twitch IRCにはbotであることを示す公式タグが存在しないため、既知の名前のみを対象にする
+ * (誤って一般利用者を除去しないよう、`bot`で終わるという緩い判定は行わない)。
+ */
+const KNOWN_BOT_USERNAMES = new Set([
+  "nightbot",
+  "streamelements",
+  "moobot",
+  "fossabot",
+  "wizebot",
+  "streamlabs",
+  "commanderroot",
+]);
+
+/** `https://` または `http://` から始まるURLにマッチする(グローバルフラグはreplaceのみに使う) */
+const URL_PATTERN = /https?:\/\/\S+/gi;
+
+export interface EvaluateAutoExtractionCandidateOptions {
+  /** 抽出強度。省略時は "normal" */
+  strictness?: AutoExtractionStrictness;
+  /** 重複判定に使う直近の発言本文一覧(正規化前の原文でよい) */
+  recentTexts?: readonly string[];
+}
+
+function isKnownBotUsername(username: string): boolean {
+  return KNOWN_BOT_USERNAMES.has(username.toLowerCase());
+}
+
+/** emote部分を取り除いた本文を返す(emotes.tsのセグメント分割を再利用する) */
+function textWithoutEmotes(message: TwitchChatMessage): string {
+  return splitMessageIntoSegments(message.text, message.emotes)
+    .filter((segment) => segment.type === "text")
+    .map((segment) => segment.text)
+    .join("");
+}
+
+/** 比較用に前後の空白を除き小文字化する */
+function normalizeForDuplicateCheck(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+/**
+ * チャット発言が自動抽出パイプラインの次段階(triage)に進めるかを判定する。
+ * 通過する場合は `null`、除去する場合はその理由を返す
+ * (該当しうる理由が複数あっても、`FILTER_REJECTION_REASONS` の列挙順で最初に一致したものを返す)。
+ */
+export function evaluateAutoExtractionCandidate(
+  message: TwitchChatMessage,
+  options: EvaluateAutoExtractionCandidateOptions = {},
+): FilterRejectionReason | null {
+  const strictness = options.strictness ?? "normal";
+  const minLength = MIN_MESSAGE_LENGTH_BY_STRICTNESS[strictness];
+  const trimmedText = message.text.trim();
+
+  if (isKnownBotUsername(message.username)) {
+    return "bot";
+  }
+
+  if (trimmedText.startsWith("!")) {
+    return "command";
+  }
+
+  if (message.emotes.length > 0 && textWithoutEmotes(message).trim() === "") {
+    return "emote-only";
+  }
+
+  if (trimmedText !== "" && trimmedText.replace(URL_PATTERN, "").trim() === "") {
+    return "url-only";
+  }
+
+  if (trimmedText.length < minLength) {
+    return "too-short";
+  }
+
+  const normalized = normalizeForDuplicateCheck(message.text);
+  if (options.recentTexts?.some((recentText) => normalizeForDuplicateCheck(recentText) === normalized)) {
+    return "duplicate";
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- `src/lib/twitch/message-filter.ts`: bot発言・`!`コマンド・emoteのみ・URLのみ・極端に短い発言・直近の重複を除去する純関数(LLM不使用)を追加
- `src/lib/ai/triage.ts`: `responseConstraint: {type:"boolean"}`でGemini Nanoに学習価値を判定させ、既存の`SessionPool`(手動ピックと共有)へ常に低優先度でenqueue
- `src/lib/ai/auto-extraction.ts`: message-filter → triage → explain → candidates保存 を束ねるパイプライン(`createAutoExtractionPipeline`)。直近発言のリングバッファを内部状態として保持
- `src/lib/db/schema.ts`(Dexie version 2)/`src/lib/db/candidates.ts`: レビュー待ちカード候補(`candidates`テーブル)のCRUDと、採用(`cards.ts`の`createCard`をトランザクション内で再利用)・却下
- `src/lib/settings.ts`: `autoExtraction: {enabled, strictness}` を追加(`.default()`で旧バージョンのLocalStorageデータとの後方互換を確保)
- `/settings`: 自動抽出のオン/オフ・フィルタの厳しさの設定UI
- `/deck`: 自動抽出の候補レビューUI(採用/却下)
- `/`(ホーム): 受信メッセージごとに自動抽出パイプラインを実行(有効時のみ)。チャンネル接続/切断時にAbortControllerで中断

## Test plan
- [x] `npm test`: 176件全て成功
- [x] `npm run type-check`: エラーなし
- [x] `npm run lint`: 警告・エラーなし
- [x] 実機Chrome(Prompt API利用可能)で `npm run dev` を起動し、`/settings`で自動抽出を有効化 → 実際のTwitchチャンネル(xqc)に接続 → IndexedDBの`candidates`テーブルに自動生成されたカード候補が溜まることを確認
- [x] `/deck`の候補レビューUIで「採用」(単語帳への保存+候補削除)・「却下」(候補削除のみ)が実際に動作することを確認

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)