### PR TITLE
feat: 復習クイズ(SM-2)を追加

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,8 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // vitestのカバレッジレポート(自動生成)
+    "coverage/**",
   ]),
 ]);
 

--- a/src/app/study/page.test.tsx
+++ b/src/app/study/page.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * src/app/study/page.tsx(復習クイズ画面)のテスト。
+ *
+ * Phase 5の完了条件である「期日が来たカードだけが出題され、成績で次回間隔が変わる」を、
+ * fake-indexeddb上で実際の `cards.ts` / `reviews.ts` / `quiz.ts` を動かして検証する
+ * (復習クイズはLLM非依存の設計のためモック不要)。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import StudyPage from "./page";
+import { db } from "@/lib/db/schema";
+import { createCard } from "@/lib/db/cards";
+import * as cardsModule from "@/lib/db/cards";
+import * as reviewsModule from "@/lib/db/reviews";
+
+/** カード化済みの語句を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
+function seedCard(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
+  return createCard({
+    term: "GG",
+    kind: "abbreviation",
+    meaning: "Good Game(お疲れさま、いい試合でした)の略語",
+    note: "対戦系ゲームの配信終了時によく使われる",
+    sourceMessageText: "GG everyone, that was such a clutch play!",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en",
+    explainLang: "ja",
+    tags: [],
+    ...overrides,
+  });
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await db.cards.clear();
+  await db.reviews.clear();
+});
+
+describe("StudyPage", () => {
+  it("復習対象のカードが1件もない場合、その旨を表示する", async () => {
+    render(<StudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/復習するカードはありません/)).toBeInTheDocument();
+    });
+  });
+
+  it("穴埋め問題に正解すると正誤が表示され、採点後に復習セッションが終了する", async () => {
+    await seedCard({
+      term: "clutch",
+      meaning: "土壇場での見事なプレー",
+      sourceMessageText: "that was such a clutch play honestly",
+    });
+    const user = userEvent.setup();
+
+    render(<StudyPage />);
+
+    await waitFor(() => expect(screen.getByLabelText("答えを入力")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("答えを入力"), "clutch");
+    await user.click(screen.getByRole("button", { name: "判定する" }));
+
+    await waitFor(() => expect(screen.getByText("正解!")).toBeInTheDocument());
+    expect(screen.getByText("土壇場での見事なプレー")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "普通" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/復習セッションが終了しました/)).toBeInTheDocument();
+    });
+    const reviews = await db.reviews.toArray();
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].grade).toBe("good");
+    const stored = await db.cards.toArray();
+    expect(stored[0].srs.interval).toBe(1);
+  });
+
+  it("穴埋め問題に不正解だと不正解と表示され、次へボタンでAgainとして記録される", async () => {
+    await seedCard({ term: "clutch", sourceMessageText: "that was such a clutch play honestly" });
+    const user = userEvent.setup();
+
+    render(<StudyPage />);
+
+    await waitFor(() => expect(screen.getByLabelText("答えを入力")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("答えを入力"), "wrong-answer");
+    await user.click(screen.getByRole("button", { name: "判定する" }));
+
+    await waitFor(() => expect(screen.getByText("不正解")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "次のカードへ" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/復習セッションが終了しました/)).toBeInTheDocument();
+    });
+    const reviews = await db.reviews.toArray();
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0].grade).toBe("again");
+  });
+
+  it("意味当て4択に正解すると正誤が表示され、採点後に復習セッションが終了する", async () => {
+    // termが元の発言に含まれないカードにすることで、穴埋めを出題不可にし意味当て4択に固定する
+    const target = await seedCard({
+      term: "GG",
+      meaning: "意味A",
+      sourceMessageText: "hello everyone, glad to be here today",
+    });
+    await seedCard({ term: "clutch", meaning: "意味B" });
+    await seedCard({ term: "poggers", meaning: "意味C" });
+    await seedCard({ term: "kappa", meaning: "意味D" });
+    // 単語帳一覧はcreatedAtの新しい順に返るため、due値を明示的に最も早くしてGGカードの出題順を確定させる
+    await db.cards.update(target.id!, { srs: { ...target.srs, due: target.srs.due - 1 } });
+    const user = userEvent.setup();
+
+    render(<StudyPage />);
+
+    await waitFor(() => expect(screen.getByText("GG")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "意味A" }));
+
+    await waitFor(() => expect(screen.getByText("正解!")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "簡単" }));
+
+    // 単語帳には4件あるため、1件採点した時点ではまだ残りカードの出題に進む(セッションは終了しない)
+    await waitFor(async () => {
+      const reviews = await db.reviews.toArray();
+      expect(reviews.filter((r) => r.grade === "easy")).toHaveLength(1);
+    });
+  });
+
+  it("学習統計(復習件数・正答率)を表示する", async () => {
+    await seedCard({ term: "clutch", sourceMessageText: "that was such a clutch play honestly" });
+    const user = userEvent.setup();
+
+    render(<StudyPage />);
+
+    await waitFor(() => expect(screen.getByLabelText("答えを入力")).toBeInTheDocument());
+    expect(screen.getByText(/復習件数: 0件/)).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("答えを入力"), "clutch");
+    await user.click(screen.getByRole("button", { name: "判定する" }));
+    await waitFor(() => expect(screen.getByText("正解!")).toBeInTheDocument());
+    await user.click(screen.getByRole("button", { name: "普通" }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/復習件数: 1件/)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/正答率: 100%/)).toBeInTheDocument();
+  });
+
+  it("採点の記録中は採点ボタンが無効化され、連打してもreviewCardは1回しか呼ばれない(二重送信防止)", async () => {
+    const card = await seedCard({ term: "clutch", sourceMessageText: "that was such a clutch play honestly" });
+    const user = userEvent.setup();
+
+    let resolveReview!: (value: Awaited<ReturnType<typeof reviewsModule.reviewCard>>) => void;
+    const pendingReview = new Promise<Awaited<ReturnType<typeof reviewsModule.reviewCard>>>((resolve) => {
+      resolveReview = resolve;
+    });
+    const reviewCardSpy = vi.spyOn(reviewsModule, "reviewCard").mockReturnValue(pendingReview);
+
+    render(<StudyPage />);
+    await waitFor(() => expect(screen.getByLabelText("答えを入力")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("答えを入力"), "clutch");
+    await user.click(screen.getByRole("button", { name: "判定する" }));
+    await waitFor(() => expect(screen.getByText("正解!")).toBeInTheDocument());
+
+    const goodButton = screen.getByRole("button", { name: "普通" });
+    await user.click(goodButton);
+
+    // reviewCardがまだ解決していない間は採点ボタンが無効化され、連打してもreviewCardは1回しか呼ばれない
+    expect(goodButton).toBeDisabled();
+    await user.click(goodButton);
+    expect(reviewCardSpy).toHaveBeenCalledTimes(1);
+
+    resolveReview(card);
+    await waitFor(() => {
+      expect(screen.getByText(/復習セッションが終了しました/)).toBeInTheDocument();
+    });
+  });
+
+  it("採点の記録に失敗した場合、その旨をエラーメッセージとして表示する", async () => {
+    await seedCard({ term: "clutch", sourceMessageText: "that was such a clutch play honestly" });
+    const user = userEvent.setup();
+
+    vi.spyOn(reviewsModule, "reviewCard").mockRejectedValue(new Error("カードが見つかりません(id: 1)"));
+
+    render(<StudyPage />);
+    await waitFor(() => expect(screen.getByLabelText("答えを入力")).toBeInTheDocument());
+    await user.type(screen.getByLabelText("答えを入力"), "clutch");
+    await user.click(screen.getByRole("button", { name: "判定する" }));
+    await waitFor(() => expect(screen.getByText("正解!")).toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "普通" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/カードが見つかりません/);
+    });
+  });
+
+  it("初期読み込みに失敗した場合、その旨をエラーメッセージとして表示する", async () => {
+    vi.spyOn(cardsModule, "listCards").mockRejectedValue(new Error("単語帳の読み込みに失敗しました"));
+
+    render(<StudyPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/単語帳の読み込みに失敗しました/);
+    });
+  });
+
+  it("同じ意味を持つカードが複数あっても、Reactキー重複の警告を出さずに意味当て4択を描画する", async () => {
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // 4件とも元の発言にtermを含めないことで、単語帳一覧の並び順に関わらずどのカードが
+    // 出題対象になっても穴埋めが選ばれず、常に意味当て4択(4件とも1問に登場)になるようにする
+    const sourceMessageText = "hello everyone, glad to be here today";
+    await seedCard({ term: "GG", meaning: "同じ意味", sourceMessageText });
+    await seedCard({ term: "clutch", meaning: "同じ意味", sourceMessageText });
+    await seedCard({ term: "poggers", meaning: "違う意味C", sourceMessageText });
+    await seedCard({ term: "kappa", meaning: "違う意味D", sourceMessageText });
+
+    render(<StudyPage />);
+
+    await waitFor(() => expect(screen.getByText("次の語句の意味は?")).toBeInTheDocument());
+
+    const hasKeyWarning = consoleErrorSpy.mock.calls.some((args) => String(args[0]).includes("same key"));
+    expect(hasKeyWarning).toBe(false);
+  });
+});

--- a/src/app/study/page.tsx
+++ b/src/app/study/page.tsx
@@ -1,0 +1,240 @@
+/**
+ * 復習クイズページ(/study)。
+ *
+ * SM-2(間隔反復)で期日が来たカードだけを出題する。出題形式は「意味当て4択」と
+ * 「穴埋め」の2種で、回答後は正誤を表示したうえで採点(Again/Hard/Good/Easy)を行う。
+ * 採点結果は `reviewCard` がSM-2状態の更新とreviews履歴の記録を行い、次回の
+ * 出題間隔に反映される。クイズの根幹はコードだけで完結し、LLMには依存しない
+ * (AIが使えない環境でも復習は動作するという設計方針、AGENTS.md参照)。
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { listCards, selectDueCards } from "@/lib/db/cards";
+import { getReviewStats, reviewCard } from "@/lib/db/reviews";
+import type { Card as DeckCard } from "@/lib/db/schema";
+import type { Grade } from "@/lib/db/srs";
+import { buildQuizQuestion, isQuizzable, type QuizQuestion } from "@/lib/study/quiz";
+
+type Phase = "loading" | "no-due" | "answering" | "answered" | "finished";
+
+/** 学習統計の表示用に、件数ベースで正答率を管理する(採点のたびにDBへ再集計をかけずに済ませるため) */
+interface ReviewCounts {
+  total: number;
+  /** Again以外の採点を正答とみなした件数 */
+  correct: number;
+}
+
+const INITIAL_REVIEW_COUNTS: ReviewCounts = { total: 0, correct: 0 };
+
+/** エラーをユーザー向けメッセージに変換する(想定外の例外でも空文字を表示しないための最終防御) */
+function toErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}
+
+export default function StudyPage() {
+  const [phase, setPhase] = useState<Phase>("loading");
+  const [deck, setDeck] = useState<DeckCard[]>([]);
+  const [queue, setQueue] = useState<DeckCard[]>([]);
+  const [question, setQuestion] = useState<QuizQuestion | null>(null);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [inputValue, setInputValue] = useState("");
+  const [reviewCounts, setReviewCounts] = useState<ReviewCounts>(INITIAL_REVIEW_COUNTS);
+  const [isSubmittingGrade, setIsSubmittingGrade] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const now = Date.now();
+    Promise.all([listCards(), getReviewStats()])
+      .then(([allCards, initialStats]) => {
+        const due = selectDueCards(allCards, now);
+        // 意味当て4択・穴埋めのどちらも出題できないカード(単語帳が1件だけ、かつtermが元発言と一致しない等)は除外する
+        const quizzable = due.filter((card) => isQuizzable(card, allCards));
+
+        setDeck(allCards);
+        setReviewCounts({
+          total: initialStats.totalReviews,
+          correct: Math.round(initialStats.correctRate * initialStats.totalReviews),
+        });
+
+        if (quizzable.length === 0) {
+          setPhase("no-due");
+          return;
+        }
+
+        setQueue(quizzable);
+        setQuestion(buildQuizQuestion(quizzable[0], allCards));
+        setPhase("answering");
+      })
+      .catch((error: unknown) => {
+        setErrorMessage(toErrorMessage(error, "復習データの読み込みに失敗しました"));
+      });
+  }, []);
+
+  const handleMeaningChoiceAnswer = useCallback(
+    (choiceIndex: number) => {
+      if (!question || question.format !== "meaning-choice") return;
+      setIsCorrect(choiceIndex === question.correctIndex);
+      setPhase("answered");
+    },
+    [question],
+  );
+
+  const handleFillBlankSubmit = useCallback(() => {
+    if (!question || question.format !== "fill-blank") return;
+    const normalizedInput = inputValue.trim().toLowerCase();
+    const normalizedTerm = question.card.term.trim().toLowerCase();
+    setIsCorrect(normalizedInput === normalizedTerm);
+    setPhase("answered");
+  }, [question, inputValue]);
+
+  const handleGrade = useCallback(
+    (grade: Grade) => {
+      // 記録が完了する前の連打で同じ回答が二重に採点されるのを防ぐ
+      if (!question?.card.id || isSubmittingGrade) return;
+      const cardId = question.card.id;
+
+      setIsSubmittingGrade(true);
+      reviewCard(cardId, grade, Date.now())
+        .then(() => {
+          setReviewCounts((prev) => ({
+            total: prev.total + 1,
+            correct: prev.correct + (grade === "again" ? 0 : 1),
+          }));
+
+          const rest = queue.slice(1);
+          setIsCorrect(null);
+          setInputValue("");
+
+          if (rest.length === 0) {
+            setQueue([]);
+            setQuestion(null);
+            setPhase("finished");
+            return;
+          }
+
+          setQueue(rest);
+          setQuestion(buildQuizQuestion(rest[0], deck));
+          setPhase("answering");
+        })
+        .catch((error: unknown) => {
+          setErrorMessage(toErrorMessage(error, "採点の記録に失敗しました"));
+        })
+        .finally(() => {
+          setIsSubmittingGrade(false);
+        });
+    },
+    [question, queue, deck, isSubmittingGrade],
+  );
+
+  const correctRate = reviewCounts.total === 0 ? 0 : reviewCounts.correct / reviewCounts.total;
+
+  return (
+    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>復習クイズ</CardTitle>
+          <CardDescription>
+            復習件数: {reviewCounts.total}件 / 正答率: {Math.round(correctRate * 100)}%
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {errorMessage && (
+            <p role="alert" className="text-sm text-destructive">
+              {errorMessage}
+            </p>
+          )}
+
+          {phase === "loading" && !errorMessage && <p className="text-sm text-muted-foreground">読み込み中...</p>}
+
+          {phase === "no-due" && (
+            <p className="text-sm text-muted-foreground">
+              復習するカードはありません。単語帳にカードを追加するか、期日が来るまでお待ちください。
+            </p>
+          )}
+
+          {phase === "finished" && (
+            <p className="text-sm text-muted-foreground">復習セッションが終了しました。お疲れさまでした。</p>
+          )}
+
+          {(phase === "answering" || phase === "answered") && question && (
+            <div className="flex flex-col gap-3">
+              <p className="text-xs text-muted-foreground">残り{queue.length}件</p>
+
+              {question.format === "meaning-choice" && (
+                <div className="flex flex-col gap-3">
+                  <p className="text-sm text-muted-foreground">次の語句の意味は?</p>
+                  <p className="text-lg font-semibold">{question.card.term}</p>
+                  <p className="text-xs italic text-muted-foreground">「{question.card.sourceMessageText}」</p>
+                  <div className="grid gap-2">
+                    {question.choices.map((choice, index) => (
+                      <Button
+                        key={index}
+                        variant="outline"
+                        disabled={phase === "answered"}
+                        onClick={() => handleMeaningChoiceAnswer(index)}
+                      >
+                        {choice}
+                      </Button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {question.format === "fill-blank" && (
+                <div className="flex flex-col gap-3">
+                  <p className="text-sm text-muted-foreground">空欄に入る語句は?</p>
+                  <p className="text-lg font-semibold">{question.maskedText}</p>
+                  <div className="flex flex-col gap-1.5">
+                    <Label htmlFor="fill-blank-input">答えを入力</Label>
+                    <div className="flex gap-2">
+                      <Input
+                        id="fill-blank-input"
+                        value={inputValue}
+                        disabled={phase === "answered"}
+                        onChange={(e) => setInputValue(e.target.value)}
+                      />
+                      <Button onClick={handleFillBlankSubmit} disabled={phase === "answered"}>
+                        判定する
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {phase === "answered" && (
+                <div className="flex flex-col gap-2 rounded-md border p-3">
+                  <p className="font-semibold">{isCorrect ? "正解!" : "不正解"}</p>
+                  <p className="text-sm text-muted-foreground">{question.card.meaning}</p>
+                  {question.card.note && <p className="text-xs text-muted-foreground">{question.card.note}</p>}
+
+                  {isCorrect ? (
+                    <div className="flex gap-2">
+                      <Button variant="outline" disabled={isSubmittingGrade} onClick={() => handleGrade("hard")}>
+                        難しい
+                      </Button>
+                      <Button variant="outline" disabled={isSubmittingGrade} onClick={() => handleGrade("good")}>
+                        普通
+                      </Button>
+                      <Button variant="outline" disabled={isSubmittingGrade} onClick={() => handleGrade("easy")}>
+                        簡単
+                      </Button>
+                    </div>
+                  ) : (
+                    <Button variant="outline" disabled={isSubmittingGrade} onClick={() => handleGrade("again")}>
+                      次のカードへ
+                    </Button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/site-header.test.tsx
+++ b/src/components/site-header.test.tsx
@@ -28,4 +28,11 @@ describe("SiteHeader", () => {
     const deckLink = screen.getByRole("link", { name: "単語帳" });
     expect(deckLink).toHaveAttribute("href", "/deck");
   });
+
+  it("復習クイズページ(/study)へのリンクを表示する", () => {
+    render(<SiteHeader />);
+
+    const studyLink = screen.getByRole("link", { name: "復習" });
+    expect(studyLink).toHaveAttribute("href", "/study");
+  });
 });

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -2,8 +2,7 @@
  * 全ページ共通のヘッダー。
  *
  * chat-sensei はページ数の少ないシングルパーパスアプリのため、
- * ナビゲーションは実装済みのページ(ホーム / 単語帳 / 設定)のみを表示する。
- * 復習(/study)は Phase 5 でページ実装後にリンクを追加する。
+ * ナビゲーションは実装済みのページ(ホーム / 単語帳 / 復習 / 設定)のみを表示する。
  */
 import Link from "next/link";
 
@@ -17,6 +16,9 @@ export function SiteHeader() {
         <div className="flex items-center gap-4 text-sm">
           <Link href="/deck" className="text-muted-foreground transition-colors hover:text-foreground">
             単語帳
+          </Link>
+          <Link href="/study" className="text-muted-foreground transition-colors hover:text-foreground">
+            復習
           </Link>
           <Link href="/settings" className="text-muted-foreground transition-colors hover:text-foreground">
             設定

--- a/src/lib/db/cards.test.ts
+++ b/src/lib/db/cards.test.ts
@@ -7,7 +7,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { db } from "./schema";
-import { createCard, deleteCard, exportCardsToJson, listCards, searchCards } from "./cards";
+import { createCard, deleteCard, exportCardsToJson, listCards, listDueCards, searchCards, selectDueCards } from "./cards";
 
 /** カード化ボタンから渡される入力を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
 function buildNewCardInput(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
@@ -89,6 +89,36 @@ describe("searchCards", () => {
     const result = await searchCards("");
 
     expect(result).toHaveLength(2);
+  });
+});
+
+describe("listDueCards", () => {
+  it("期日(srs.due)が現在時刻以下のカードだけを、期日が早い順に返す", async () => {
+    const overdue = await createCard(buildNewCardInput({ term: "GG" }));
+    const future = await createCard(buildNewCardInput({ term: "clutch" }));
+    const moreOverdue = await createCard(buildNewCardInput({ term: "poggers" }));
+
+    const now = new Date("2026-07-29T12:00:00.000Z").getTime();
+    await db.cards.update(overdue.id!, { srs: { ...overdue.srs, due: now - 1000 } });
+    await db.cards.update(future.id!, { srs: { ...future.srs, due: now + 1000 } });
+    await db.cards.update(moreOverdue.id!, { srs: { ...moreOverdue.srs, due: now - 2000 } });
+
+    const due = await listDueCards(now);
+
+    expect(due.map((card) => card.term)).toEqual(["poggers", "GG"]);
+  });
+});
+
+describe("selectDueCards", () => {
+  it("カード配列から、期日(srs.due)が現在時刻以下のものだけを期日が早い順に抽出する(DBアクセスなしの純関数)", () => {
+    const now = new Date("2026-07-29T12:00:00.000Z").getTime();
+    const overdue = { ...buildNewCardInput({ term: "GG" }), id: 1, createdAt: 0, srs: { due: now - 1000, interval: 0, easeFactor: 2.5, repetitions: 0, lapses: 0, lastReviewedAt: null } };
+    const future = { ...buildNewCardInput({ term: "clutch" }), id: 2, createdAt: 0, srs: { due: now + 1000, interval: 0, easeFactor: 2.5, repetitions: 0, lapses: 0, lastReviewedAt: null } };
+    const moreOverdue = { ...buildNewCardInput({ term: "poggers" }), id: 3, createdAt: 0, srs: { due: now - 2000, interval: 0, easeFactor: 2.5, repetitions: 0, lapses: 0, lastReviewedAt: null } };
+
+    const due = selectDueCards([overdue, future, moreOverdue], now);
+
+    expect(due.map((card) => card.term)).toEqual(["poggers", "GG"]);
   });
 });
 

--- a/src/lib/db/cards.ts
+++ b/src/lib/db/cards.ts
@@ -52,6 +52,20 @@ export async function searchCards(query: string): Promise<Card[]> {
   );
 }
 
+/**
+ * カード配列から、期日(srs.due)が現在時刻以下のものだけを期日が早い順に抽出する(DBアクセスなしの純関数)。
+ * すでに全カードを取得済みの呼び出し元(復習クイズページなど)は、`listDueCards` で再度DBへ
+ * 問い合わせる代わりにこちらを使うことで、同じテーブルへの重複スキャンを避けられる。
+ */
+export function selectDueCards(cards: Card[], now: number): Card[] {
+  return cards.filter((card) => card.srs.due <= now).sort((a, b) => a.srs.due - b.srs.due);
+}
+
+/** 期日(srs.due)が現在時刻以下のカードを、期日が早い順に返す(復習クイズの出題対象取得に使う) */
+export async function listDueCards(now: number): Promise<Card[]> {
+  return selectDueCards(await db.cards.toArray(), now);
+}
+
 /** 指定したIDのカードを削除する */
 export async function deleteCard(id: number): Promise<void> {
   await db.cards.delete(id);

--- a/src/lib/db/reviews.test.ts
+++ b/src/lib/db/reviews.test.ts
@@ -1,0 +1,75 @@
+/**
+ * src/lib/db/reviews.ts のテスト。
+ *
+ * fake-indexeddbを使い、採点(reviewCard)がSM-2状態の更新とreviews記録を
+ * 不可分に(同一トランザクションで)行うこと、統計(getReviewStats)が
+ * 復習件数・正答率を正しく計算することを検証する。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { db } from "./schema";
+import { createCard } from "./cards";
+import { getReviewStats, reviewCard } from "./reviews";
+
+/** カード化ボタンから渡される入力を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
+function buildNewCardInput(overrides: Partial<Parameters<typeof createCard>[0]> = {}) {
+  return {
+    term: "GG",
+    kind: "abbreviation" as const,
+    meaning: "Good Game(お疲れさま、いい試合でした)の略語",
+    note: "対戦系ゲームの配信終了時によく使われる",
+    sourceMessageText: "GG everyone, that was such a clutch play!",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en" as const,
+    explainLang: "ja" as const,
+    tags: [],
+    ...overrides,
+  };
+}
+
+afterEach(async () => {
+  await db.cards.clear();
+  await db.reviews.clear();
+});
+
+describe("reviewCard", () => {
+  it("SM-2状態を更新して保存し、reviewsに履歴を記録する", async () => {
+    const card = await createCard(buildNewCardInput());
+    const now = new Date("2026-07-29T12:00:00.000Z").getTime();
+
+    const updated = await reviewCard(card.id!, "good", now);
+
+    expect(updated.srs.interval).toBe(1);
+    expect(updated.srs.repetitions).toBe(1);
+    const stored = await db.cards.get(card.id!);
+    expect(stored?.srs).toEqual(updated.srs);
+    const reviews = await db.reviews.toArray();
+    expect(reviews).toHaveLength(1);
+    expect(reviews[0]).toMatchObject({ cardId: card.id, grade: "good", reviewedAt: now });
+  });
+
+  it("存在しないカードIDを渡すとエラーを投げる", async () => {
+    await expect(reviewCard(9999, "good", Date.now())).rejects.toThrow(/見つかりません/);
+  });
+});
+
+describe("getReviewStats", () => {
+  it("復習履歴がない場合は件数0・正答率0を返す", async () => {
+    const stats = await getReviewStats();
+
+    expect(stats).toEqual({ totalReviews: 0, correctRate: 0 });
+  });
+
+  it("Again以外の採点を正答とみなし、件数と正答率を計算する", async () => {
+    const card = await createCard(buildNewCardInput());
+    const now = new Date("2026-07-29T12:00:00.000Z").getTime();
+    await reviewCard(card.id!, "good", now);
+    await reviewCard(card.id!, "again", now + 1000);
+    await reviewCard(card.id!, "easy", now + 2000);
+
+    const stats = await getReviewStats();
+
+    expect(stats.totalReviews).toBe(3);
+    expect(stats.correctRate).toBeCloseTo(2 / 3);
+  });
+});

--- a/src/lib/db/reviews.ts
+++ b/src/lib/db/reviews.ts
@@ -1,0 +1,46 @@
+/**
+ * 復習履歴(`Review`)の記録とSM-2状態の更新を行うモジュール。
+ *
+ * 復習クイズ(/study)で1問答えるたびに `reviewCard` を呼ぶ。`gradeCard`(SM-2純関数)で
+ * カードのSRS状態を更新し、同じDexieトランザクション内で `reviews` に採点結果を記録する
+ * ことで、「カードは更新されたが履歴が残らない」といった中途半端な状態を避ける。
+ */
+import type { Card } from "./schema";
+import { db } from "./schema";
+import { gradeCard, type Grade } from "./srs";
+
+/** 学習統計(復習件数・正答率) */
+export interface ReviewStats {
+  totalReviews: number;
+  /** Again以外の採点を正答とみなした割合(0〜1)。復習履歴がない場合は0 */
+  correctRate: number;
+}
+
+/**
+ * カードを採点する: SM-2状態(`gradeCard`)を更新して保存し、reviewsに履歴を記録する。
+ * 更新後のカード(新しいsrsを含む)を返す。
+ */
+export async function reviewCard(cardId: number, grade: Grade, now: number): Promise<Card> {
+  return db.transaction("rw", db.cards, db.reviews, async () => {
+    const card = await db.cards.get(cardId);
+    if (!card) {
+      throw new Error(`カードが見つかりません(id: ${cardId})`);
+    }
+
+    const srs = gradeCard(card.srs, grade, now);
+    await db.cards.update(cardId, { srs });
+    await db.reviews.add({ cardId, grade, reviewedAt: now });
+
+    return { ...card, srs };
+  });
+}
+
+/** 全復習履歴から件数・正答率(Again以外を正答とみなす)を計算する */
+export async function getReviewStats(): Promise<ReviewStats> {
+  const reviews = await db.reviews.toArray();
+  if (reviews.length === 0) {
+    return { totalReviews: 0, correctRate: 0 };
+  }
+  const correctCount = reviews.filter((review) => review.grade !== "again").length;
+  return { totalReviews: reviews.length, correctRate: correctCount / reviews.length };
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -10,6 +10,7 @@ import Dexie, { type Table } from "dexie";
 import type { EmotePosition } from "../twitch/irc-parser";
 import type { ExplanationItemKind } from "../ai/schemas";
 import type { SupportedLanguage } from "../ai/prompts";
+import type { Grade } from "./srs";
 
 /** Twitchチャットの1メッセージを永続化した形 */
 export interface StoredMessage {
@@ -29,10 +30,7 @@ export interface StoredMessage {
   confidence: number | null;
 }
 
-/**
- * SM-2間隔反復アルゴリズムの状態(Phase 5「復習クイズ」で使用)。
- * Phase 3時点ではカード作成時に初期値を保存するのみで、採点ロジックは実装しない。
- */
+/** SM-2間隔反復アルゴリズムの状態。採点ロジックは `srs.ts` の `gradeCard` を参照 */
 export interface CardSrsState {
   /** 次回復習予定日時(epoch ms) */
   due: number;
@@ -69,12 +67,12 @@ export interface Card {
   srs: CardSrsState;
 }
 
-/** 復習履歴(Phase 5「復習クイズ」で使用) */
+/** 復習履歴 */
 export interface Review {
   id?: number;
   cardId: number;
-  /** 採点(Again/Hard/Good/Easyなど、Phase 5で定義する) */
-  grade: number;
+  /** 採点(Again/Hard/Good/Easy)。`srs.ts` の `gradeCard` にそのまま渡す */
+  grade: Grade;
   reviewedAt: number;
 }
 

--- a/src/lib/db/srs.test.ts
+++ b/src/lib/db/srs.test.ts
@@ -1,0 +1,113 @@
+/**
+ * src/lib/db/srs.ts のテスト。
+ *
+ * SM-2相当のアルゴリズムをDBアクセスなしの純関数として検証する。
+ * 「初回復習も即座に必要」とみなす初期状態(cards.ts の createInitialSrsState 相当)から、
+ * 各採点(Again/Hard/Good/Easy)でinterval・easeFactor・repetitions・lapsesがどう遷移するかを確認する。
+ */
+import { describe, expect, it } from "vitest";
+import { gradeCard } from "./srs";
+import type { CardSrsState } from "./schema";
+
+/** 未復習カードの初期SRS状態を模したテストデータ */
+function buildInitialSrsState(overrides: Partial<CardSrsState> = {}): CardSrsState {
+  return {
+    due: 0,
+    interval: 0,
+    easeFactor: 2.5,
+    repetitions: 0,
+    lapses: 0,
+    lastReviewedAt: null,
+    ...overrides,
+  };
+}
+
+const NOW = new Date("2026-07-29T10:00:00.000Z").getTime();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("gradeCard", () => {
+  it("初回にGoodと採点すると、1日後が次回期日になりrepetitionsが1になる", () => {
+    const result = gradeCard(buildInitialSrsState(), "good", NOW);
+
+    expect(result.interval).toBe(1);
+    expect(result.due).toBe(NOW + 1 * DAY_MS);
+    expect(result.repetitions).toBe(1);
+    expect(result.easeFactor).toBe(2.5);
+    expect(result.lapses).toBe(0);
+    expect(result.lastReviewedAt).toBe(NOW);
+  });
+
+  it("2回目のGoodで6日後になる", () => {
+    const first = gradeCard(buildInitialSrsState(), "good", NOW);
+
+    const second = gradeCard(first, "good", NOW + DAY_MS);
+
+    expect(second.interval).toBe(6);
+    expect(second.repetitions).toBe(2);
+  });
+
+  it("3回目以降のGoodは、旧intervalに旧easeFactorを掛けて伸びる", () => {
+    const state = buildInitialSrsState({ interval: 6, repetitions: 2, easeFactor: 2.5 });
+
+    const result = gradeCard(state, "good", NOW);
+
+    expect(result.interval).toBe(15); // 6 * 2.5
+    expect(result.repetitions).toBe(3);
+    expect(result.easeFactor).toBe(2.5); // Goodはease増減なし
+  });
+
+  it("Againと採点すると、即座に再出題対象になりrepetitions/intervalがリセットされ、lapsesが増える", () => {
+    const state = buildInitialSrsState({ interval: 15, repetitions: 3, easeFactor: 2.5, lapses: 1 });
+
+    const result = gradeCard(state, "again", NOW);
+
+    expect(result.due).toBe(NOW);
+    expect(result.interval).toBe(0);
+    expect(result.repetitions).toBe(0);
+    expect(result.lapses).toBe(2);
+    expect(result.easeFactor).toBeCloseTo(2.3); // 2.5 - 0.2
+    expect(result.lastReviewedAt).toBe(NOW);
+  });
+
+  it("easeFactorは1.3を下回らない", () => {
+    const state = buildInitialSrsState({ easeFactor: 1.35 });
+
+    const result = gradeCard(state, "again", NOW);
+
+    expect(result.easeFactor).toBe(1.3);
+  });
+
+  it("初回にHardと採点すると1日後になり、easeFactorが0.15下がる", () => {
+    const result = gradeCard(buildInitialSrsState(), "hard", NOW);
+
+    expect(result.interval).toBe(1);
+    expect(result.repetitions).toBe(1);
+    expect(result.easeFactor).toBeCloseTo(2.35);
+  });
+
+  it("3回目以降のHardは、easeFactorに依存せずintervalを1.2倍する", () => {
+    const state = buildInitialSrsState({ interval: 10, repetitions: 2, easeFactor: 2.0 });
+
+    const result = gradeCard(state, "hard", NOW);
+
+    expect(result.interval).toBe(12); // 10 * 1.2
+    expect(result.easeFactor).toBeCloseTo(1.85);
+  });
+
+  it("初回にEasyと採点すると4日後になり、easeFactorが0.15上がる", () => {
+    const result = gradeCard(buildInitialSrsState(), "easy", NOW);
+
+    expect(result.interval).toBe(4);
+    expect(result.repetitions).toBe(1);
+    expect(result.easeFactor).toBeCloseTo(2.65);
+  });
+
+  it("3回目以降のEasyは、旧easeFactorに1.3倍のボーナスを掛けて大きく伸びる", () => {
+    const state = buildInitialSrsState({ interval: 6, repetitions: 2, easeFactor: 2.5 });
+
+    const result = gradeCard(state, "easy", NOW);
+
+    expect(result.interval).toBe(20); // round(6 * 2.5 * 1.3) = round(19.5) = 20
+    expect(result.easeFactor).toBeCloseTo(2.65);
+  });
+});

--- a/src/lib/db/srs.ts
+++ b/src/lib/db/srs.ts
@@ -1,0 +1,98 @@
+/**
+ * SM-2相当の間隔反復アルゴリズムを純関数として実装するモジュール。
+ *
+ * 復習クイズ(/study)の採点結果からカードの次回復習期日を計算する。
+ * 安定性を優先し、DBアクセスもLLM呼び出しも行わない(`gradeCard` は入力から出力を
+ * 決定的に計算するだけの純関数)。
+ *
+ * 採点は Anki などで広く使われる4段階(Again/Hard/Good/Easy)とし、教科書的な
+ * SuperMemo-2 の定義に合わせて「今回のintervalは更新前のeaseFactorを使って計算し、
+ * easeFactor自体はこの回の採点結果で更新して次回に持ち越す」という順序で計算する。
+ */
+import type { CardSrsState } from "./schema";
+
+/** 復習クイズの採点(自己申告する想起の手応え) */
+export const GRADES = ["again", "hard", "good", "easy"] as const;
+export type Grade = (typeof GRADES)[number];
+
+/** easeFactorがどれだけ下がっても学習が破綻しないための下限値(SuperMemo-2の定義値) */
+const MIN_EASE_FACTOR = 1.3;
+
+/** 採点ごとのeaseFactor増減幅 */
+const EASE_FACTOR_DELTA: Record<Grade, number> = {
+  again: -0.2,
+  hard: -0.15,
+  good: 0,
+  easy: 0.15,
+};
+
+/** 初回成功時(repetitions === 0)の次回間隔(日) */
+const FIRST_INTERVAL_DAYS: Record<Exclude<Grade, "again">, number> = {
+  hard: 1,
+  good: 1,
+  easy: 4,
+};
+
+/** 2回目成功時(repetitions === 1)の次回間隔(日) */
+const SECOND_INTERVAL_DAYS: Record<Exclude<Grade, "again">, number> = {
+  hard: 3,
+  good: 6,
+  easy: 10,
+};
+
+/** 3回目以降のHardで、easeFactorに依存せずintervalに掛ける係数 */
+const HARD_INTERVAL_MULTIPLIER = 1.2;
+
+/** 3回目以降のEasyで、easeFactorベースのintervalにさらに掛けるボーナス係数 */
+const EASY_BONUS_MULTIPLIER = 1.3;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * 採点結果(grade)をもとに、現在のSRS状態から次回のSRS状態を計算する。
+ *
+ * - Again: 学習に失敗したとみなし、repetitions/intervalを0にリセットして即座に再出題対象にする
+ * - Hard/Good/Easy: repetitionsを進め、直近の復習回数(0回目・1回目・2回目以降)に応じた式でintervalを伸ばす
+ *
+ * @param srsState 現在のSRS状態
+ * @param grade 復習クイズでの採点
+ * @param now 採点時刻(epoch ms)。呼び出し元で確定させた時刻を渡す(この関数はDate.now()を呼ばない)
+ */
+export function gradeCard(srsState: CardSrsState, grade: Grade, now: number): CardSrsState {
+  const easeFactor = Math.max(MIN_EASE_FACTOR, srsState.easeFactor + EASE_FACTOR_DELTA[grade]);
+
+  if (grade === "again") {
+    return {
+      due: now,
+      interval: 0,
+      easeFactor,
+      repetitions: 0,
+      lapses: srsState.lapses + 1,
+      lastReviewedAt: now,
+    };
+  }
+
+  const repetitions = srsState.repetitions + 1;
+  let interval: number;
+  if (srsState.repetitions === 0) {
+    interval = FIRST_INTERVAL_DAYS[grade];
+  } else if (srsState.repetitions === 1) {
+    interval = SECOND_INTERVAL_DAYS[grade];
+  } else if (grade === "hard") {
+    interval = srsState.interval * HARD_INTERVAL_MULTIPLIER;
+  } else if (grade === "easy") {
+    interval = srsState.interval * srsState.easeFactor * EASY_BONUS_MULTIPLIER;
+  } else {
+    interval = srsState.interval * srsState.easeFactor;
+  }
+  interval = Math.max(1, Math.round(interval));
+
+  return {
+    due: now + interval * DAY_MS,
+    interval,
+    easeFactor,
+    repetitions,
+    lapses: srsState.lapses,
+    lastReviewedAt: now,
+  };
+}

--- a/src/lib/study/quiz.test.ts
+++ b/src/lib/study/quiz.test.ts
@@ -1,0 +1,199 @@
+/**
+ * src/lib/study/quiz.ts のテスト。
+ *
+ * DBアクセスなしの純関数として、意味当て4択・穴埋めの2形式の出題ロジックを検証する。
+ * 選択肢のシャッフルは乱数を注入できるようにしているため、テストでは決定的な乱数関数を渡す。
+ */
+import { describe, expect, it } from "vitest";
+import {
+  buildFillBlankQuestion,
+  buildMeaningChoiceQuestion,
+  buildQuizQuestion,
+  isFillBlankAvailable,
+  isMeaningChoiceAvailable,
+  isQuizzable,
+} from "./quiz";
+import type { Card } from "@/lib/db/schema";
+
+let nextCardId = 1;
+
+/** 単語帳カードを模したテストデータ(意味の分かる日本語・実チャット文を使用) */
+function buildCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: nextCardId++,
+    term: "GG",
+    kind: "abbreviation",
+    meaning: "Good Game(お疲れさま、いい試合でした)の略語",
+    note: "対戦系ゲームの配信終了時によく使われる",
+    sourceMessageText: "GG everyone, that was such a clutch play!",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en",
+    explainLang: "ja",
+    tags: [],
+    createdAt: 0,
+    srs: { due: 0, interval: 0, easeFactor: 2.5, repetitions: 0, lapses: 0, lastReviewedAt: null },
+    ...overrides,
+  };
+}
+
+describe("buildMeaningChoiceQuestion", () => {
+  it("他カードが3件以上あれば、正解1件+誤答3件の4択を作る", () => {
+    const target = buildCard({ term: "GG", meaning: "意味A" });
+    const others = [
+      buildCard({ term: "clutch", meaning: "意味B" }),
+      buildCard({ term: "poggers", meaning: "意味C" }),
+      buildCard({ term: "kappa", meaning: "意味D" }),
+    ];
+
+    const question = buildMeaningChoiceQuestion(target, others, () => 0);
+
+    expect(question.choices).toHaveLength(4);
+    expect(question.choices).toContain("意味A");
+    expect(question.choices[question.correctIndex]).toBe("意味A");
+  });
+
+  it("他カードが3件未満の場合はエラーを投げる", () => {
+    const target = buildCard();
+    const others = [buildCard({ term: "clutch" }), buildCard({ term: "poggers" })];
+
+    expect(() => buildMeaningChoiceQuestion(target, others)).toThrow(/3件以上/);
+  });
+
+  it("同じ乱数関数を渡せば常に同じ並びになり(決定的)、異なる乱数関数なら並びが変わりうる", () => {
+    const target = buildCard({ term: "GG", meaning: "意味A" });
+    const others = [
+      buildCard({ term: "clutch", meaning: "意味B" }),
+      buildCard({ term: "poggers", meaning: "意味C" }),
+      buildCard({ term: "kappa", meaning: "意味D" }),
+    ];
+
+    const first = buildMeaningChoiceQuestion(target, others, () => 0);
+    const second = buildMeaningChoiceQuestion(target, others, () => 0);
+    const third = buildMeaningChoiceQuestion(target, others, () => 0.99);
+
+    expect(first.choices).toEqual(second.choices);
+    expect(first.choices).not.toEqual(third.choices);
+    expect(first.choices[first.correctIndex]).toBe("意味A");
+    expect(third.choices[third.correctIndex]).toBe("意味A");
+  });
+});
+
+describe("buildFillBlankQuestion", () => {
+  it("元の発言からtermをマスクした穴埋め問題を作る", () => {
+    const card = buildCard({ term: "clutch", sourceMessageText: "that was such a clutch play honestly" });
+
+    const question = buildFillBlankQuestion(card);
+
+    expect(question.maskedText).toBe("that was such a ＿＿＿＿ play honestly");
+  });
+
+  it("元の発言にtermが複数回登場する場合はすべてマスクする", () => {
+    const card = buildCard({ term: "gg", sourceMessageText: "gg gg well played" });
+
+    const question = buildFillBlankQuestion(card);
+
+    expect(question.maskedText).toBe("＿＿＿＿ ＿＿＿＿ well played");
+  });
+
+  it("元の発言にtermが含まれない場合はエラーを投げる", () => {
+    const card = buildCard({ term: "clutch", sourceMessageText: "gg well played" });
+
+    expect(() => buildFillBlankQuestion(card)).toThrow(/含まれていません/);
+  });
+
+  it("termが他の単語の一部として埋め込まれている箇所はマスクしない(単語境界チェック)", () => {
+    // "goggles" の中の "gg" は独立した語ではないため、単独で登場する "gg" だけをマスクする
+    const card = buildCard({ term: "gg", sourceMessageText: "gg goggles everywhere" });
+
+    const question = buildFillBlankQuestion(card);
+
+    expect(question.maskedText).toBe("＿＿＿＿ goggles everywhere");
+  });
+});
+
+describe("isMeaningChoiceAvailable", () => {
+  it("自分自身を除いた他カードが3件以上あればtrueを返す", () => {
+    const target = buildCard();
+    const deck = [target, buildCard(), buildCard(), buildCard()];
+
+    expect(isMeaningChoiceAvailable(target, deck)).toBe(true);
+  });
+
+  it("自分自身を除いた他カードが3件未満ならfalseを返す", () => {
+    const target = buildCard();
+    const deck = [target, buildCard()];
+
+    expect(isMeaningChoiceAvailable(target, deck)).toBe(false);
+  });
+});
+
+describe("isFillBlankAvailable", () => {
+  it("元の発言にtermが含まれていればtrueを返す", () => {
+    const card = buildCard({ term: "clutch", sourceMessageText: "that was clutch" });
+
+    expect(isFillBlankAvailable(card)).toBe(true);
+  });
+
+  it("元の発言にtermが含まれていなければfalseを返す", () => {
+    const card = buildCard({ term: "clutch", sourceMessageText: "gg well played" });
+
+    expect(isFillBlankAvailable(card)).toBe(false);
+  });
+
+  it("termが他の単語の一部として埋め込まれているだけの場合はfalseを返す(単語境界チェック)", () => {
+    const card = buildCard({ term: "gg", sourceMessageText: "goggles everywhere" });
+
+    expect(isFillBlankAvailable(card)).toBe(false);
+  });
+});
+
+describe("isQuizzable", () => {
+  it("意味当て4択・穴埋めのどちらかが出題可能ならtrueを返す", () => {
+    const target = buildCard({ term: "clutch", sourceMessageText: "that was such a clutch play" });
+
+    expect(isQuizzable(target, [target])).toBe(true);
+  });
+
+  it("どちらの形式も出題できない場合はfalseを返す", () => {
+    const target = buildCard({ term: "clutch", sourceMessageText: "gg well played" });
+
+    expect(isQuizzable(target, [target])).toBe(false);
+  });
+});
+
+describe("buildQuizQuestion", () => {
+  it("両方の形式が出題可能な場合、乱数が0.5未満なら意味当て4択になる", () => {
+    const target = buildCard({ term: "clutch", sourceMessageText: "that was such a clutch play" });
+    const deck = [target, buildCard(), buildCard(), buildCard()];
+
+    const question = buildQuizQuestion(target, deck, () => 0.1);
+
+    expect(question.format).toBe("meaning-choice");
+  });
+
+  it("両方の形式が出題可能な場合、乱数が0.5以上なら穴埋めになる", () => {
+    const target = buildCard({ term: "clutch", sourceMessageText: "that was such a clutch play" });
+    const deck = [target, buildCard(), buildCard(), buildCard()];
+
+    const question = buildQuizQuestion(target, deck, () => 0.9);
+
+    expect(question.format).toBe("fill-blank");
+  });
+
+  it("意味当て4択が出題できない場合(他カードが3件未満)は穴埋めになる", () => {
+    const target = buildCard({ term: "clutch", sourceMessageText: "that was such a clutch play" });
+    const deck = [target];
+
+    const question = buildQuizQuestion(target, deck);
+
+    expect(question.format).toBe("fill-blank");
+  });
+
+  it("どちらの形式も出題できない場合はエラーを投げる", () => {
+    const target = buildCard({ term: "clutch", sourceMessageText: "gg well played" });
+    const deck = [target];
+
+    expect(() => buildQuizQuestion(target, deck)).toThrow(/出題可能/);
+  });
+});

--- a/src/lib/study/quiz.ts
+++ b/src/lib/study/quiz.ts
@@ -1,0 +1,147 @@
+/**
+ * 復習クイズ(/study)の出題ロジックを純関数として実装するモジュール。
+ *
+ * 出題形式は2種類:
+ * - 意味当て4択: 対象カードの意味を正解とし、誤答選択肢を単語帳の他カードから抽出する
+ * - 穴埋め: 対象カードの元のチャット原文(sourceMessageText)からtermをマスクする
+ *
+ * DBアクセスは行わず、呼び出し元(/study ページ)がDexieから読み込んだカード配列を渡す。
+ * 選択肢のシャッフルに使う乱数は引数として注入できるようにし、テストで決定的に検証できる
+ * ようにしている(既定値は `Math.random`)。
+ */
+import type { Card } from "@/lib/db/schema";
+
+/** 意味当て4択を出題するために必要な、対象カード以外の最小カード枚数(誤答選択肢の数) */
+export const MIN_DISTRACTOR_COUNT = 3;
+
+/** 穴埋め問題でtermを隠す際のプレースホルダー */
+const BLANK_PLACEHOLDER = "＿＿＿＿";
+
+/** 正規表現の特殊文字をエスケープする(termをそのままリテラルとして扱うため) */
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * termの前後が文字・数字で挟まれていない箇所だけにマッチする正規表現を組み立てる。
+ * 例えば term="gg" は "goggles" の内部にマッチせず、独立した "gg" にのみマッチする。
+ * (Unicodeの文字カテゴリを使うため、日本語など多言語のtermにも対応する)
+ */
+function buildWordBoundaryPattern(term: string, flags: string): RegExp {
+  const escaped = escapeRegExp(term);
+  return new RegExp(`(?<![\\p{L}\\p{N}])${escaped}(?![\\p{L}\\p{N}])`, `${flags}u`);
+}
+
+export interface MeaningChoiceQuestion {
+  format: "meaning-choice";
+  card: Card;
+  /** シャッフル済みの選択肢(意味の文字列)。1件だけが正解 */
+  choices: string[];
+  /** `choices` 内で正解が入っているインデックス */
+  correctIndex: number;
+}
+
+export interface FillBlankQuestion {
+  format: "fill-blank";
+  card: Card;
+  /** sourceMessageText 中のtermをすべて `BLANK_PLACEHOLDER` に置き換えた文字列 */
+  maskedText: string;
+}
+
+export type QuizQuestion = MeaningChoiceQuestion | FillBlankQuestion;
+
+/** Fisher-Yatesで配列をシャッフルする(引数の配列は変更しない) */
+function shuffle<T>(items: T[], random: () => number): T[] {
+  const result = [...items];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+}
+
+/** 対象カードについて、意味当て4択が出題可能か(誤答選択肢を3件確保できるか)を判定する */
+export function isMeaningChoiceAvailable(card: Card, deck: Card[]): boolean {
+  return deck.filter((other) => other.id !== card.id).length >= MIN_DISTRACTOR_COUNT;
+}
+
+/**
+ * 対象カードについて、穴埋めが出題可能か(元の発言にtermが単語境界つきで含まれるか)を判定する。
+ * 単純な部分一致(includes)だと、他の単語に埋め込まれた箇所(例: term="gg"に対する"goggles")を
+ * 誤ってマッチさせてしまうため、前後が文字・数字でない箇所への一致のみを対象とする。
+ */
+export function isFillBlankAvailable(card: Card): boolean {
+  return buildWordBoundaryPattern(card.term, "").test(card.sourceMessageText);
+}
+
+/** 対象カードについて、意味当て4択・穴埋めのいずれかが出題可能かを判定する */
+export function isQuizzable(card: Card, deck: Card[]): boolean {
+  return isMeaningChoiceAvailable(card, deck) || isFillBlankAvailable(card);
+}
+
+/**
+ * 意味当て4択を作る。誤答選択肢は `otherCards` からランダムに3件抽出する。
+ * `otherCards` が3件未満の場合は誤答が確保できないためエラーを投げる
+ * (呼び出し元は `isMeaningChoiceAvailable` で事前に確認すること)。
+ */
+export function buildMeaningChoiceQuestion(
+  card: Card,
+  otherCards: Card[],
+  random: () => number = Math.random,
+): MeaningChoiceQuestion {
+  if (otherCards.length < MIN_DISTRACTOR_COUNT) {
+    throw new Error(
+      `意味当て4択には誤答選択肢として他のカードが${MIN_DISTRACTOR_COUNT}件以上必要です(現在: ${otherCards.length}件)`,
+    );
+  }
+
+  const distractors = shuffle(otherCards, random).slice(0, MIN_DISTRACTOR_COUNT);
+  const options = [
+    { text: card.meaning, isCorrect: true },
+    ...distractors.map((distractor) => ({ text: distractor.meaning, isCorrect: false })),
+  ];
+  const shuffledOptions = shuffle(options, random);
+
+  return {
+    format: "meaning-choice",
+    card,
+    choices: shuffledOptions.map((option) => option.text),
+    correctIndex: shuffledOptions.findIndex((option) => option.isCorrect),
+  };
+}
+
+/**
+ * 穴埋め問題を作る。元の発言(sourceMessageText)にtermが含まれない場合はエラーを投げる
+ * (呼び出し元は `isFillBlankAvailable` で事前に確認すること)。
+ */
+export function buildFillBlankQuestion(card: Card): FillBlankQuestion {
+  if (!isFillBlankAvailable(card)) {
+    throw new Error(`元の発言にtermが含まれていません(term: ${card.term}, 発言: ${card.sourceMessageText})`);
+  }
+
+  return {
+    format: "fill-blank",
+    card,
+    maskedText: card.sourceMessageText.replace(buildWordBoundaryPattern(card.term, "g"), BLANK_PLACEHOLDER),
+  };
+}
+
+/**
+ * カードとデッキ(単語帳全体)の状況に応じて、意味当て4択・穴埋めのいずれかを出題する。
+ * 両方出題可能な場合は乱数で形式を選ぶ。どちらも出題できない場合はエラーを投げる。
+ */
+export function buildQuizQuestion(card: Card, deck: Card[], random: () => number = Math.random): QuizQuestion {
+  if (!isQuizzable(card, deck)) {
+    throw new Error(`出題可能な形式がありません(term: ${card.term})`);
+  }
+
+  const canMeaningChoice = isMeaningChoiceAvailable(card, deck);
+  const canFillBlank = isFillBlankAvailable(card);
+
+  const useMeaningChoice = canMeaningChoice && (!canFillBlank || random() < 0.5);
+  if (useMeaningChoice) {
+    const otherCards = deck.filter((other) => other.id !== card.id);
+    return buildMeaningChoiceQuestion(card, otherCards, random);
+  }
+  return buildFillBlankQuestion(card);
+}


### PR DESCRIPTION
## Summary

- SM-2相当の間隔反復アルゴリズムを純関数(`gradeCard`)として実装し、期日が来たカードだけを`/study`で出題する復習クイズを追加
- 出題形式は「意味当て4択」(誤答は単語帳の他カードから抽出)と「穴埋め」(元のチャット原文からtermをマスク、単語境界チェック付き)の2種
- 採点(Again/Hard/Good/Easy)は`reviewCard`がSM-2状態の更新とreviews履歴の記録を1トランザクションで行い、次回の出題間隔に反映する
- クイズの根幹はLLMに依存させず、コードだけで完結する設計(AIが使えない環境でも復習は動作する)

## 実装ファイル

- `src/lib/db/srs.ts`: SM-2純関数(`gradeCard`)
- `src/lib/db/cards.ts`: `selectDueCards`/`listDueCards`(出題対象取得)
- `src/lib/db/reviews.ts`: `reviewCard`(採点記録)/`getReviewStats`(学習統計)
- `src/lib/study/quiz.ts`: 出題ロジック(意味当て4択・穴埋め)
- `src/app/study/page.tsx`: 復習クイズ画面
- `src/components/site-header.tsx`: `/study`へのナビリンク追加

## CodeRabbit代替レビュー対応

CodeRabbitがレートリミットのため`/code-review`(high)で代替実施。指摘のうち以下を修正:

- 採点ボタンの二重送信防止(連打によるSM-2状態の二重更新を防止)
- 非同期処理(初期読み込み・採点)へのエラーハンドリング追加
- 穴埋め問題のマスキングで単語境界を無視していた不具合の修正(例: term="gg"が"goggles"に誤マッチ)
- 意味当て4択のReactキー重複の修正
- 出題可否判定ロジックの重複解消(`isQuizzable`に統一)
- `/study`マウント時の重複DBスキャン・採点ごとの統計再取得を解消

`Review.grade`への実行時バリデーション追加は、既存コードベースが他のDexie読み取りにも同様のバリデーションを行っていないため見送りました。

## Test plan

- [x] `npm test`(219件パス)
- [x] `npm run type-check`
- [x] `npm run lint`(警告ゼロ)
- [x] `npm run build`
- [x] CodeRabbit代替(`/code-review high`)の指摘に対応

Closes #3