### PR TITLE
feat: 自動抽出候補をチャット横のパネルにリアルタイム表示し、クリックで採用/却下できるようにする

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -3,7 +3,9 @@
  *
  * Phase 1 の主要導線である「チャンネル名を入力して接続する → 受信した発言が
  * 表示名・色・emote付きで表示される → 切断する」という流れに加え、
- * Phase 2 の主要導線である「発言をクリックするとAI解説が表示される」を検証する。
+ * Phase 2 の主要導線である「発言をクリックするとAI解説が表示される」、
+ * Phase 5 の主要導線である「自動抽出候補がチャット横のパネルにリアルタイムで
+ * 蓄積され、採用/却下できる」を検証する。
  * 実際のWebSocket通信・Prompt API呼び出しは行わず、`createTwitchIrcClient` /
  * `runBrowserDiagnosis` / `explainChatMessage` をモックしてシミュレートする。
  */
@@ -15,6 +17,7 @@ import type { TwitchIrcClientCallbacks } from "@/lib/twitch/irc-client";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
 import type { ExplanationResult } from "@/lib/ai/schemas";
 import { db } from "@/lib/db/schema";
+import { createCandidate } from "@/lib/db/candidates";
 
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
@@ -89,6 +92,7 @@ beforeEach(async () => {
   vi.mocked(createAutoExtractionPipeline).mockReturnValue({ processMessage: vi.fn().mockResolvedValue(undefined) });
   // 前のテストの失敗等でカードが残っていても、各テストが空の状態から始まるようにする
   await db.cards.clear();
+  await db.candidates.clear();
   // チャット接続ストアはページ遷移をまたいで状態を保持するモジュールスコープの
   // シングルトンであり、テスト間でも共有されてしまうため、毎回未接続状態に戻す
   resetChatConnectionStoreForTests();
@@ -104,6 +108,7 @@ afterEach(async () => {
   vi.mocked(createAutoExtractionPipeline).mockReset();
   window.localStorage.clear();
   await db.cards.clear();
+  await db.candidates.clear();
 });
 
 /** 接続 → open状態 → 指定メッセージを1件受信、までの共通セットアップ */
@@ -535,6 +540,74 @@ describe("Home の自動抽出(バックグラウンド)", () => {
     await user.click(await screen.findByRole("button", { name: "切断する" }));
 
     expect(capturedSignal?.aborted).toBe(true);
+  });
+});
+
+describe("Home の自動抽出候補パネル", () => {
+  /** テスト用の候補データ(意味の分かる日本語文字列を使用) */
+  function buildCandidateInput(overrides: Partial<Parameters<typeof createCandidate>[0]> = {}) {
+    return {
+      term: "clutch",
+      kind: "word" as const,
+      meaning: "土壇場での見事なプレー",
+      note: "対戦ゲームの実況・チャットでよく使われる",
+      sourceMessageText: "that was such a clutch play honestly",
+      sourceChannel: "somechannel",
+      sourceAuthor: "yamada_taro",
+      targetLang: "en" as const,
+      explainLang: "ja" as const,
+      tags: [],
+      ...overrides,
+    };
+  }
+
+  it("候補がない場合はチャット横のパネルを表示しない", () => {
+    render(<Home />);
+
+    expect(screen.queryByText("自動抽出候補")).not.toBeInTheDocument();
+  });
+
+  it("候補が生成されると、チャット横のパネルにリアルタイムで表示される", async () => {
+    render(<Home />);
+
+    await createCandidate(buildCandidateInput());
+
+    expect(await screen.findByText("自動抽出候補")).toBeInTheDocument();
+    expect(screen.getByText("clutch")).toBeInTheDocument();
+    expect(screen.getByText("土壇場での見事なプレー")).toBeInTheDocument();
+  });
+
+  it("採用ボタンを押すと候補が単語帳に保存され、パネルから消える", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+    await createCandidate(buildCandidateInput({ term: "GG", meaning: "good game(お疲れ様)の略語" }));
+    await screen.findByText("GG");
+
+    await user.click(screen.getByRole("button", { name: "採用" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("自動抽出候補")).not.toBeInTheDocument();
+    });
+    const storedCards = await db.cards.toArray();
+    expect(storedCards).toHaveLength(1);
+    expect(storedCards[0].term).toBe("GG");
+    expect(await db.candidates.count()).toBe(0);
+  });
+
+  it("却下ボタンを押すと候補が削除され、パネルから消える(単語帳には保存されない)", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+    await createCandidate(buildCandidateInput());
+    await screen.findByText("clutch");
+
+    await user.click(screen.getByRole("button", { name: "却下" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("自動抽出候補")).not.toBeInTheDocument();
+    });
+    const storedCards = await db.cards.toArray();
+    expect(storedCards).toHaveLength(0);
+    expect(await db.candidates.count()).toBe(0);
   });
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,10 @@
  * 発言をクリックすると、設定済みの言語ペアで Prompt API(Gemini Nano)による
  * 構造化解説をダイアログ表示する(手動ピック)。Prompt API が利用できない
  * 環境では、理由を明示したうえで生成を行わない(暗黙のフォールバックはしない)。
+ *
+ * 自動抽出(バックグラウンド)が生成した候補は、チャットログの横に常設の
+ * `CandidatePanel` としてリアルタイムに表示する(`candidates` テーブルを
+ * Dexie の liveQuery で購読するため、手動での再取得は不要)。
  */
 "use client";
 
@@ -34,8 +38,11 @@ import { createAutoExtractionPipeline, type AutoExtractionPipeline } from "@/lib
 import type { ExplanationItem, ExplanationResult } from "@/lib/ai/schemas";
 import { loadSettings } from "@/lib/settings";
 import { createCard } from "@/lib/db/cards";
+import { acceptCandidate, rejectCandidate, subscribeToCandidates } from "@/lib/db/candidates";
+import type { Candidate } from "@/lib/db/schema";
 import { subscribeToChatMessages, useChatConnectionStore } from "@/store/chat-connection";
 import { TwitchEmbedPlayer } from "@/components/twitch-embed-player";
+import { CandidatePanel } from "@/components/candidate-panel";
 
 const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
   idle: "待機中",
@@ -131,6 +138,24 @@ export default function Home() {
     return unsubscribe;
   }, [getAutoExtractionPipeline]);
 
+  // --- 自動抽出候補のリアルタイムパネル ---
+  // 自動抽出パイプラインが`candidates`テーブルに書き込むと、liveQuery経由でここが更新される。
+  // 手動で一覧を再取得する必要はなく、採用/却下によるテーブル変更も同じ経路で自動反映される。
+  const [candidates, setCandidates] = useState<Candidate[]>([]);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToCandidates((next) => setCandidates(next));
+    return unsubscribe;
+  }, []);
+
+  const handleAcceptCandidate = useCallback((id: number) => {
+    acceptCandidate(id);
+  }, []);
+
+  const handleRejectCandidate = useCallback((id: number) => {
+    rejectCandidate(id);
+  }, []);
+
   const handleConnect = useCallback(() => {
     const channel = channelInput.trim();
     if (!channel) return;
@@ -221,7 +246,14 @@ export default function Home() {
         dialogState.status !== "idle" && "md:pr-96",
       )}
     >
-      <div className="flex w-full max-w-3xl flex-col gap-4 p-6">
+      <div
+        className={cn(
+          "flex w-full max-w-3xl flex-col gap-4 p-6 transition-[max-width] duration-150",
+          // 自動抽出候補パネル(幅lg:20rem)をチャットログの横に並べる余白を確保するため、
+          // 候補が1件以上ある間だけ広い画面幅(lg以上)でコンテナ全体を広げる。
+          candidates.length > 0 && "lg:max-w-5xl",
+        )}
+      >
         <Card>
           <CardHeader>
             <CardTitle>chat-sensei</CardTitle>
@@ -263,19 +295,23 @@ export default function Home() {
           </Card>
         )}
 
-        <Card className="flex flex-1 flex-col overflow-hidden">
-          <ScrollArea className="h-[60vh]">
-            <ol className="flex flex-col gap-1 p-4">
-              {messages.map((message) => (
-                <ChatMessageRow
-                  key={message.id ?? `${message.username}-${message.timestampMs}`}
-                  message={message}
-                  onSelect={handleMessageClick}
-                />
-              ))}
-            </ol>
-          </ScrollArea>
-        </Card>
+        <div className="flex flex-1 flex-col gap-4 lg:flex-row">
+          <Card className="flex flex-1 flex-col overflow-hidden">
+            <ScrollArea className="h-[60vh]">
+              <ol className="flex flex-col gap-1 p-4">
+                {messages.map((message) => (
+                  <ChatMessageRow
+                    key={message.id ?? `${message.username}-${message.timestampMs}`}
+                    message={message}
+                    onSelect={handleMessageClick}
+                  />
+                ))}
+              </ol>
+            </ScrollArea>
+          </Card>
+
+          <CandidatePanel candidates={candidates} onAccept={handleAcceptCandidate} onReject={handleRejectCandidate} />
+        </div>
       </div>
 
       {/*

--- a/src/components/candidate-panel.test.tsx
+++ b/src/components/candidate-panel.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * src/components/candidate-panel.tsx のテスト。
+ *
+ * 自動抽出パイプラインが生成した候補(Candidate)を1件ずつ提示し、
+ * 採用/却下ボタンのクリックで onAccept/onReject が呼ばれることを検証する。
+ * DB操作(採用/却下の実処理)はこのコンポーネントの責務外(呼び出し元に委譲)のため、
+ * ここではコールバックが正しい候補idで呼ばれることのみを確認する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { CandidatePanel } from "./candidate-panel";
+import type { Candidate } from "@/lib/db/schema";
+
+/** テスト用の候補データ(意味の分かる日本語文字列を使用) */
+function buildCandidate(overrides: Partial<Candidate> = {}): Candidate {
+  return {
+    id: 1,
+    term: "clutch",
+    kind: "word",
+    meaning: "土壇場での見事なプレー",
+    note: "対戦ゲームの実況・チャットでよく使われる",
+    sourceMessageText: "that was such a clutch play honestly",
+    sourceChannel: "zackrawrr",
+    sourceAuthor: "yamada_taro",
+    targetLang: "en",
+    explainLang: "ja",
+    tags: [],
+    createdAt: new Date("2026-07-29T10:00:00.000Z").getTime(),
+    ...overrides,
+  };
+}
+
+describe("CandidatePanel", () => {
+  it("候補が空の場合は何も表示しない", () => {
+    const { container } = render(<CandidatePanel candidates={[]} onAccept={vi.fn()} onReject={vi.fn()} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("先頭の候補が用語・意味・メモ・出典付きで表示され、残り件数が見出しに表示される", () => {
+    const first = buildCandidate({ id: 1, term: "clutch" });
+    const second = buildCandidate({ id: 2, term: "GG" });
+    render(<CandidatePanel candidates={[first, second]} onAccept={vi.fn()} onReject={vi.fn()} />);
+
+    expect(screen.getByText("自動抽出候補")).toBeInTheDocument();
+    expect(screen.getByText("2件")).toBeInTheDocument();
+    expect(screen.getByText("clutch")).toBeInTheDocument();
+    expect(screen.getByText("土壇場での見事なプレー")).toBeInTheDocument();
+    expect(screen.getByText("対戦ゲームの実況・チャットでよく使われる")).toBeInTheDocument();
+    expect(screen.getByText(/that was such a clutch play honestly/)).toBeInTheDocument();
+    // 2件目(GG)は先頭ではないため、用語としては表示されない
+    expect(screen.queryByText("GG")).not.toBeInTheDocument();
+  });
+
+  it("採用ボタンを押すと、先頭候補のidでonAcceptが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onAccept = vi.fn();
+    const candidate = buildCandidate({ id: 42 });
+    render(<CandidatePanel candidates={[candidate]} onAccept={onAccept} onReject={vi.fn()} />);
+
+    await user.click(screen.getByRole("button", { name: "採用" }));
+
+    expect(onAccept).toHaveBeenCalledWith(42);
+  });
+
+  it("却下ボタンを押すと、先頭候補のidでonRejectが呼ばれる", async () => {
+    const user = userEvent.setup();
+    const onReject = vi.fn();
+    const candidate = buildCandidate({ id: 42 });
+    render(<CandidatePanel candidates={[candidate]} onAccept={vi.fn()} onReject={onReject} />);
+
+    await user.click(screen.getByRole("button", { name: "却下" }));
+
+    expect(onReject).toHaveBeenCalledWith(42);
+  });
+});

--- a/src/components/candidate-panel.tsx
+++ b/src/components/candidate-panel.tsx
@@ -1,0 +1,73 @@
+/**
+ * 自動抽出候補のレビューパネル。
+ *
+ * 自動抽出パイプラインがバックグラウンドで生成した候補(Candidate)を、
+ * チャット画面の横で1件ずつ提示する。レビュー順は呼び出し元(`candidates`配列)の
+ * 先頭を最優先とし、通常は作成日時が古い順(=`subscribeToCandidates`の並び)を渡す想定。
+ * 採用/却下はクリック操作のみ(ドラッグ・スワイプ操作は行わない)で、
+ * 実際のDB更新(採用=単語帳への保存/却下=削除)は呼び出し元の`onAccept`/`onReject`に委譲する。
+ */
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { Candidate } from "@/lib/db/schema";
+
+export interface CandidatePanelProps {
+  /** レビュー対象の候補一覧。先頭(candidates[0])が現在表示中のカードになる */
+  candidates: Candidate[];
+  onAccept: (id: number) => void;
+  onReject: (id: number) => void;
+}
+
+export function CandidatePanel({ candidates, onAccept, onReject }: CandidatePanelProps) {
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  const current = candidates[0];
+  const remainingCount = candidates.length - 1;
+
+  return (
+    <Card className="flex w-full flex-col gap-3 lg:w-80 lg:shrink-0">
+      <CardHeader className="flex flex-row items-center justify-between gap-2">
+        <CardTitle>自動抽出候補</CardTitle>
+        <Badge variant="secondary">{candidates.length}件</Badge>
+      </CardHeader>
+      <CardContent className="flex flex-col gap-3">
+        {/*
+          Tinderのような「カードが積み重なっている」見た目を、ドラッグなしの
+          最小限のCSSだけで表現する装飾用プレビュー。次の候補があるときだけ、
+          現在のカードの背後にわずかに覗かせる(操作対象ではないためaria-hiddenで除外)。
+        */}
+        {remainingCount > 0 && (
+          <div
+            aria-hidden="true"
+            className="-mb-6 h-3 scale-95 rounded-md border bg-muted/50"
+          />
+        )}
+        <div className="rounded-md border p-3">
+          <div className="flex items-center gap-2">
+            <span className="font-semibold">{current.term}</span>
+            <Badge variant="secondary">{current.kind}</Badge>
+          </div>
+          <p className="text-sm text-muted-foreground">{current.meaning}</p>
+          {current.note && <p className="text-xs text-muted-foreground">{current.note}</p>}
+          <p className="mt-1 text-xs text-muted-foreground italic">「{current.sourceMessageText}」</p>
+          <div className="mt-3 flex gap-2">
+            <Button onClick={() => onAccept(current.id!)} size="sm" className="flex-1">
+              採用
+            </Button>
+            <Button onClick={() => onReject(current.id!)} size="sm" variant="outline" className="flex-1">
+              却下
+            </Button>
+          </div>
+        </div>
+        {remainingCount > 0 && (
+          <p className="text-xs text-muted-foreground">他 {remainingCount} 件</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/db/candidates.test.ts
+++ b/src/lib/db/candidates.test.ts
@@ -7,8 +7,9 @@
  * 各テストの独立性を保つため、テストごとに `db.candidates` / `db.cards` を空にしてから実行する。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Candidate } from "./schema";
 import { db } from "./schema";
-import { acceptCandidate, createCandidate, listCandidates, rejectCandidate } from "./candidates";
+import { acceptCandidate, createCandidate, listCandidates, rejectCandidate, subscribeToCandidates } from "./candidates";
 
 /** 自動抽出パイプラインが生成する候補入力を模したテストデータ(意味の分かる日本語・実チャット文を使用) */
 function buildNewCandidateInput(overrides: Partial<Parameters<typeof createCandidate>[0]> = {}) {
@@ -106,5 +107,52 @@ describe("rejectCandidate", () => {
     expect(storedCandidate).toBeUndefined();
     const storedCards = await db.cards.toArray();
     expect(storedCards).toHaveLength(0);
+  });
+});
+
+describe("subscribeToCandidates", () => {
+  it("購読直後は空配列で呼ばれ、候補を作成すると作成日時が古い順の一覧でコールバックが呼ばれる", async () => {
+    const dateNowSpy = vi.spyOn(Date, "now");
+    dateNowSpy.mockReturnValue(new Date("2026-07-29T10:00:00.000Z").getTime());
+
+    const received: Candidate[][] = [];
+    const unsubscribe = subscribeToCandidates((candidates) => {
+      received.push(candidates);
+    });
+
+    await vi.waitFor(() => {
+      expect(received.length).toBeGreaterThanOrEqual(1);
+    });
+    expect(received[0]).toEqual([]);
+
+    const older = await createCandidate(buildNewCandidateInput({ term: "clutch" }));
+    dateNowSpy.mockReturnValue(new Date("2026-07-29T10:05:00.000Z").getTime());
+    const newer = await createCandidate(buildNewCandidateInput({ term: "GG" }));
+
+    await vi.waitFor(() => {
+      const latest = received[received.length - 1];
+      expect(latest.map((candidate) => candidate.id)).toEqual([older.id, newer.id]);
+    });
+
+    unsubscribe();
+  });
+
+  it("購読解除後は候補を追加してもコールバックが呼ばれない", async () => {
+    const received: Candidate[][] = [];
+    const unsubscribe = subscribeToCandidates((candidates) => {
+      received.push(candidates);
+    });
+    await vi.waitFor(() => {
+      expect(received.length).toBeGreaterThanOrEqual(1);
+    });
+
+    unsubscribe();
+    const callCountAtUnsubscribe = received.length;
+
+    await createCandidate(buildNewCandidateInput());
+    // liveQueryの再実行が起こりうる猶予を置いても、購読解除後は呼び出し回数が増えないことを確認する
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(received.length).toBe(callCountAtUnsubscribe);
   });
 });

--- a/src/lib/db/candidates.ts
+++ b/src/lib/db/candidates.ts
@@ -6,6 +6,7 @@
  * 貯め、利用者が `/deck` のレビューUIで採用/却下してから初めて単語帳(`cards`)に入る。
  * 採用時のSRS初期化ロジックは `cards.ts` の `createCard` をそのまま再利用し、重複させない。
  */
+import { liveQuery } from "dexie";
 import type { Card, Candidate } from "./schema";
 import { db } from "./schema";
 import { createCard } from "./cards";
@@ -57,4 +58,21 @@ export async function acceptCandidate(id: number): Promise<Card> {
 /** 候補を却下する: 単語帳には保存せず削除する */
 export async function rejectCandidate(id: number): Promise<void> {
   await db.candidates.delete(id);
+}
+
+/**
+ * 候補テーブルの変更をリアルタイムに購読する。
+ * 自動抽出パイプラインが候補を追加した瞬間や、採用/却下で候補が減った瞬間に
+ * `onData` が最新の一覧(作成日時が古い順=レビューすべき順)で呼ばれる。
+ * 返り値の関数を呼ぶと購読を解除する。
+ */
+export function subscribeToCandidates(
+  onData: (candidates: Candidate[]) => void,
+  onError?: (error: unknown) => void,
+): () => void {
+  const subscription = liveQuery(() => db.candidates.orderBy("createdAt").toArray()).subscribe({
+    next: onData,
+    error: (error: unknown) => onError?.(error),
+  });
+  return () => subscription.unsubscribe();
 }


### PR DESCRIPTION
## Summary
- `subscribeToCandidates`(`src/lib/db/candidates.ts`)を追加し、Dexieの`liveQuery`で`candidates`テーブルをリアルタイム購読できるようにした
- 候補を1件ずつ提示し、クリックで採用/却下できる`CandidatePanel`(`src/components/candidate-panel.tsx`)を新規作成した
- ホーム画面(`src/app/page.tsx`)のチャットログ横に上記パネルを常設し、自動抽出候補がリアルタイムに蓄積・レビューできるようにした。既存の解説パネル(右固定・非モーダル)とは別枠で共存させ、双方の表示ロジックには手を入れていない

## Test plan
- [x] `npm run lint`(警告ゼロ)
- [x] `npm run type-check`
- [x] `npm test`(267件全通過、新規追加分含む)
- [x] `npm run build`
- [x] CodeRabbit CLIレビュー実施(指摘1件: テストでcandidatesテーブルの削除も検証するよう追加 → 対応済み)
- [x] ローカルdevサーバー + ブラウザで、候補の採用/却下によりパネルがリアルタイムに更新されることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)