### PR TITLE
fix: ページ遷移でチャット接続が切れる不具合を修正

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -53,6 +53,7 @@ import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
 import { explainChatMessage, createExplainBaseSessionFactory } from "@/lib/ai/explain";
 import { createAutoExtractionPipeline } from "@/lib/ai/auto-extraction";
 import { saveSettings } from "@/lib/settings";
+import { resetChatConnectionStoreForTests } from "@/store/chat-connection";
 
 /** 全項目利用可能な基準診断結果 */
 const readyDiagnosis: EnvironmentDiagnosis = {
@@ -86,6 +87,9 @@ beforeEach(async () => {
   vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage: vi.fn().mockResolvedValue(undefined) });
   // 前のテストの失敗等でカードが残っていても、各テストが空の状態から始まるようにする
   await db.cards.clear();
+  // チャット接続ストアはページ遷移をまたいで状態を保持するモジュールスコープの
+  // シングルトンであり、テスト間でも共有されてしまうため、毎回未接続状態に戻す
+  resetChatConnectionStoreForTests();
 });
 
 afterEach(async () => {
@@ -437,11 +441,14 @@ describe("Home の自動抽出(バックグラウンド)", () => {
 });
 
 describe("Home の言語ペア切替(通し確認)", () => {
-  // Home のセッションプールは画面ごとに1度だけ生成され(sessionPoolRef)、
-  // /settings で言語ペアを変更した後は画面遷移(アンマウント→再マウント)を経て
-  // 反映される。ここではその「アンマウント→設定変更→再マウント」の流れを再現し、
-  // 新しいセッションプールが常に最新の言語ペアで作り直されることを検証する。
-  it("言語ペアを変更してから画面を再マウントすると、新しい設定でベースセッションが作り直される", async () => {
+  // チャット接続(TwitchIrcClient)・接続状態・発言一覧は store/chat-connection.ts
+  // でページ遷移をまたいで維持される一方、AI解説用のセッションプールは Home
+  // コンポーネントのローカルなref(sessionPoolRef)で画面ごとに1度だけ生成される。
+  // /settings で言語ペアを変更して / に戻ってきた場合、チャット接続自体は
+  // 再接続せずに維持されたまま、新しいセッションプールが最新の言語ペアで
+  // 作り直されることを検証する(「アンマウント→設定変更→再マウント」で
+  // 画面遷移を再現する)。
+  it("言語ペアを変更して画面を行き来しても、チャット接続は維持されたまま新しい設定でベースセッションが作り直される", async () => {
     saveSettings({
       targetLang: "en",
       explainLang: "ja",
@@ -470,7 +477,31 @@ describe("Home の言語ペア切替(通し確認)", () => {
 
     const user2 = userEvent.setup();
     render(<Home />);
-    await connectAndReceiveMessage(user2, "otra vez chat");
+
+    // 再接続操作をしていないにもかかわらず、接続済みの状態と直前までの発言が維持されている
+    // (= ページ遷移でチャット接続が切れないことの検証)
+    expect(await screen.findByText("接続済み")).toBeInTheDocument();
+    expect(screen.getByText("gg chat")).toBeInTheDocument();
+
+    capturedCallbacks?.onEvent({
+      type: "privmsg",
+      channel: "somechannel",
+      message: {
+        id: "msg-otra",
+        channel: "somechannel",
+        userId: "333333",
+        username: "viajeroanon",
+        displayName: "viajeroanon",
+        color: null,
+        text: "otra vez chat",
+        isAction: false,
+        emotes: [],
+        badges: [],
+        timestampMs: 1690000000002,
+      },
+    });
+    await screen.findByText("otra vez chat");
+
     await user2.click(screen.getByRole("button", { name: /otra vez chat/ }));
     await waitFor(() => {
       expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
@@ -478,5 +509,105 @@ describe("Home の言語ペア切替(通し確認)", () => {
 
     expect(createExplainBaseSessionFactory).toHaveBeenCalledTimes(2);
     expect(createExplainBaseSessionFactory).toHaveBeenNthCalledWith(2, "es", "de");
+  });
+});
+
+describe("Home のページ遷移(チャット接続の永続化)", () => {
+  // 本来の不具合: チャットに接続した後、単語帳(/deck)・復習(/study)・設定(/settings)
+  // ページに遷移すると、Home がアンマウントされることでチャット接続そのものが
+  // 切れてしまっていた。store/chat-connection.ts に接続状態・発言一覧を移したことで、
+  // Home がアンマウント・再マウントされても接続と発言が保持されることを検証する。
+  it("接続後にページ遷移(アンマウント)しても、再度チャンネル名を入力せずに接続状態と発言一覧が保持される", async () => {
+    const user = userEvent.setup();
+    const { unmount } = render(<Home />);
+    await connectAndReceiveMessage(user, "nice play chat");
+    expect(screen.getByText("接続済み")).toBeInTheDocument();
+
+    // /deck・/study・/settings への遷移を、Home のアンマウントとして再現する
+    unmount();
+    render(<Home />);
+
+    expect(screen.getByText("接続済み")).toBeInTheDocument();
+    expect(screen.getByText("nice play chat")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "切断する" })).toBeInTheDocument();
+  });
+
+  // 自動抽出(自動抽出パイプラインへの投入)は Home コンポーネントの購読(subscribeToChatMessages)に
+  // 依存しており、チャット接続そのものとは独立している。画面遷移中(Home アンマウント中)は
+  // 購読が解除されるため発言は自動抽出されず、再マウント後に届いた発言だけが自動抽出されることを検証する。
+  it("画面遷移中(アンマウント中)に届いた発言は自動抽出されず、再マウント後に届いた発言のみ自動抽出される", async () => {
+    saveSettings({
+      targetLang: "en",
+      explainLang: "ja",
+      autoExtraction: { enabled: true, strictness: "normal" },
+    });
+    const processMessage = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage });
+    const user = userEvent.setup();
+
+    const { unmount } = render(<Home />);
+    await connectAndReceiveMessage(user, "first message before leaving");
+    await waitFor(() => {
+      expect(processMessage).toHaveBeenCalledTimes(1);
+    });
+
+    // /deck 等への遷移を、Home のアンマウントとして再現する。
+    // 接続(store側)は維持されたまま、Home 側の自動抽出の購読だけが解除される。
+    unmount();
+    capturedCallbacks?.onEvent({
+      type: "privmsg",
+      channel: "somechannel",
+      message: {
+        id: "msg-while-away",
+        channel: "somechannel",
+        userId: "444444",
+        username: "awaymessage",
+        displayName: "awaymessage",
+        color: null,
+        text: "message while away",
+        isAction: false,
+        emotes: [],
+        badges: [],
+        timestampMs: 1690000000003,
+      },
+    });
+
+    render(<Home />);
+    // 再マウント直後は、環境診断(runBrowserDiagnosis)の非同期解決を待つ必要がある
+    // (診断結果はrefへの反映も含めて非同期に完了するため、ここで一度イベントループを譲る)
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // 遷移前の発言・アンマウント中に届いた発言のいずれも画面には残っている(接続自体は維持されている)
+    await screen.findByText("message while away");
+    expect(screen.getByText("first message before leaving")).toBeInTheDocument();
+    // しかしアンマウント中に届いた発言は自動抽出されない(呼び出し回数は1のまま)
+    expect(processMessage).toHaveBeenCalledTimes(1);
+
+    // 再マウント後に届いた発言は、通常どおり自動抽出される
+    capturedCallbacks?.onEvent({
+      type: "privmsg",
+      channel: "somechannel",
+      message: {
+        id: "msg-after-return",
+        channel: "somechannel",
+        userId: "555555",
+        username: "returnmessage",
+        displayName: "returnmessage",
+        color: null,
+        text: "message after return",
+        isAction: false,
+        emotes: [],
+        badges: [],
+        timestampMs: 1690000000004,
+      },
+    });
+
+    await waitFor(() => {
+      expect(processMessage).toHaveBeenCalledTimes(2);
+    });
+    expect(processMessage).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ text: "message after return" }),
+      expect.anything(),
+    );
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import { createTwitchIrcClient, type ConnectionState, type TwitchIrcClient } from "@/lib/twitch/irc-client";
+import type { ConnectionState } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { buildEmoteImageUrl, splitMessageIntoSegments } from "@/lib/twitch/emotes";
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
@@ -33,9 +33,7 @@ import { createAutoExtractionPipeline, type AutoExtractionPipeline } from "@/lib
 import type { ExplanationItem, ExplanationResult } from "@/lib/ai/schemas";
 import { loadSettings } from "@/lib/settings";
 import { createCard } from "@/lib/db/cards";
-
-/** チャットに表示する発言の最大保持件数(古いものから捨てるリングバッファ) */
-const MAX_DISPLAYED_MESSAGES = 300;
+import { subscribeToChatMessages, useChatConnectionStore } from "@/store/chat-connection";
 
 const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
   idle: "待機中",
@@ -60,13 +58,17 @@ type ExplanationDialogState =
 
 export default function Home() {
   const [channelInput, setChannelInput] = useState("");
-  const [connectionState, setConnectionState] = useState<ConnectionState>("idle");
-  const [messages, setMessages] = useState<TwitchChatMessage[]>([]);
-  const clientRef = useRef<TwitchIrcClient | null>(null);
+  // 接続状態・受信済み発言はページ遷移(コンポーネントのアンマウント)をまたいで
+  // 保持する必要があるため、コンポーネントローカルではなくモジュールスコープの
+  // ストア(chat-connection.ts)で管理する。詳細はストアのコメントを参照。
+  const connectionState = useChatConnectionStore((state) => state.connectionState);
+  const messages = useChatConnectionStore((state) => state.messages);
+  const connect = useChatConnectionStore((state) => state.connect);
+  const disconnect = useChatConnectionStore((state) => state.disconnect);
 
   // --- AI解説(手動ピック)・自動抽出(バックグラウンド)で共有する参照 ---
   const [aiDiagnosis, setAiDiagnosis] = useState<EnvironmentDiagnosis | null>(null);
-  // getClient()のonEventはマウント時の1回しか再生成されないクロージャのため、
+  // 下記のsubscribeToChatMessagesのリスナーはマウント時に1度だけ生成されるクロージャのため、
   // 最新のaiDiagnosisをrefにも同期しておき、自動抽出の実行可否をそこから判定する。
   const aiDiagnosisRef = useRef<EnvironmentDiagnosis | null>(null);
   const sessionPoolRef = useRef<SessionPool | null>(null);
@@ -103,56 +105,42 @@ export default function Home() {
     return autoExtractionPipelineRef.current;
   }, [getSessionPool]);
 
-  // クライアントは初回レンダリング時に一度だけ生成する。
-  // setState群はReactが安定した参照を保証するため、コールバック内で使っても古いクロージャの問題は起きない。
-  // (refに保持したgetAutoExtractionPipeline/aiDiagnosisRefも、呼び出し時点で最新の値を参照する)
-  const getClient = useCallback((): TwitchIrcClient => {
-    if (!clientRef.current) {
-      clientRef.current = createTwitchIrcClient({
-        onStateChange: (state) => setConnectionState(state),
-        onEvent: (event) => {
-          if (event.type !== "privmsg") return;
-          setMessages((prev) => {
-            const next = [...prev, event.message];
-            return next.length > MAX_DISPLAYED_MESSAGES
-              ? next.slice(next.length - MAX_DISPLAYED_MESSAGES)
-              : next;
+  // 受信した発言(privmsg)を購読し、自動抽出パイプラインに投入する。
+  // 接続そのものはストア側で維持されるため、ここでは「表示中の画面がHomeである間だけ」
+  // 自動抽出を行う(refに保持したaiDiagnosisRef/設定は、呼び出し時点で最新の値を参照する)。
+  useEffect(() => {
+    const unsubscribe = subscribeToChatMessages((message) => {
+      const { settings } = loadSettings();
+      if (settings.autoExtraction.enabled && aiDiagnosisRef.current?.overallReady) {
+        getAutoExtractionPipeline()
+          .processMessage(message, {
+            strictness: settings.autoExtraction.strictness,
+            targetLang: settings.targetLang,
+            explainLang: settings.explainLang,
+            signal: autoExtractionAbortControllerRef.current?.signal,
+          })
+          .catch(() => {
+            // 自動抽出はベストエフォートのバックグラウンド処理のため、
+            // 個別発言の失敗(Prompt APIエラー・中断)はUIに通知せず読み捨てる
           });
-
-          const { settings } = loadSettings();
-          if (settings.autoExtraction.enabled && aiDiagnosisRef.current?.overallReady) {
-            getAutoExtractionPipeline()
-              .processMessage(event.message, {
-                strictness: settings.autoExtraction.strictness,
-                targetLang: settings.targetLang,
-                explainLang: settings.explainLang,
-                signal: autoExtractionAbortControllerRef.current?.signal,
-              })
-              .catch(() => {
-                // 自動抽出はベストエフォートのバックグラウンド処理のため、
-                // 個別発言の失敗(Prompt APIエラー・中断)はUIに通知せず読み捨てる
-              });
-          }
-        },
-      });
-    }
-    return clientRef.current;
+      }
+    });
+    return unsubscribe;
   }, [getAutoExtractionPipeline]);
 
   const handleConnect = useCallback(() => {
     const channel = channelInput.trim();
     if (!channel) return;
-    setMessages([]);
     // チャンネルを切り替えるので、前のチャンネルに紐づく自動抽出ジョブを中断する
     autoExtractionAbortControllerRef.current?.abort();
     autoExtractionAbortControllerRef.current = new AbortController();
-    getClient().connect(channel);
-  }, [channelInput, getClient]);
+    connect(channel);
+  }, [channelInput, connect]);
 
   const handleDisconnect = useCallback(() => {
     autoExtractionAbortControllerRef.current?.abort();
-    getClient().disconnect();
-  }, [getClient]);
+    disconnect();
+  }, [disconnect]);
 
   const connected = isConnectingOrConnected(connectionState);
 

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -1,0 +1,154 @@
+/**
+ * src/store/chat-connection.ts(チャット接続の永続ストア)のテスト。
+ *
+ * ページ遷移(/deck・/study・/settingsへの移動)は Home コンポーネントの
+ * アンマウントを引き起こすため、接続状態・受信済み発言をコンポーネントの
+ * ローカル state / ref に持たせると、そのたびに Twitch IRC への WebSocket
+ * 接続そのものが失われてしまう(コンポーネントのアンマウントで唯一の参照が
+ * 消え、GC対象になるため)。
+ *
+ * このストアはモジュールスコープの Zustand ストアとして接続状態・発言一覧を
+ * 保持することで、どのページが表示されていても接続が維持されることを保証する。
+ * ここでは実際の WebSocket 通信を行わず、`createTwitchIrcClient` をモックして
+ * ストア単体の振る舞いを検証する。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { TwitchIrcClientCallbacks } from "@/lib/twitch/irc-client";
+import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+
+const mockConnect = vi.fn();
+const mockDisconnect = vi.fn();
+let capturedCallbacks: TwitchIrcClientCallbacks | null = null;
+
+vi.mock("@/lib/twitch/irc-client", () => ({
+  createTwitchIrcClient: vi.fn((callbacks: TwitchIrcClientCallbacks) => {
+    capturedCallbacks = callbacks;
+    return {
+      connect: mockConnect,
+      disconnect: mockDisconnect,
+      getState: () => "idle",
+    };
+  }),
+}));
+
+import { resetChatConnectionStoreForTests, subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
+
+/** テスト用のサンプル発言(実況チャットにありそうな「ナイスプレー」の一言) */
+function createSampleMessage(overrides: Partial<TwitchChatMessage> = {}): TwitchChatMessage {
+  return {
+    id: "msg-1",
+    channel: "somechannel",
+    userId: "987654",
+    username: "codechamp92",
+    displayName: "CodeChamp92",
+    color: "#1E90FF",
+    text: "nice play chat",
+    isAction: false,
+    emotes: [],
+    badges: [],
+    timestampMs: 1690000000000,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  // モジュールスコープのストアはテスト間で共有されるため、各テストの前に初期状態へ戻す
+  resetChatConnectionStoreForTests();
+});
+
+afterEach(() => {
+  mockConnect.mockClear();
+  mockDisconnect.mockClear();
+});
+
+describe("useChatConnectionStore", () => {
+  it("connect()を呼ぶと、TwitchIrcClientのconnect()にチャンネル名がそのまま渡される", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(mockConnect).toHaveBeenCalledWith("ZackRawrr");
+  });
+
+  it("connect()を呼ぶと、直前までの発言一覧がクリアされる", () => {
+    useChatConnectionStore.setState({ messages: [createSampleMessage()] });
+
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(useChatConnectionStore.getState().messages).toEqual([]);
+  });
+
+  it("disconnect()を呼ぶと、TwitchIrcClientのdisconnect()が呼ばれる", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    useChatConnectionStore.getState().disconnect();
+
+    expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("クライアントからonStateChangeが通知されると、connectionStateが更新される", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onStateChange?.("open");
+
+    expect(useChatConnectionStore.getState().connectionState).toBe("open");
+  });
+
+  it("privmsgイベントを受信すると、messagesに追加される", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const message = createSampleMessage();
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message });
+
+    expect(useChatConnectionStore.getState().messages).toEqual([message]);
+  });
+
+  it("表示上限(300件)を超えると、古い発言から破棄される", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    for (let i = 0; i < 305; i += 1) {
+      capturedCallbacks?.onEvent({
+        type: "privmsg",
+        channel: "somechannel",
+        message: createSampleMessage({ id: `msg-${i}`, text: `message ${i}` }),
+      });
+    }
+
+    const { messages } = useChatConnectionStore.getState();
+    expect(messages).toHaveLength(300);
+    expect(messages[0].text).toBe("message 5");
+    expect(messages[299].text).toBe("message 304");
+  });
+});
+
+describe("subscribeToChatMessages", () => {
+  it("登録したリスナーは受信したprivmsgイベントのメッセージで呼ばれる", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const listener = vi.fn();
+    subscribeToChatMessages(listener);
+    const message = createSampleMessage();
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message });
+
+    expect(listener).toHaveBeenCalledWith(message);
+  });
+
+  it("unsubscribe()を呼んだ後は、リスナーが呼ばれなくなる", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const listener = vi.fn();
+    const unsubscribe = subscribeToChatMessages(listener);
+    unsubscribe();
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message: createSampleMessage() });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("privmsg以外のイベント(ping等)ではリスナーは呼ばれない", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const listener = vi.fn();
+    subscribeToChatMessages(listener);
+
+    capturedCallbacks?.onEvent({ type: "ping", payload: "PING :tmi.twitch.tv" });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -1,0 +1,93 @@
+/**
+ * Twitch チャットへの接続状態・受信済み発言を保持する、モジュールスコープの永続ストア。
+ *
+ * chat-sensei はページ数の少ないシングルパーパスアプリで、ホーム(/)以外にも
+ * /deck・/study・/settings への画面遷移がある。これらは Next.js App Router 上の
+ * 別ルートであり、遷移するとホーム画面のコンポーネントはアンマウントされる。
+ *
+ * 接続状態・発言一覧をホーム画面のコンポーネントローカルな state / ref として
+ * 持たせると、アンマウントと同時に `TwitchIrcClient`・WebSocket への唯一の参照が
+ * 消えてしまい、実際の接続も切断されてしまう。このストアはそれらを React の
+ * コンポーネントツリーの外(モジュールスコープの Zustand ストア)に保持することで、
+ * どの画面を表示していても接続を維持する。
+ */
+import { create } from "zustand";
+import { createTwitchIrcClient, type ConnectionState, type TwitchIrcClient } from "@/lib/twitch/irc-client";
+import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+
+/** チャットに表示する発言の最大保持件数(古いものから捨てるリングバッファ) */
+const MAX_DISPLAYED_MESSAGES = 300;
+
+interface ChatConnectionState {
+  connectionState: ConnectionState;
+  messages: TwitchChatMessage[];
+  connect: (channel: string) => void;
+  disconnect: () => void;
+}
+
+/** 発言受信時に自動抽出などの追加処理を行うためのリスナー */
+type ChatMessageListener = (message: TwitchChatMessage) => void;
+const messageListeners = new Set<ChatMessageListener>();
+
+let client: TwitchIrcClient | null = null;
+
+/**
+ * `TwitchIrcClient` を遅延生成する。生成は初回接続時の1度きりとし、
+ * 以降はページ遷移をまたいでも同一インスタンスを使い回す。
+ */
+function getClient(): TwitchIrcClient {
+  if (!client) {
+    client = createTwitchIrcClient({
+      onStateChange: (state) => useChatConnectionStore.setState({ connectionState: state }),
+      onEvent: (event) => {
+        if (event.type !== "privmsg") return;
+        useChatConnectionStore.setState((prev) => {
+          const next = [...prev.messages, event.message];
+          return {
+            messages:
+              next.length > MAX_DISPLAYED_MESSAGES ? next.slice(next.length - MAX_DISPLAYED_MESSAGES) : next,
+          };
+        });
+        messageListeners.forEach((listener) => listener(event.message));
+      },
+    });
+  }
+  return client;
+}
+
+export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
+  connectionState: "idle",
+  messages: [],
+  connect: (channel) => {
+    set({ messages: [] });
+    getClient().connect(channel);
+  },
+  disconnect: () => {
+    getClient().disconnect();
+  },
+}));
+
+/**
+ * 受信した発言(privmsg)を購読する。自動抽出パイプラインのように、
+ * 画面表示用のリングバッファとは独立に「受信した発言そのもの」を必要とする
+ * 処理から利用する。戻り値の関数を呼ぶと購読を解除できる。
+ */
+export function subscribeToChatMessages(listener: ChatMessageListener): () => void {
+  messageListeners.add(listener);
+  return () => {
+    messageListeners.delete(listener);
+  };
+}
+
+/**
+ * テスト専用: モジュールスコープに保持している `TwitchIrcClient` とストアの状態を
+ * 初期状態に戻す。本番コードではページ遷移をまたいで接続を維持するために、
+ * このクライアントを意図的にモジュールスコープのシングルトンとして保持しているが、
+ * その結果テストケース間で状態が漏れてしまうため、各テストの beforeEach で
+ * この関数を呼び出して初期化すること。
+ */
+export function resetChatConnectionStoreForTests(): void {
+  client = null;
+  messageListeners.clear();
+  useChatConnectionStore.setState({ connectionState: "idle", messages: [] });
+}


### PR DESCRIPTION
## Summary
- チャットに接続した後、単語帳(/deck)・復習(/study)・設定(/settings)へ画面遷移するとチャット接続が切れる不具合を修正
- 原因: 接続状態・受信済み発言・`TwitchIrcClient`インスタンスがHomeコンポーネント(`src/app/page.tsx`)のローカルstate/refに閉じていたため、Next.js App Routerでのページ遷移によりHomeがアンマウントされると、実際のWebSocket接続への唯一の参照が失われ切断されていた
- これらをモジュールスコープの永続ストア(`src/store/chat-connection.ts`、Zustand製)に移し、Reactコンポーネントのマウント/アンマウントに依存せず接続を維持するようにした
- 自動抽出パイプラインの購読(`subscribeToChatMessages`)は引き続きHomeコンポーネントのマウント中のみ有効(画面遷移中は自動抽出を行わない、既存仕様どおり)。セッションプール・環境診断は画面ごとに最新設定で作り直される既存の挙動も維持

## Test plan
- [x] `npm run lint`(警告ゼロ)
- [x] `npm run type-check`
- [x] `npm test`(27ファイル/237テスト、全通過)
- [x] `src/store/chat-connection.test.ts`(新規)でストア単体の振る舞い(connect/disconnect/onStateChange/onEvent/リングバッファ300件上限/subscribeToChatMessages)を検証
- [x] `src/app/page.test.tsx`にアンマウント→再マウントしても接続状態・発言一覧が保持されることを検証する回帰テストを追加
- [x] 画面遷移中に届いた発言は自動抽出されず、復帰後の発言のみ自動抽出されることを検証するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)