### PR TITLE
feat: チャット接続時にTwitch配信embedプレイヤーを表示

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -29,6 +29,8 @@ vi.mock("@/lib/twitch/irc-client", () => ({
       getState: () => "idle",
     };
   }),
+  // 実装(irc-client.ts)と同じ正規化ロジックをテストでも使う(チャンネル名の小文字化・#除去)
+  normalizeChannelName: (channel: string) => channel.replace(/^#/, "").toLowerCase(),
 }));
 
 vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
@@ -211,6 +213,40 @@ describe("Home(ライブチャット画面)", () => {
       "src",
       "https://static-cdn.jtvnw.net/emoticons/v2/25/default/dark/2.0",
     );
+  });
+});
+
+describe("Home の配信embed(Twitch埋め込みプレイヤー)", () => {
+  it("未接続の状態では配信embedを表示しない", () => {
+    render(<Home />);
+
+    expect(screen.queryByTitle(/Twitch配信プレイヤー/)).not.toBeInTheDocument();
+  });
+
+  it("チャンネル名を入力して接続すると、そのチャンネルの配信embedが表示される", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByLabelText("チャンネル名"), "ZackRawrr");
+    await user.click(screen.getByRole("button", { name: "接続する" }));
+    capturedCallbacks?.onStateChange?.("open");
+
+    const iframe = await screen.findByTitle("Twitch配信プレイヤー: zackrawrr");
+    expect(iframe.tagName).toBe("IFRAME");
+  });
+
+  it("切断すると、配信embedが非表示になる", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.type(screen.getByLabelText("チャンネル名"), "somechannel");
+    await user.click(screen.getByRole("button", { name: "接続する" }));
+    capturedCallbacks?.onStateChange?.("open");
+    await screen.findByTitle("Twitch配信プレイヤー: somechannel");
+
+    await user.click(screen.getByRole("button", { name: "切断する" }));
+
+    expect(screen.queryByTitle(/Twitch配信プレイヤー/)).not.toBeInTheDocument();
   });
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,6 +34,7 @@ import type { ExplanationItem, ExplanationResult } from "@/lib/ai/schemas";
 import { loadSettings } from "@/lib/settings";
 import { createCard } from "@/lib/db/cards";
 import { subscribeToChatMessages, useChatConnectionStore } from "@/store/chat-connection";
+import { TwitchEmbedPlayer } from "@/components/twitch-embed-player";
 
 const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
   idle: "待機中",
@@ -63,6 +64,7 @@ export default function Home() {
   // ストア(chat-connection.ts)で管理する。詳細はストアのコメントを参照。
   const connectionState = useChatConnectionStore((state) => state.connectionState);
   const messages = useChatConnectionStore((state) => state.messages);
+  const channel = useChatConnectionStore((state) => state.channel);
   const connect = useChatConnectionStore((state) => state.connect);
   const disconnect = useChatConnectionStore((state) => state.disconnect);
 
@@ -242,6 +244,12 @@ export default function Home() {
           </div>
         </CardContent>
       </Card>
+
+      {channel && (
+        <Card className="overflow-hidden p-0">
+          <TwitchEmbedPlayer channel={channel} />
+        </Card>
+      )}
 
       <Card className="flex flex-1 flex-col overflow-hidden">
         <ScrollArea className="h-[60vh]">

--- a/src/components/twitch-embed-player.test.tsx
+++ b/src/components/twitch-embed-player.test.tsx
@@ -1,0 +1,41 @@
+/**
+ * src/components/twitch-embed-player.tsx のテスト。
+ *
+ * Twitch公式の埋め込みプレイヤー(`https://player.twitch.tv/`)をiframeで表示する
+ * コンポーネントが、指定チャンネル・現在のホスト名(parentパラメータ)を正しく
+ * srcに反映することを検証する。
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TwitchEmbedPlayer } from "./twitch-embed-player";
+
+describe("TwitchEmbedPlayer", () => {
+  it("指定したチャンネル名と現在のホスト名(parent)を含むiframeを表示する", () => {
+    render(<TwitchEmbedPlayer channel="zackrawrr" />);
+
+    const iframe = screen.getByTitle("Twitch配信プレイヤー: zackrawrr");
+    expect(iframe.tagName).toBe("IFRAME");
+    const src = new URL(iframe.getAttribute("src") ?? "");
+    expect(src.origin + src.pathname).toBe("https://player.twitch.tv/");
+    expect(src.searchParams.get("channel")).toBe("zackrawrr");
+    // jsdomのデフォルトのホスト名(localhost)がTwitch embedのparentパラメータに渡っている
+    expect(src.searchParams.get("parent")).toBe("localhost");
+  });
+
+  it("自動再生時にブラウザの自動再生ポリシーでブロックされないよう、既定でミュート再生する", () => {
+    render(<TwitchEmbedPlayer channel="zackrawrr" />);
+
+    const iframe = screen.getByTitle("Twitch配信プレイヤー: zackrawrr");
+    const src = new URL(iframe.getAttribute("src") ?? "");
+    expect(src.searchParams.get("muted")).toBe("true");
+  });
+
+  it("channelが変わると、iframeのsrcも新しいチャンネル名に更新される", () => {
+    const { rerender } = render(<TwitchEmbedPlayer channel="zackrawrr" />);
+    rerender(<TwitchEmbedPlayer channel="shroud" />);
+
+    const iframe = screen.getByTitle("Twitch配信プレイヤー: shroud");
+    const src = new URL(iframe.getAttribute("src") ?? "");
+    expect(src.searchParams.get("channel")).toBe("shroud");
+  });
+});

--- a/src/components/twitch-embed-player.tsx
+++ b/src/components/twitch-embed-player.tsx
@@ -1,0 +1,54 @@
+/**
+ * Twitch公式の埋め込みプレイヤー(`https://player.twitch.tv/`)をiframeで表示するコンポーネント。
+ *
+ * Twitch embedはブラウザの `Referer`/`postMessage` オリジンをホスト側で検証するため、
+ * `parent` クエリパラメータに埋め込み先のホスト名(`window.location.hostname`)を渡す必要がある。
+ * ブラウザの自動再生ポリシー(ミュートなし動画の自動再生ブロック)を回避するため、既定でミュート再生する。
+ *
+ * `window` はサーバー側レンダリング時に存在しないため、`useSyncExternalStore` を使い
+ * サーバーでは`null`、クライアントでは`window.location.hostname`を返すことで、
+ * hydrationミスマッチを起こさずにホスト名を取得する。
+ */
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const TWITCH_PLAYER_BASE_URL = "https://player.twitch.tv/";
+
+interface TwitchEmbedPlayerProps {
+  /** 表示するTwitchチャンネル名(正規化済みを想定) */
+  channel: string;
+}
+
+/** ホスト名はレンダー中に変化しないため、購読不要(何もしないunsubscribeを返す) */
+function subscribeToHostname(): () => void {
+  return () => {};
+}
+
+function getHostnameSnapshot(): string {
+  return window.location.hostname;
+}
+
+function getServerHostnameSnapshot(): null {
+  return null;
+}
+
+export function TwitchEmbedPlayer({ channel }: TwitchEmbedPlayerProps) {
+  const hostname = useSyncExternalStore(subscribeToHostname, getHostnameSnapshot, getServerHostnameSnapshot);
+
+  if (hostname === null) return null;
+
+  const src = new URL(TWITCH_PLAYER_BASE_URL);
+  src.searchParams.set("channel", channel);
+  src.searchParams.set("parent", hostname);
+  src.searchParams.set("muted", "true");
+
+  return (
+    <iframe
+      src={src.toString()}
+      title={`Twitch配信プレイヤー: ${channel}`}
+      allowFullScreen
+      className="aspect-video w-full"
+    />
+  );
+}

--- a/src/components/twitch-embed-player.tsx
+++ b/src/components/twitch-embed-player.tsx
@@ -48,7 +48,8 @@ export function TwitchEmbedPlayer({ channel }: TwitchEmbedPlayerProps) {
       src={src.toString()}
       title={`Twitch配信プレイヤー: ${channel}`}
       allowFullScreen
-      className="aspect-video w-full"
+      // Twitch embedの推奨最小サイズ(400x300px)を狭い画面でも下回らないようmin-h/min-wを設定する
+      className="aspect-video w-full min-h-[300px] min-w-[300px]"
     />
   );
 }

--- a/src/lib/twitch/irc-client.ts
+++ b/src/lib/twitch/irc-client.ts
@@ -76,8 +76,11 @@ function defaultRandomSuffix(): number {
   return Math.floor(Math.random() * 80_000) + 10_000;
 }
 
-/** チャンネル名から先頭の `#` を除き小文字化する(Twitchのチャンネル名は大文字小文字を区別しない) */
-function normalizeChannelName(channel: string): string {
+/**
+ * チャンネル名から先頭の `#` を除き小文字化する(Twitchのチャンネル名は大文字小文字を区別しない)。
+ * 配信embed(iframe)にもIRC接続と同じ正規化済みチャンネル名を渡すため、ストア側と共有できるようexportする。
+ */
+export function normalizeChannelName(channel: string): string {
   return channel.replace(/^#/, "").toLowerCase();
 }
 

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -29,6 +29,8 @@ vi.mock("@/lib/twitch/irc-client", () => ({
       getState: () => "idle",
     };
   }),
+  // 実装(irc-client.ts)と同じ正規化ロジックをテストでも使う(チャンネル名の小文字化・#除去)
+  normalizeChannelName: (channel: string) => channel.replace(/^#/, "").toLowerCase(),
 }));
 
 import { resetChatConnectionStoreForTests, subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
@@ -82,6 +84,20 @@ describe("useChatConnectionStore", () => {
     useChatConnectionStore.getState().disconnect();
 
     expect(mockDisconnect).toHaveBeenCalled();
+  });
+
+  it("connect()を呼ぶと、配信embed用に正規化(小文字化)したチャンネル名がchannelに保持される", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(useChatConnectionStore.getState().channel).toBe("zackrawrr");
+  });
+
+  it("disconnect()を呼ぶと、channelがnullに戻る", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    useChatConnectionStore.getState().disconnect();
+
+    expect(useChatConnectionStore.getState().channel).toBeNull();
   });
 
   it("クライアントからonStateChangeが通知されると、connectionStateが更新される", () => {

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -10,9 +10,17 @@
  * 消えてしまい、実際の接続も切断されてしまう。このストアはそれらを React の
  * コンポーネントツリーの外(モジュールスコープの Zustand ストア)に保持することで、
  * どの画面を表示していても接続を維持する。
+ *
+ * 接続中のチャンネル名(`channel`)も併せて保持し、`TwitchEmbedPlayer`(配信embed)の
+ * 表示切り替えに使う。
  */
 import { create } from "zustand";
-import { createTwitchIrcClient, type ConnectionState, type TwitchIrcClient } from "@/lib/twitch/irc-client";
+import {
+  createTwitchIrcClient,
+  normalizeChannelName,
+  type ConnectionState,
+  type TwitchIrcClient,
+} from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 
 /** チャットに表示する発言の最大保持件数(古いものから捨てるリングバッファ) */
@@ -21,6 +29,8 @@ const MAX_DISPLAYED_MESSAGES = 300;
 interface ChatConnectionState {
   connectionState: ConnectionState;
   messages: TwitchChatMessage[];
+  /** 接続中のチャンネル名(正規化済み)。配信embed(TwitchEmbedPlayer)の表示に使う。未接続時はnull */
+  channel: string | null;
   connect: (channel: string) => void;
   disconnect: () => void;
 }
@@ -58,11 +68,13 @@ function getClient(): TwitchIrcClient {
 export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
   connectionState: "idle",
   messages: [],
+  channel: null,
   connect: (channel) => {
-    set({ messages: [] });
+    set({ messages: [], channel: normalizeChannelName(channel) });
     getClient().connect(channel);
   },
   disconnect: () => {
+    set({ channel: null });
     getClient().disconnect();
   },
 }));
@@ -89,5 +101,5 @@ export function subscribeToChatMessages(listener: ChatMessageListener): () => vo
 export function resetChatConnectionStoreForTests(): void {
   client = null;
   messageListeners.clear();
-  useChatConnectionStore.setState({ connectionState: "idle", messages: [] });
+  useChatConnectionStore.setState({ connectionState: "idle", messages: [], channel: null });
 }


### PR DESCRIPTION
## Summary
- Twitchチャンネルに接続すると、チャット一覧の上に公式の埋め込みプレイヤー(`player.twitch.tv`)を表示し、配信映像も同時に視聴できるようにする
- 切断すると配信embedは非表示に戻る
- `chat-connection`ストアに接続中チャンネル名(`channel`)を保持するstateを追加し、`irc-client.ts`の`normalizeChannelName`をexportしてストアと共有(正規化ロジックの重複を排除)
- `TwitchEmbedPlayer`コンポーネントを新規追加。`parent`クエリパラメータ(embedのオリジン検証用)は`useSyncExternalStore`でhydrationミスマッチなく取得する
- CodeRabbitの指摘を受け、狭い画面でもTwitch embedの推奨最小サイズ(400x300px)を下回らないよう`min-h`/`min-w`を設定

## Test plan
- [x] `npm run lint` / `npm run type-check` / `npm test`(255件)がすべて成功
- [x] `npm run build` が成功
- [x] devサーバーで実際にブラウザ操作し、チャンネル接続時にTwitch公式の埋め込みプレイヤー(オフライン表示画面)が正しく表示され、切断で非表示になることを確認
- [x] CodeRabbitレビューを1回実行し、指摘(embed最小サイズ)に対応済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)