### PR TITLE
fix: チャット解説パネルをモーダルから非モーダルの右サイドパネルに変更

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -248,6 +248,27 @@ describe("Home の配信embed(Twitch埋め込みプレイヤー)", () => {
 
     expect(screen.queryByTitle(/Twitch配信プレイヤー/)).not.toBeInTheDocument();
   });
+
+  // 本来の不具合: 発言クリックで開く解説パネルが中央モーダル(modal既定=true)実装だったため、
+  // base-ui Dialogがパネル外の要素すべてに inert/aria-hidden="true" を付与し、
+  // その配下にある配信embedのiframeがブラウザからバックグラウンドタブ相当に扱われ再生が止まっていた。
+  // 解説パネルを非モーダル化した後は、開いていても配信embedがinert化されず再生が止まらないことを検証する。
+  it("発言をクリックして解説パネルを開いても、配信embedのiframeはinert化されない(再生が止まらない)", async () => {
+    vi.mocked(explainChatMessage).mockResolvedValue(sampleExplanation);
+    const user = userEvent.setup();
+    render(<Home />);
+    await connectAndReceiveMessage(user, "gg chat");
+    const iframe = await screen.findByTitle("Twitch配信プレイヤー: somechannel");
+
+    await user.click(screen.getByRole("button", { name: /gg chat/ }));
+    await waitFor(() => {
+      expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
+    });
+
+    expect(iframe).not.toHaveAttribute("inert");
+    expect(iframe.closest("[inert]")).toBeNull();
+    expect(iframe.closest('[aria-hidden="true"]')).toBeNull();
+  });
 });
 
 describe("Home のAI解説(手動ピック)", () => {
@@ -349,10 +370,8 @@ describe("Home のAI解説(手動ピック)", () => {
     expect(explainChatMessage).not.toHaveBeenCalled();
   });
 
-  // ダイアログはモーダルのため、開いている間は背景の発言リストが inert(操作不可)になる。
-  // そのため「別の発言を選び直す」導線は、実際には一度ダイアログを閉じてから行われる。
   // 閉じる操作(×ボタン/handleDialogOpenChange)が、進行中の解説ジョブを正しく中断することを検証する。
-  it("ダイアログを閉じると進行中の解説ジョブを中断し、閉じた後は別の発言を選び直せる", async () => {
+  it("パネルを閉じると進行中の解説ジョブを中断し、閉じた後は別の発言を選び直せる", async () => {
     let firstCallSignal: AbortSignal | undefined;
     vi.mocked(explainChatMessage).mockImplementationOnce((_pool, _text, options) => {
       firstCallSignal = options?.signal;
@@ -388,6 +407,49 @@ describe("Home のAI解説(手動ピック)", () => {
     expect(firstCallSignal?.aborted).toBe(true);
 
     await user.click(screen.getByRole("button", { name: /second message/ }));
+    await waitFor(() => {
+      expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
+    });
+  });
+
+  // 解説パネルは非モーダル(サイド展開)のため、開いたまま背景の発言リストを操作できる。
+  // パネルを閉じずに別の発言をクリックした場合も、進行中のジョブを中断して新しい発言の解説に切り替わることを検証する。
+  it("パネルを閉じずに別の発言をクリックすると、進行中の解説ジョブを中断して新しい発言の解説に切り替わる", async () => {
+    let firstCallSignal: AbortSignal | undefined;
+    vi.mocked(explainChatMessage).mockImplementationOnce((_pool, _text, options) => {
+      firstCallSignal = options?.signal;
+      return new Promise(() => {}); // 永久に未解決(中断だけを検証するため)
+    });
+    vi.mocked(explainChatMessage).mockResolvedValueOnce(sampleExplanation);
+    const user = userEvent.setup();
+    render(<Home />);
+    await connectAndReceiveMessage(user, "first message");
+    capturedCallbacks?.onEvent({
+      type: "privmsg",
+      channel: "somechannel",
+      message: {
+        id: "msg-2",
+        channel: "somechannel",
+        userId: "222",
+        username: "arukeinn",
+        displayName: "arukeinn",
+        color: null,
+        text: "second message",
+        isAction: false,
+        emotes: [],
+        badges: [],
+        timestampMs: 1690000000001,
+      },
+    });
+    await screen.findByText("second message");
+
+    await user.click(screen.getByRole("button", { name: /first message/ }));
+    expect(await screen.findByText(/解説を生成中/)).toBeInTheDocument();
+
+    // パネルを閉じずに、そのまま別の発言をクリックする
+    await user.click(screen.getByRole("button", { name: /second message/ }));
+
+    expect(firstCallSignal?.aborted).toBe(true);
     await waitFor(() => {
       expect(screen.getByText(sampleExplanation.translation)).toBeInTheDocument();
     });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,7 @@ import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } f
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
 import type { ConnectionState } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { buildEmoteImageUrl, splitMessageIntoSegments } from "@/lib/twitch/emotes";
@@ -209,64 +210,86 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-1 flex-col gap-4 p-6">
-      <Card>
-        <CardHeader>
-          <CardTitle>chat-sensei</CardTitle>
-          <CardDescription>
-            Twitch のチャンネル名を入力してライブチャットに接続します(ログイン不要)。発言をクリックするとAI解説が表示されます。
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="flex flex-col gap-3">
-          <div className="flex flex-col gap-1.5">
-            <Label htmlFor="channel-input">チャンネル名</Label>
-            <div className="flex gap-2">
-              <Input
-                id="channel-input"
-                placeholder="例: zackrawrr"
-                value={channelInput}
-                onChange={(e) => setChannelInput(e.target.value)}
-                disabled={connected}
-              />
-              {connected ? (
-                <Button onClick={handleDisconnect} variant="outline">
-                  切断する
-                </Button>
-              ) : (
-                <Button onClick={handleConnect} disabled={channelInput.trim().length === 0}>
-                  接続する
-                </Button>
-              )}
-            </div>
-            <p className="text-xs text-muted-foreground" role="status">
-              状態: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
-            </p>
-          </div>
-        </CardContent>
-      </Card>
-
-      {channel && (
-        <Card className="overflow-hidden p-0">
-          <TwitchEmbedPlayer channel={channel} />
-        </Card>
+    <div
+      className={cn(
+        "flex w-full flex-1 justify-center transition-[padding] duration-150",
+        // 解説パネル(幅24rem = max-w-sm、下記Dialogのwidth指定と合わせる)が画面右に固定表示される間、
+        // この外側コンテナに右パディングを付け、中央寄せの基準を左へ寄せる。本文ボックス(max-w-3xl)
+        // 自体の幅はここでは変えないため、余白に十分な広さがあるビューポートでは本文が不必要に
+        // 圧縮されず、パネルの手前まで実寸で表示される(幅が足りない場合のみ w-full により自然に縮む)。
+        // 狭い画面(md未満)ではパネルが画面全幅のオーバーレイになるため、余白確保は不要。
+        dialogState.status !== "idle" && "md:pr-96",
       )}
+    >
+      <div className="flex w-full max-w-3xl flex-col gap-4 p-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>chat-sensei</CardTitle>
+            <CardDescription>
+              Twitch のチャンネル名を入力してライブチャットに接続します(ログイン不要)。発言をクリックするとAI解説が表示されます。
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="channel-input">チャンネル名</Label>
+              <div className="flex gap-2">
+                <Input
+                  id="channel-input"
+                  placeholder="例: zackrawrr"
+                  value={channelInput}
+                  onChange={(e) => setChannelInput(e.target.value)}
+                  disabled={connected}
+                />
+                {connected ? (
+                  <Button onClick={handleDisconnect} variant="outline">
+                    切断する
+                  </Button>
+                ) : (
+                  <Button onClick={handleConnect} disabled={channelInput.trim().length === 0}>
+                    接続する
+                  </Button>
+                )}
+              </div>
+              <p className="text-xs text-muted-foreground" role="status">
+                状態: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
+              </p>
+            </div>
+          </CardContent>
+        </Card>
 
-      <Card className="flex flex-1 flex-col overflow-hidden">
-        <ScrollArea className="h-[60vh]">
-          <ol className="flex flex-col gap-1 p-4">
-            {messages.map((message) => (
-              <ChatMessageRow
-                key={message.id ?? `${message.username}-${message.timestampMs}`}
-                message={message}
-                onSelect={handleMessageClick}
-              />
-            ))}
-          </ol>
-        </ScrollArea>
-      </Card>
+        {channel && (
+          <Card className="overflow-hidden p-0">
+            <TwitchEmbedPlayer channel={channel} />
+          </Card>
+        )}
 
-      <Dialog open={dialogState.status !== "idle"} onOpenChange={handleDialogOpenChange}>
-        <DialogContent>
+        <Card className="flex flex-1 flex-col overflow-hidden">
+          <ScrollArea className="h-[60vh]">
+            <ol className="flex flex-col gap-1 p-4">
+              {messages.map((message) => (
+                <ChatMessageRow
+                  key={message.id ?? `${message.username}-${message.timestampMs}`}
+                  message={message}
+                  onSelect={handleMessageClick}
+                />
+              ))}
+            </ol>
+          </ScrollArea>
+        </Card>
+      </div>
+
+      {/*
+        解説パネルは非モーダル(modal=false)にする。base-ui Dialogはmodal時、
+        パネル外の要素(配信embedのiframeを含む)にinert/aria-hidden="true"を付与するため、
+        中央モーダルのままだとパネルを開くたびに配信embedの再生が止まってしまう。
+        非モーダル化に加え、中央オーバーレイではなく画面右側に固定表示するパネルUIへ変更することで、
+        パネルを開いたままプレイヤー・チャットログの両方を操作できるようにする。
+      */}
+      <Dialog open={dialogState.status !== "idle"} onOpenChange={handleDialogOpenChange} modal={false}>
+        <DialogContent
+          showOverlay={false}
+          className="inset-y-0 right-0 left-auto h-dvh w-full max-w-none sm:max-w-full md:max-w-sm translate-x-0 translate-y-0 grid-rows-[auto_1fr] gap-4 overflow-y-auto rounded-none rounded-l-xl border-l shadow-lg data-open:slide-in-from-right data-closed:slide-out-to-right"
+        >
           <DialogHeader>
             <DialogTitle>チャット解説</DialogTitle>
             {dialogState.status !== "idle" && (

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -43,13 +43,16 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  showOverlay = true,
   ...props
 }: DialogPrimitive.Popup.Props & {
   showCloseButton?: boolean
+  /** 非モーダル(例: サイドパネル)で背景を暗転・操作不可にしたくない場合に false を指定する */
+  showOverlay?: boolean
 }) {
   return (
     <DialogPortal>
-      <DialogOverlay />
+      {showOverlay && <DialogOverlay />}
       <DialogPrimitive.Popup
         data-slot="dialog-content"
         className={cn(


### PR DESCRIPTION
## Summary
- 発言クリックで開く解説パネルが中央モーダル(base-ui Dialogのmodal既定=true)実装だったため、開いている間は配信embedのiframeを含むパネル外の要素すべてに`inert`/`aria-hidden="true"`が付与され、配信の再生が止まってしまっていた
- パネルを非モーダル化(`modal={false}`)し、画面右に固定表示するサイドパネルUIへ変更することで、パネルを開いたままプレイヤー・チャットログを操作できるようにした
- パネル表示中は本文コンテナ(`flex justify-center` + 条件付き`md:pr-96`)で右側の余白を確保し、配信embed・チャットログとパネルが重ならないようにした。本文ボックス自体の幅は変えないため、余白が十分あるビューポートでは不必要に圧縮されない
- 狭い画面(`md`未満)ではパネルが画面全幅のオーバーレイになるよう`max-w-none sm:max-w-full md:max-w-sm`で調整(CodeRabbitの指摘を反映)

## Test plan
- [x] `npm test`(257件)・`npm run type-check`・`npm run lint`・`npm run build` すべて成功
- [x] TDD: パネル表示中に配信embedのiframeがinert化されないこと、パネルを閉じずに別発言へ解説対象を切り替えられることを検証する新規テストを追加(`src/app/page.test.tsx`)
- [x] 実ブラウザ(Twitchチャンネルに接続)で確認: パネルが右からスライド表示され、背景のプレイヤー・チャットログが暗転せず操作可能。`iframe.closest('[inert]')`等が`null`であることをJS実行で直接確認
- [x] 実ブラウザで配信embedとパネルの重なり・余白を実測し、修正前後でオーバーラップ・過圧縮が解消されていることを確認
- [x] CodeRabbitレビュー実施済み(1件の指摘に対応済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)