### PR TITLE
Phase 6: 仕上げ(データ全削除・README整備・言語ペア切替の回帰テスト)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,149 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# chat-sensei
 
-## Getting Started
+Twitch の実況チャットを教材にする、サーバーを持たないクライアントサイド専用の語学学習ツールです。
 
-First, run the development server:
+視聴中に流れてくる生きた発言(スラング・略語・ネットミーム)をその場でクリックすると、Chrome 内蔵の Gemini Nano(Prompt API)が学ぶ言語と解説言語の設定に応じて構造化された解説を生成します。気になった語句はワンクリックで単語帳に保存でき、SM-2 間隔反復アルゴリズムによる復習クイズで定着させられます。
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+ログイン・バックエンド・外部APIキーは一切不要です。AI推論はブラウザ内で完結し、データはすべてこの端末の IndexedDB / LocalStorage にのみ保存されます。
+
+## 特徴
+
+- **ログイン不要の匿名 Twitch IRC 接続**: `wss://irc-ws.chat.twitch.tv` に直接接続し、色付き表示名・emote 画像付きでチャットをリアルタイム表示します
+- **Gemini Nano によるその場解説**: 発言をクリックすると、訳・直訳・注目語句(スラング/略語/イディオム/emote/文法/単語の種別・意味・使い方メモ)・難易度を JSON Schema で構造化して取得します
+- **手動ピック + 自動抽出の併用**: 気になった発言は手動でカード化できるほか、設定で自動抽出を有効にすると学習価値の高い発言をバックグラウンドで拾い、`/deck` の候補レビューに貯めます
+- **単語帳(`/deck`)**: 保存したカードの検索・削除・JSON エクスポート、自動抽出候補の採用/却下ができます
+- **復習クイズ(`/study`)**: SM-2 相当のアルゴリズムで出題間隔を管理し、「意味当て4択」「穴埋め」の2形式で出題します。LLM に依存しないため、Prompt API が使えない環境でも復習だけは継続できます
+- **言語ペア設定(`/settings`)**: 学ぶ言語(targetLang)と解説言語(explainLang)を en / ja / es / de / fr から選べます。同一言語の組み合わせは保存時にエラーになります
+- **環境診断とデータ管理(`/settings`)**: Chrome バージョン・Prompt API / Language Detector API の可用性・ストレージ空き容量を診断して表示するほか、保存データ(IndexedDB + LocalStorage)を確認ダイアログ付きで一括削除できます
+
+## アーキテクチャ
+
+サーバーコードは一切持ちません。Next.js の App Router を使いますが、全ページをクライアントコンポーネントとして構成し、Route Handler・Server Action は作っていません。
+
+```
+チャンネル指定
+   ↓
+Twitch IRC (WebSocket, 匿名)  ──→ messages (Dexie, リングバッファ)
+   ↓                                  ↓
+ノイズ除去フィルタ(純関数)      ライブ表示(クリックで手動ピック)
+   ↓                                  ↓
+[低優先] 学習価値のboolean判定    [高優先] 解説生成
+   ↓                                  ↓
+        Gemini Nano 直列キュー(同時実行数1)
+                    ↓
+        構造化解説(responseConstraint / JSON Schema)
+                    ↓
+              cards (Dexie) ──→ 復習クイズ(SM-2)
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Prompt API は Web Worker 非対応でメインスレッドでのみ動作するため、`src/lib/ai/session-pool.ts` が単一のベースセッション + 優先度付き直列キュー(手動ピック=高優先度、自動抽出=低優先度)でメインスレッドを保護します。ベースセッションは `session.clone()` で使い捨てブランチを都度作り、システムプロンプトのウォームアップを再利用しつつジョブ間のコンテキスト汚染を防ぎます。
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+### ディレクトリ構成
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```
+src/
+  app/
+    page.tsx              # ライブ画面(チャット + 解説ダイアログ)
+    deck/page.tsx          # 単語帳(一覧・検索・削除・エクスポート・候補レビュー)
+    study/page.tsx         # 復習クイズ
+    settings/page.tsx      # 環境診断・言語設定・自動抽出設定・データ管理
+  components/               # shadcn/ui ベースのUI
+  lib/
+    twitch/
+      irc-parser.ts         # 純関数: IRC行 → 構造化メッセージ
+      irc-client.ts          # WebSocket接続 / PING応答 / 再接続
+      message-filter.ts      # 純関数: ノイズ除去・自動抽出の事前フィルタ
+      emotes.ts               # 純関数: emotesタグ → CDN URL
+    ai/
+      availability.ts         # Prompt API / Language Detector APIの可用性診断
+      session-pool.ts          # 単一セッション + 優先度付き直列キュー
+      prompts.ts                # 言語ペアに応じたプロンプト生成
+      schemas.ts                 # responseConstraint用JSON Schema
+      explain.ts                  # 発言 → 構造化解説
+      triage.ts                    # 発言 → 学習価値のboolean判定
+      auto-extraction.ts            # message-filter → triage → explain のパイプライン
+    db/
+      schema.ts               # Dexieテーブル定義(messages/cards/reviews/candidates)
+      cards.ts / messages.ts / candidates.ts / reviews.ts  # CRUD
+      srs.ts                    # 純関数: SM-2間隔反復アルゴリズム
+      reset.ts                    # データ全削除(IndexedDB)
+    settings.ts               # LocalStorage設定の読み書き(zodバリデーション)
+    study/quiz.ts              # 出題ロジック(4択・穴埋め)
+```
 
-## Learn More
+## 必須要件(実行環境)
 
-To learn more about Next.js, take a look at the following resources:
+Prompt API(Gemini Nano)は Chrome にのみ組み込まれた実験的機能のため、以下を満たす環境が必要です。`/settings` の環境診断カードで自動判定されます。
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+| 項目 | 要件 |
+|---|---|
+| ブラウザ | Google Chrome 148 以降(Web ページ向けに stable 化済み。origin trialトークン不要) |
+| 通信 | HTTPS または `localhost`(secure context)。ただし secure context は前提条件であり、これだけで利用可能になるわけではない |
+| OS | デスクトップのみ(Windows / macOS / Linux、および Chromebook Plus)。Prompt API はモバイルChromeで未対応、通常のChromebookも対象外 |
+| GPU | 4GB超のVRAM |
+| ストレージ | 初回モデルダウンロードに空き 22GB 程度が必要 |
+| ネットワーク | 初回モデルダウンロードは従量制回線では実行されない(unmetered connection) |
+| 対応言語 | 入出力ともに `en` / `ja` / `es` / `de` / `fr` |
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+上記に加えてモデル自体のダウンロード完了とユーザー操作(アクティベーション)が必要なため、`/settings` の環境診断カードは secure context かどうかだけでなく、これらすべてを踏まえた最終的な利用可否を表示します。
 
-## Deploy on Vercel
+**Prompt API が使えない環境でも、チャット閲覧・チャンネル接続・既存カードの復習(`/study`)は動作します。** AI解説・自動抽出のみが無効化され、`/settings` および解説ダイアログに理由が明示されます(クラウドAPIへの切り替えやダミー解説へのフォールバックは行いません)。
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## セットアップ
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```bash
+npm install
+npm run dev
+```
+
+[http://localhost:3000](http://localhost:3000) を Chrome 148 以降で開いてください(`localhost` は secure context として扱われるため Prompt API の利用条件の1つを満たします。ただし対応ハードウェア/OS・空きストレージ・モデルのダウンロード状況・ユーザー操作なども必要です)。初回はモデルダウンロードにユーザー操作を伴うボタン操作が必要です。
+
+## 使い方
+
+1. ホーム画面でTwitchのチャンネル名(例: `zackrawrr`)を入力して「接続する」を押す(ログイン不要の匿名接続)
+2. 気になる発言をクリックすると、`/settings` で設定した言語ペアで解説ダイアログが開く
+3. 解説内の語句にある「カード化」ボタンで単語帳に保存する
+4. `/settings` で自動抽出を有効にすると、放置しているだけでも学習価値の高い発言が候補として貯まる(`/deck` でレビューして採用/却下)
+5. `/study` で期日が来たカードだけが出題され、採点(Again/Hard/Good/Easy)に応じて次回の出題間隔が変わる
+
+## データの保存場所と削除
+
+chat-sensei 自身のサーバーは存在せず、アプリのデータ(受信したチャットの保存・AI解説の生成)はすべてこの端末内で完結します。ただし、指定したTwitchチャンネルへの接続に伴い、チャンネル名とチャット本文はTwitch側のサーバー(`wss://irc-ws.chat.twitch.tv`)へ送信されます(これはTwitch IRCへの接続方式上必須であり、匿名接続のためログインは不要です)。保存先は以下のブラウザ内ストレージのみです。
+
+- **IndexedDB(Dexie)**: 受信したチャット(`messages`)・単語帳カード(`cards`)・復習履歴(`reviews`)・自動抽出候補(`candidates`)
+- **LocalStorage**: 言語ペア・自動抽出のON/OFFと強度などの設定
+
+`/settings` の「データ管理」カードから、確認ダイアログを経て上記すべてを一括削除できます。
+
+## 開発コマンド
+
+```bash
+npm run dev         # 開発サーバー起動
+npm run build        # 本番ビルド
+npm run lint          # ESLint(警告ゼロを維持)
+npm run type-check     # tsc --noEmit
+npm test                # Vitest(単体テスト一括実行)
+npm run test:watch       # Vitest(ウォッチモード)
+```
+
+テストは Vitest + React Testing Library + `fake-indexeddb` で構成し、`window.LanguageModel` / `WebSocket` / IndexedDB / 時刻などの外部依存はすべてモックしています。純関数(IRCパーサ・メッセージフィルタ・SM-2・プロンプト生成)を中心に TDD(RED→GREEN→REFACTOR)で実装しています。
+
+## デプロイ
+
+Vercel での静的配信のみを前提としています(サーバーサイド処理を持たないため、Vercel はビルド成果物の配信のみを担当します)。
+
+```bash
+vercel deploy          # プレビューデプロイ
+vercel deploy --prod    # 本番デプロイ
+```
+
+Prompt API は secure context を要求するため、HTTPS で配信される Vercel のプレビュー/本番URLでは問題なく動作します。
+
+## 使用技術
+
+- [Next.js](https://nextjs.org/)(App Router / 全ページクライアントコンポーネント)
+- [Chrome Prompt API](https://developer.chrome.com/docs/ai/prompt-api)(Gemini Nano、構造化出力に `responseConstraint` を使用)
+- [Dexie](https://dexie.org/)(IndexedDBラッパー)
+- [Tailwind CSS](https://tailwindcss.com/) / [shadcn/ui](https://ui.shadcn.com/)
+- [Zod](https://zod.dev/)(LocalStorage設定・AI応答のスキーマ検証)
+- [Vitest](https://vitest.dev/) / [React Testing Library](https://testing-library.com/react) / [fake-indexeddb](https://github.com/dumbmatter/fakeIndexedDB)

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -37,7 +37,12 @@ vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
 
 vi.mock("@/lib/ai/explain", async () => {
   const actual = await vi.importActual<typeof import("@/lib/ai/explain")>("@/lib/ai/explain");
-  return { ...actual, explainChatMessage: vi.fn() };
+  return {
+    ...actual,
+    explainChatMessage: vi.fn(),
+    // 言語ペアがセッションプール生成に正しく渡っているかを検証するため、実装は維持しつつ呼び出しを監視する
+    createExplainBaseSessionFactory: vi.fn(actual.createExplainBaseSessionFactory),
+  };
 });
 
 vi.mock("@/lib/ai/auto-extraction", () => ({
@@ -45,7 +50,7 @@ vi.mock("@/lib/ai/auto-extraction", () => ({
 }));
 
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
-import { explainChatMessage } from "@/lib/ai/explain";
+import { explainChatMessage, createExplainBaseSessionFactory } from "@/lib/ai/explain";
 import { createAutoExtractionPipeline } from "@/lib/ai/auto-extraction";
 import { saveSettings } from "@/lib/settings";
 
@@ -89,6 +94,7 @@ afterEach(async () => {
   capturedCallbacks = null;
   vi.mocked(runBrowserDiagnosis).mockReset();
   vi.mocked(explainChatMessage).mockReset();
+  vi.mocked(createExplainBaseSessionFactory).mockClear();
   vi.mocked(createAutoExtractionPipeline).mockReset();
   window.localStorage.clear();
   await db.cards.clear();
@@ -427,5 +433,50 @@ describe("Home の自動抽出(バックグラウンド)", () => {
     await user.click(await screen.findByRole("button", { name: "切断する" }));
 
     expect(capturedSignal?.aborted).toBe(true);
+  });
+});
+
+describe("Home の言語ペア切替(通し確認)", () => {
+  // Home のセッションプールは画面ごとに1度だけ生成され(sessionPoolRef)、
+  // /settings で言語ペアを変更した後は画面遷移(アンマウント→再マウント)を経て
+  // 反映される。ここではその「アンマウント→設定変更→再マウント」の流れを再現し、
+  // 新しいセッションプールが常に最新の言語ペアで作り直されることを検証する。
+  it("言語ペアを変更してから画面を再マウントすると、新しい設定でベースセッションが作り直される", async () => {
+    saveSettings({
+      targetLang: "en",
+      explainLang: "ja",
+      autoExtraction: { enabled: false, strictness: "normal" },
+    });
+    vi.mocked(explainChatMessage).mockResolvedValue(sampleExplanation);
+
+    const user1 = userEvent.setup();
+    const { unmount } = render(<Home />);
+    await connectAndReceiveMessage(user1, "gg chat");
+    await user1.click(screen.getByRole("button", { name: /gg chat/ }));
+    await waitFor(() => {
+      expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
+    });
+
+    expect(createExplainBaseSessionFactory).toHaveBeenCalledTimes(1);
+    expect(createExplainBaseSessionFactory).toHaveBeenNthCalledWith(1, "en", "ja");
+
+    // /settings で言語ペアを変更し、/ に戻ってきた状況を再現する(コンポーネントの破棄・再生成)
+    unmount();
+    saveSettings({
+      targetLang: "es",
+      explainLang: "de",
+      autoExtraction: { enabled: false, strictness: "normal" },
+    });
+
+    const user2 = userEvent.setup();
+    render(<Home />);
+    await connectAndReceiveMessage(user2, "otra vez chat");
+    await user2.click(screen.getByRole("button", { name: /otra vez chat/ }));
+    await waitFor(() => {
+      expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
+    });
+
+    expect(createExplainBaseSessionFactory).toHaveBeenCalledTimes(2);
+    expect(createExplainBaseSessionFactory).toHaveBeenNthCalledWith(2, "es", "de");
   });
 });

--- a/src/app/settings/page.test.tsx
+++ b/src/app/settings/page.test.tsx
@@ -6,7 +6,7 @@
  * ここではそのモジュールをモックしてページの表示ロジックのみを確認する。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import SettingsPage from "./page";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
@@ -16,7 +16,12 @@ vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
   runBrowserDiagnosis: vi.fn(),
 }));
 
+vi.mock("@/lib/db/reset", () => ({
+  clearAllIndexedDbData: vi.fn(),
+}));
+
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
+import { clearAllIndexedDbData } from "@/lib/db/reset";
 
 /** 全項目が利用可能な基準診断結果(お使いの Chrome 150 相当を想定) */
 const readyDiagnosis: EnvironmentDiagnosis = {
@@ -30,6 +35,7 @@ const readyDiagnosis: EnvironmentDiagnosis = {
 
 afterEach(() => {
   vi.mocked(runBrowserDiagnosis).mockReset();
+  vi.mocked(clearAllIndexedDbData).mockReset();
   window.localStorage.clear();
 });
 
@@ -196,6 +202,81 @@ describe("SettingsPage", () => {
         explainLang: "ja",
         autoExtraction: { enabled: true, strictness: "strict" },
       });
+    });
+  });
+
+  describe("データ管理", () => {
+    it("「データを全て削除する」ボタンを押しても、確認ダイアログが出るまでは削除処理を呼ばない", async () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+      const user = userEvent.setup();
+
+      render(<SettingsPage />);
+      await user.click(screen.getByRole("button", { name: "データを全て削除する" }));
+
+      expect(screen.getByText(/この操作は取り消せません/)).toBeInTheDocument();
+      expect(clearAllIndexedDbData).not.toHaveBeenCalled();
+    });
+
+    it("確認ダイアログでキャンセルすると、削除処理を呼ばずダイアログが閉じる", async () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+      const user = userEvent.setup();
+
+      render(<SettingsPage />);
+      await user.click(screen.getByRole("button", { name: "データを全て削除する" }));
+      await user.click(screen.getByRole("button", { name: "キャンセル" }));
+
+      expect(screen.queryByText(/この操作は取り消せません/)).not.toBeInTheDocument();
+      expect(clearAllIndexedDbData).not.toHaveBeenCalled();
+    });
+
+    it("確認ダイアログで削除を確定すると、IndexedDBとLocalStorageの両方が削除され、設定がデフォルトに戻る", async () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+      vi.mocked(clearAllIndexedDbData).mockResolvedValue(undefined);
+      window.localStorage.setItem(
+        SETTINGS_STORAGE_KEY,
+        JSON.stringify({ targetLang: "es", explainLang: "de", autoExtraction: { enabled: true, strictness: "strict" } }),
+      );
+      const user = userEvent.setup();
+
+      render(<SettingsPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText("学ぶ言語")).toHaveValue("es");
+      });
+
+      await user.click(screen.getByRole("button", { name: "データを全て削除する" }));
+      await user.click(screen.getByRole("button", { name: "削除する" }));
+
+      await waitFor(() => {
+        expect(clearAllIndexedDbData).toHaveBeenCalledTimes(1);
+      });
+      expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
+      expect(screen.getByText("データを全て削除しました")).toBeInTheDocument();
+      expect(screen.getByLabelText("学ぶ言語")).toHaveValue("en");
+      expect(screen.getByLabelText("解説言語")).toHaveValue("ja");
+    });
+
+    it("削除処理が失敗した場合はエラーメッセージを表示し、設定は保持する", async () => {
+      vi.mocked(runBrowserDiagnosis).mockResolvedValue(readyDiagnosis);
+      vi.mocked(clearAllIndexedDbData).mockRejectedValue(new Error("IndexedDBの削除に失敗しました"));
+      window.localStorage.setItem(
+        SETTINGS_STORAGE_KEY,
+        JSON.stringify({ targetLang: "es", explainLang: "de", autoExtraction: { enabled: false, strictness: "normal" } }),
+      );
+      const user = userEvent.setup();
+
+      render(<SettingsPage />);
+      await waitFor(() => {
+        expect(screen.getByLabelText("学ぶ言語")).toHaveValue("es");
+      });
+
+      await user.click(screen.getByRole("button", { name: "データを全て削除する" }));
+      await user.click(screen.getByRole("button", { name: "削除する" }));
+
+      await waitFor(() => {
+        expect(within(screen.getByRole("dialog")).getByText("IndexedDBの削除に失敗しました")).toBeInTheDocument();
+      });
+      expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).not.toBeNull();
+      expect(screen.getByLabelText("学ぶ言語")).toHaveValue("es");
     });
   });
 });

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -11,20 +11,31 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { AlertTriangle, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { AlertTriangle, CheckCircle2, Loader2, Trash2, XCircle } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
 import { describeDiagnosis, type DiagnosisMessage } from "@/lib/ai/describeDiagnosis";
 import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "@/lib/ai/prompts";
 import { AUTO_EXTRACTION_STRICTNESS_LEVELS, type AutoExtractionStrictness } from "@/lib/twitch/message-filter";
+import { clearAllIndexedDbData } from "@/lib/db/reset";
 import {
   AUTO_EXTRACTION_STRICTNESS_DISPLAY_NAMES,
   DEFAULT_SETTINGS,
   LANGUAGE_DISPLAY_NAMES,
+  clearSettings,
   loadSettings,
   saveSettings,
   settingsSchema,
@@ -112,6 +123,36 @@ export default function SettingsPage() {
     setSaveError(null);
     setSavedNotice(true);
   }, [settingsForm]);
+
+  // --- データ管理(IndexedDB + LocalStorageの全削除) ---
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [deletedNotice, setDeletedNotice] = useState(false);
+
+  // IndexedDB(messages/cards/reviews/candidates)とLocalStorageの設定を両方削除する。
+  // 「一方だけ消える」中途半端な状態はFail-Fast方針に反するため、IndexedDBの削除に
+  // 失敗した場合はLocalStorage側には触れず、理由を明示してエラー表示する。
+  const handleConfirmDeleteAllData = useCallback(() => {
+    setIsDeleting(true);
+    setDeleteError(null);
+    clearAllIndexedDbData()
+      .then(() => {
+        clearSettings();
+        setSettingsForm(DEFAULT_SETTINGS);
+        setWasCorrupted(false);
+        setSaveError(null);
+        setSavedNotice(false);
+        setIsDeleteDialogOpen(false);
+        setDeletedNotice(true);
+      })
+      .catch((error: unknown) => {
+        setDeleteError(error instanceof Error ? error.message : String(error));
+      })
+      .finally(() => {
+        setIsDeleting(false);
+      });
+  }, []);
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 p-6">
@@ -275,6 +316,65 @@ export default function SettingsPage() {
           </Button>
         </CardContent>
       </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>データ管理</CardTitle>
+          <CardDescription>
+            chat-sensei が保存したデータ(受信したチャット・単語帳・復習履歴・言語設定など)を、
+            この端末のIndexedDBとLocalStorageから完全に削除します。サーバーにはデータを送信していないため、
+            削除すると復元はできません。
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-4">
+          {deletedNotice && !deleteError && (
+            <Alert className="border-emerald-500/50 text-emerald-700 dark:text-emerald-400">
+              <CheckCircle2 aria-hidden="true" />
+              <AlertDescription>データを全て削除しました</AlertDescription>
+            </Alert>
+          )}
+
+          <Button
+            onClick={() => {
+              setDeletedNotice(false);
+              setIsDeleteDialogOpen(true);
+            }}
+            variant="destructive"
+            className="self-start"
+          >
+            <Trash2 aria-hidden="true" />
+            データを全て削除する
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>データを全て削除しますか?</DialogTitle>
+            <DialogDescription>
+              受信したチャット・単語帳のカード・復習履歴・言語設定がこの端末から完全に削除されます。
+              この操作は取り消せません。
+            </DialogDescription>
+          </DialogHeader>
+
+          {/* 削除ダイアログを開いたままエラーを表示する(カード側のAlertはダイアログの背後に隠れて見えないため) */}
+          {deleteError && (
+            <Alert variant="destructive">
+              <XCircle aria-hidden="true" />
+              <AlertDescription>{deleteError}</AlertDescription>
+            </Alert>
+          )}
+
+          <DialogFooter>
+            <DialogClose render={<Button variant="outline" disabled={isDeleting} />}>キャンセル</DialogClose>
+            <Button onClick={handleConfirmDeleteAllData} variant="destructive" disabled={isDeleting}>
+              {isDeleting && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
+              削除する
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/lib/db/reset.test.ts
+++ b/src/lib/db/reset.test.ts
@@ -1,0 +1,66 @@
+/**
+ * src/lib/db/reset.ts のテスト。
+ *
+ * 設定画面(/settings)の「データを全て削除する」機能から呼び出される、
+ * IndexedDB(Dexie)の全テーブルを削除する処理を検証する。
+ * fake-indexeddb(vitest.setup.ts で `fake-indexeddb/auto` を導入済み)を使い、
+ * 実際のDexie APIに対して検証する。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import { db } from "./schema";
+import { clearAllIndexedDbData } from "./reset";
+
+afterEach(async () => {
+  await Promise.all([db.messages.clear(), db.cards.clear(), db.reviews.clear(), db.candidates.clear()]);
+});
+
+describe("clearAllIndexedDbData", () => {
+  it("messages・cards・reviews・candidatesの全レコードを削除する", async () => {
+    await db.messages.add({
+      channel: "zackrawrr",
+      userId: "987654",
+      displayName: "CodeChamp92",
+      color: "#1E90FF",
+      text: "gg chat",
+      emotes: [],
+      timestampMs: 1690000000000,
+      detectedLang: "en",
+      confidence: 0.9,
+    });
+    const cardId = await db.cards.add({
+      term: "GG",
+      kind: "abbreviation",
+      meaning: "Good Game(お疲れさま、いい試合でした)の略語",
+      note: "対戦系ゲームの配信終了時によく使われる",
+      sourceMessageText: "GG everyone, that was such a clutch play!",
+      sourceChannel: "zackrawrr",
+      sourceAuthor: "yamada_taro",
+      targetLang: "en",
+      explainLang: "ja",
+      tags: [],
+      createdAt: 1690000000000,
+      srs: { due: 1690000000000, interval: 0, easeFactor: 2.5, repetitions: 0, lapses: 0, lastReviewedAt: null },
+    });
+    await db.reviews.add({ cardId, grade: "good", reviewedAt: 1690000000000 });
+    await db.candidates.add({
+      term: "clutch",
+      kind: "slang",
+      meaning: "土壇場での好プレイ",
+      note: "劣勢からの逆転プレイに使われる",
+      sourceMessageText: "that was such a clutch play honestly",
+      sourceChannel: "zackrawrr",
+      sourceAuthor: "yamada_taro",
+      targetLang: "en",
+      explainLang: "ja",
+      tags: [],
+      createdAt: 1690000000000,
+    });
+
+    await clearAllIndexedDbData();
+
+    expect(await db.messages.count()).toBe(0);
+    expect(await db.cards.count()).toBe(0);
+    expect(await db.reviews.count()).toBe(0);
+    expect(await db.candidates.count()).toBe(0);
+  });
+});

--- a/src/lib/db/reset.ts
+++ b/src/lib/db/reset.ts
@@ -1,0 +1,16 @@
+/**
+ * IndexedDB(Dexie)に保存された全データを削除するモジュール。
+ *
+ * 設定画面(/settings)の「データを全て削除する」機能から呼ばれる。
+ * `messages` / `cards` / `reviews` / `candidates` の全テーブルを、
+ * 「一部だけ消えて一部残る」中途半端な状態を避けるため、
+ * ひとつのDexieトランザクションとして不可分に削除する。
+ */
+import { db } from "./schema";
+
+/** IndexedDBの全テーブル(messages・cards・reviews・candidates)を空にする */
+export async function clearAllIndexedDbData(): Promise<void> {
+  await db.transaction("rw", db.messages, db.cards, db.reviews, db.candidates, async () => {
+    await Promise.all([db.messages.clear(), db.cards.clear(), db.reviews.clear(), db.candidates.clear()]);
+  });
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -7,7 +7,7 @@
  * (CLAUDE.md の Fail-Fast 方針: 暗黙のフォールバックにせず、呼び出し元に理由を返す)。
  */
 import { afterEach, describe, expect, it } from "vitest";
-import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY, loadSettings, saveSettings } from "./settings";
+import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY, clearSettings, loadSettings, saveSettings } from "./settings";
 
 afterEach(() => {
   window.localStorage.clear();
@@ -67,6 +67,21 @@ describe("loadSettings", () => {
     const result = loadSettings();
 
     expect(result).toEqual({ settings: DEFAULT_SETTINGS, wasCorrupted: true });
+  });
+});
+
+describe("clearSettings", () => {
+  it("保存されていた設定をLocalStorageから削除し、以後はデフォルト設定が読み込まれる", () => {
+    saveSettings({
+      targetLang: "es",
+      explainLang: "ja",
+      autoExtraction: { enabled: true, strictness: "strict" },
+    });
+
+    clearSettings();
+
+    expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
+    expect(loadSettings()).toEqual({ settings: DEFAULT_SETTINGS, wasCorrupted: false });
   });
 });
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -99,3 +99,9 @@ export function saveSettings(settings: Settings): void {
   const validated = settingsSchema.parse(settings);
   window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(validated));
 }
+
+/** 保存されている設定を LocalStorage から削除する。以後 `loadSettings` はデフォルト設定を返す */
+export function clearSettings(): void {
+  ensureBrowserEnvironment();
+  window.localStorage.removeItem(SETTINGS_STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary

Phase 6(仕上げ)のうちコード変更が必要な項目に対応した。

- 言語ペア(targetLang/explainLang)を切り替えた際、画面遷移(アンマウント→再マウント)を経て `session-pool.ts` のベースセッションが最新設定で作り直されることを回帰テストで固定した(`src/app/page.test.tsx`)
- Prompt API非対応環境での表示・機能無効化(`availability.ts` / `describeDiagnosis.ts` / Home / SettingsPage)を既存テストで再確認した(コード変更なし)
- 設定画面(`/settings`)に、確認ダイアログ付きの「データを全て削除する」機能を追加した。IndexedDB(messages/cards/reviews/candidates、`src/lib/db/reset.ts`)とLocalStorage(`src/lib/settings.ts` の `clearSettings`)を削除する
- create-next-appのデフォルトのままだった README.md を、chat-senseiの概要・アーキテクチャ・必須要件・使い方・データの保存場所とプライバシー・デプロイ手順に合わせて全面的に書き直した

CodeRabbitレビューを実施し、指摘事項(README内のプライバシー記述の不正確さ・環境要件の不足・削除失敗時のエラー表示位置・テストのスコープ)をすべて反映済み。

## Test plan

- [x] `npm run lint`(警告ゼロ)
- [x] `npm run type-check`
- [x] `npm test`(226件全てパス)
- [x] `npm run build`
- [ ] `vercel deploy` によるプレビューデプロイ・HTTPS環境での主要導線確認・本番昇格(このPRのマージ後に別途実施)

Refs #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)