### PR TITLE
feat: 解説列 — 各行の「解説」ボタンで要求した発言だけ解説を生成して右列に表示する

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -2,11 +2,13 @@
  * src/app/page.tsx(ホーム = 3カラムのチャット閲覧画面)のテスト。
  *
  * 生IRC / 翻訳 / 解説 の3列が描画されること、受信済み発言が生IRC列に
- * 表示されること、翻訳列に発言ごとの翻訳状態が表示されること、
- * 翻訳列・解説列のぼかしをトグルで切り替えられることを検証する。
- * IRC 接続そのものは chat-connection ストアに、翻訳の生成は translations ストアに
- * 閉じているため、ここでは各ストアの state を直接書き換えて注入する。
- * 翻訳パイプラインの開始(`startTranslationPipeline`)はブラウザAPIに触れるためモックする。
+ * 表示されること、翻訳列に発言ごとの翻訳状態が表示されること、解説列で「解説」ボタンから
+ * 解説を要求でき発言ごとの解説状態が表示されること、翻訳列・解説列のぼかしをトグルで
+ * 切り替えられることを検証する。
+ * IRC 接続そのものは chat-connection ストアに、翻訳の生成は translations ストアに、
+ * 解説の生成は explanations ストアに閉じているため、ここでは各ストアの state を直接書き換えて注入する。
+ * 各パイプラインの開始(`startTranslationPipeline` / `startExplanationPipeline`)は
+ * ブラウザAPIに触れるためモックする。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen, within } from "@testing-library/react";
@@ -15,6 +17,7 @@ import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { resetBotFilterStoreForTests, useBotFilterStore } from "@/store/bot-filter";
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetTranslationStoreForTests, useTranslationStore } from "@/store/translations";
+import { resetExplanationStoreForTests, useExplanationStore, type ExplanationEntry } from "@/store/explanations";
 
 const mockStopPipeline = vi.fn();
 const mockStartTranslationPipeline = vi.fn(() => mockStopPipeline);
@@ -24,6 +27,16 @@ vi.mock("@/store/translations", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/store/translations")>()),
   startTranslationPipeline: () => mockStartTranslationPipeline(),
   warmUpTranslationPipeline: () => mockWarmUpTranslationPipeline(),
+}));
+
+const mockStopExplanationPipeline = vi.fn();
+const mockStartExplanationPipeline = vi.fn(() => mockStopExplanationPipeline);
+const mockRequestExplanation = vi.fn();
+
+vi.mock("@/store/explanations", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/explanations")>()),
+  startExplanationPipeline: () => mockStartExplanationPipeline(),
+  requestExplanation: (message: TwitchChatMessage) => mockRequestExplanation(message),
 }));
 
 import Home from "./page";
@@ -56,11 +69,15 @@ beforeEach(() => {
   mockStartTranslationPipeline.mockClear();
   mockStopPipeline.mockClear();
   mockWarmUpTranslationPipeline.mockClear();
+  mockStartExplanationPipeline.mockClear();
+  mockStopExplanationPipeline.mockClear();
+  mockRequestExplanation.mockClear();
 });
 
 afterEach(() => {
   resetChatConnectionStoreForTests();
   resetTranslationStoreForTests();
+  resetExplanationStoreForTests();
   resetBotFilterStoreForTests();
   window.localStorage.clear();
 });
@@ -227,6 +244,153 @@ describe("Home(翻訳列)", () => {
 
     await user.click(screen.getByRole("switch", { name: "翻訳をぼかす" }));
     expect(translationRow).not.toHaveClass("blur-sm");
+  });
+});
+
+describe("Home(解説列)", () => {
+  /** 解説列のテストで使う、Prompt API が使える状態の解説ストア */
+  function setExplanationReady(entries: Record<string, ExplanationEntry> = {}) {
+    useExplanationStore.setState({ promptApi: { status: "ready" }, entries });
+  }
+
+  it("マウント時に解説パイプラインを開始し、アンマウント時に停止する", () => {
+    const { unmount } = render(<Home />);
+    expect(mockStartExplanationPipeline).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(mockStopExplanationPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it("未要求の行には「解説」ボタンがあり、クリックすると対応する発言の解説を要求する", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言, サンプル発言2] });
+    setExplanationReady();
+
+    render(<Home />);
+
+    const rows = within(screen.getByRole("region", { name: "解説" })).getAllByRole("listitem");
+    await user.click(within(rows[1]).getByRole("button", { name: "解説" }));
+
+    expect(mockRequestExplanation).toHaveBeenCalledTimes(1);
+    expect(mockRequestExplanation).toHaveBeenCalledWith(サンプル発言2);
+  });
+
+  it("解説をぼかしていても「解説」ボタンはぼかしの外にあり操作できる", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    setExplanationReady();
+
+    render(<Home />);
+
+    expect(screen.getByRole("switch", { name: "解説をぼかす" })).toBeChecked();
+    const button = within(screen.getByRole("region", { name: "解説" })).getByRole("button", { name: "解説" });
+    expect(button.closest(".blur-sm")).toBeNull();
+
+    await user.click(button);
+    expect(mockRequestExplanation).toHaveBeenCalledWith(サンプル発言);
+  });
+
+  it("生成中の行は「解説中」と表示し、ボタンは出さない", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    setExplanationReady({ "msg-1": { status: "pending" } });
+
+    render(<Home />);
+
+    const column = screen.getByRole("region", { name: "解説" });
+    expect(within(column).getByText("解説中...")).toBeInTheDocument();
+    expect(within(column).queryByRole("button", { name: "解説" })).not.toBeInTheDocument();
+  });
+
+  it("完了した解説を対応する発言の行に表示する", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言, サンプル発言2] });
+    setExplanationReady({
+      "msg-2": {
+        status: "done",
+        result: {
+          translation: "これはマジでそう",
+          literal: "これはとても本物だ",
+          items: [{ term: "so real", kind: "slang", meaning: "激しく同意", note: "共感を示す若者言葉" }],
+          difficulty: 3,
+        },
+      },
+    });
+
+    render(<Home />);
+
+    const rows = within(screen.getByRole("region", { name: "解説" })).getAllByRole("listitem");
+    expect(rows[0]).toHaveAttribute("data-message-id", "msg-1");
+    expect(within(rows[0]).getByRole("button", { name: "解説" })).toBeInTheDocument();
+    expect(rows[1]).toHaveAttribute("data-message-id", "msg-2");
+    expect(rows[1]).toHaveTextContent("これはマジでそう");
+    expect(rows[1]).toHaveTextContent("so real");
+    expect(rows[1]).toHaveTextContent("難易度 3/5");
+  });
+
+  it("失敗した行は理由付きで「解説に失敗」と表示し、「再試行」ボタンで再要求できる", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    setExplanationReady({ "msg-1": { status: "failed", reason: "応答をJSONとして解釈できませんでした" } });
+
+    render(<Home />);
+
+    const column = screen.getByRole("region", { name: "解説" });
+    expect(within(column).getByText(/解説に失敗/)).toBeInTheDocument();
+    expect(within(column).getByText(/応答をJSONとして解釈できませんでした/)).toBeInTheDocument();
+
+    await user.click(within(column).getByRole("button", { name: "再試行" }));
+    expect(mockRequestExplanation).toHaveBeenCalledWith(サンプル発言);
+  });
+
+  it("Prompt API が利用できない環境では、行ごとに「解説不可」と表示してボタンを出さず、列の見出し付近に理由を表示する", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    useExplanationStore.setState({
+      promptApi: { status: "unavailable", reason: "この環境では Prompt API (window.LanguageModel) が見つかりません。" },
+      entries: {},
+    });
+
+    render(<Home />);
+
+    const column = screen.getByRole("region", { name: "解説" });
+    expect(within(column).getByText("解説不可")).toBeInTheDocument();
+    expect(within(column).queryByRole("button", { name: "解説" })).not.toBeInTheDocument();
+    expect(within(column).getByText(/window\.LanguageModel/)).toBeInTheDocument();
+  });
+
+  it("環境診断が終わるまでは「準備中」の無効なボタンを表示する", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    useExplanationStore.setState({ promptApi: { status: "checking" }, entries: {} });
+
+    render(<Home />);
+
+    const column = screen.getByRole("region", { name: "解説" });
+    expect(within(column).getByRole("button", { name: "準備中..." })).toBeDisabled();
+  });
+
+  it("ID を持たない発言の行は「解説不可(IDなし)」と表示する", () => {
+    useChatConnectionStore.setState({ messages: [{ ...サンプル発言, id: null }] });
+    setExplanationReady();
+
+    render(<Home />);
+
+    const column = screen.getByRole("region", { name: "解説" });
+    expect(within(column).getByText("解説不可(IDなし)")).toBeInTheDocument();
+    expect(within(column).queryByRole("button", { name: "解説" })).not.toBeInTheDocument();
+  });
+
+  it("解説をぼかしている間は完了した解説の行がぼかされ、解除すると外れる", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    setExplanationReady({
+      "msg-1": { status: "done", result: { translation: "訳", literal: "直訳", items: [], difficulty: 1 } },
+    });
+
+    render(<Home />);
+
+    const row = within(screen.getByRole("region", { name: "解説" })).getByRole("listitem");
+    expect(row).toHaveClass("blur-sm");
+
+    await user.click(screen.getByRole("switch", { name: "解説をぼかす" }));
+    expect(row).not.toHaveClass("blur-sm");
   });
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,7 +5,7 @@
  *
  * - 左列「生IRC」: 受信した発言をそのまま(表示名の色・emote画像付きで)表示する
  * - 中央列「翻訳」: 発言ごとの翻訳(translations ストア)を左列と同じ高さの行に表示する
- * - 右列「解説」: 発言の解説を必要に応じて生成して表示する(生成処理は未実装。骨組みのみ)
+ * - 右列「解説」: 各行の「解説」ボタンを押した発言だけ、解説(explanations ストア)を生成して表示する
  *
  * 行の高さ揃えは CSS subgrid で実現する。3列の親グリッドが「見出し1行 + 発言数ぶんの行」を
  * 持ち、各列(section)は `grid-rows-subgrid` で親の行トラックを共有する。これにより
@@ -13,15 +13,18 @@
  * スクロールは3列で共通の1つにまとめる(列ごとに独立させると行の対応が崩れるため)。
  *
  * 翻訳列・解説列は学習のためデフォルトでぼかして表示し、それぞれのトグルで解除できる。
+ * 解説列の「解説」ボタンはぼかし中でも操作できるよう、完了した解説のある行だけをぼかす。
  * 生IRC列の見出しには bot除外設定(BotFilterDialog)を開くアイコンを置く。除外パターンは
  * bot-filter ストアが LocalStorage から復元し、chat-connection ストアが受信時に適用する。
  * 接続状態・受信済み発言はモジュールスコープのストア(chat-connection.ts)が、
- * 翻訳結果は translations ストアが保持し、翻訳パイプラインはこの画面のマウント時に開始する。
+ * 翻訳結果は translations ストアが、解説結果は explanations ストアが保持し、
+ * 各パイプラインはこの画面のマウント時に開始する。
  */
 "use client";
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { BotFilterDialog } from "@/components/bot-filter-dialog";
+import { ExplanationResultView } from "@/components/explanation-result-view";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -33,6 +36,12 @@ import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { buildEmoteImageUrl, splitMessageIntoSegments } from "@/lib/twitch/emotes";
 import { hydrateBotFilterStore } from "@/store/bot-filter";
 import { useChatConnectionStore } from "@/store/chat-connection";
+import {
+  requestExplanation,
+  startExplanationPipeline,
+  useExplanationStore,
+  type ExplanationEntry,
+} from "@/store/explanations";
 import {
   startTranslationPipeline,
   useTranslationStore,
@@ -67,9 +76,13 @@ export default function Home() {
 
   const translationEntries = useTranslationStore((state) => state.entries);
   const promptApi = useTranslationStore((state) => state.promptApi);
+  const explanationEntries = useExplanationStore((state) => state.entries);
+  const explanationPromptApi = useExplanationStore((state) => state.promptApi);
 
   // 受信した発言を自動で翻訳ジョブに流す。アンマウント時は購読を解除し待機中のジョブを中断する
   useEffect(() => startTranslationPipeline(), []);
+  // 解説の環境診断を行い、「解説」ボタンからの要求を受け付ける。アンマウント時は待機中のジョブを中断する
+  useEffect(() => startExplanationPipeline(), []);
   // bot除外パターンを LocalStorage から復元する(SSR 中に触れないようマウント後に行う)
   useEffect(() => hydrateBotFilterStore(), []);
 
@@ -165,13 +178,29 @@ export default function Home() {
               ))}
             </div>
           </Column>
-          <Column title="解説" blurred={explanationBlurred}>
+          <Column
+            title="解説"
+            blurred={explanationBlurred}
+            headerExtra={
+              explanationPromptApi.status === "unavailable" ? (
+                <p className="text-xs font-normal text-destructive">{explanationPromptApi.reason}</p>
+              ) : null
+            }
+          >
             <div role="list" className="contents">
-              {messages.map((message, index) => (
-                <Row key={messageKey(message, index)} message={message} blurred={explanationBlurred}>
-                  <span className="text-muted-foreground">解説は未実装です。</span>
-                </Row>
-              ))}
+              {messages.map((message, index) => {
+                const entry = message.id === null ? undefined : explanationEntries[message.id];
+                return (
+                  <Row
+                    key={messageKey(message, index)}
+                    message={message}
+                    // ぼかすのは完了した解説だけ。ボタンや状態表示はぼかし中でも見える・操作できるようにする
+                    blurred={explanationBlurred && entry?.status === "done"}
+                  >
+                    <ExplanationCellContent message={message} entry={entry} promptApi={explanationPromptApi} />
+                  </Row>
+                );
+              })}
             </div>
           </Column>
         </div>
@@ -276,6 +305,58 @@ function TranslationCellContent({
       return <span className="text-muted-foreground">未翻訳(流量超過)</span>;
     case "unavailable":
       return <span className="text-muted-foreground">翻訳不可</span>;
+  }
+}
+
+/**
+ * 解説列の1行の中身。未要求の行には「解説」ボタンを置き、
+ * 生成中・完了・失敗・Prompt API 利用不可の各状態を暗黙に隠さず明示する。
+ */
+function ExplanationCellContent({
+  message,
+  entry,
+  promptApi,
+}: {
+  message: TwitchChatMessage;
+  entry: ExplanationEntry | undefined;
+  promptApi: PromptApiStatus;
+}) {
+  if (message.id === null) {
+    return <span className="text-muted-foreground">解説不可(IDなし)</span>;
+  }
+  if (promptApi.status === "unavailable") {
+    return <span className="text-muted-foreground">解説不可</span>;
+  }
+  if (promptApi.status === "checking") {
+    return (
+      <Button size="sm" variant="outline" disabled>
+        準備中...
+      </Button>
+    );
+  }
+  if (!entry) {
+    return (
+      <Button size="sm" variant="outline" onClick={() => requestExplanation(message)}>
+        解説
+      </Button>
+    );
+  }
+  switch (entry.status) {
+    case "pending":
+      return <span className="text-muted-foreground">解説中...</span>;
+    case "done":
+      return <ExplanationResultView result={entry.result} />;
+    case "failed":
+      return (
+        <div className="flex flex-col items-start gap-1">
+          <span className="text-destructive">解説に失敗: {entry.reason}</span>
+          <Button size="sm" variant="outline" onClick={() => requestExplanation(message)}>
+            再試行
+          </Button>
+        </div>
+      );
+    case "unavailable":
+      return <span className="text-muted-foreground">解説不可</span>;
   }
 }
 

--- a/src/components/explanation-result-view.test.tsx
+++ b/src/components/explanation-result-view.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * src/components/explanation-result-view.tsx(解説結果の表示)のテスト。
+ *
+ * `explanationSchema` の各要素(訳・直訳・注目語句・難易度)が日本語ラベル付きで
+ * 表示されること、注目語句が無い場合はその見出しを出さないことを検証する。
+ */
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { ExplanationResult } from "@/lib/ai/schemas";
+import { ExplanationResultView } from "./explanation-result-view";
+
+const サンプル解説: ExplanationResult = {
+  translation: "ナイスゲーム、チャットのみんな",
+  literal: "良いゲーム、チャット",
+  items: [
+    { term: "gg", kind: "abbreviation", meaning: "good game の略", note: "試合終了時の定番の挨拶" },
+    { term: "chat", kind: "slang", meaning: "視聴者全体への呼びかけ", note: "配信者が視聴者をまとめて呼ぶ言い方" },
+  ],
+  difficulty: 2,
+};
+
+describe("ExplanationResultView", () => {
+  it("訳・直訳・難易度を表示する", () => {
+    render(<ExplanationResultView result={サンプル解説} />);
+
+    expect(screen.getByText("ナイスゲーム、チャットのみんな")).toBeInTheDocument();
+    expect(screen.getByText("良いゲーム、チャット")).toBeInTheDocument();
+    expect(screen.getByText("難易度 2/5")).toBeInTheDocument();
+  });
+
+  it("注目語句を語句・分類(日本語ラベル)・意味・メモ付きで列挙する", () => {
+    render(<ExplanationResultView result={サンプル解説} />);
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(items[0]).toHaveTextContent("gg");
+    expect(items[0]).toHaveTextContent("略語");
+    expect(items[0]).toHaveTextContent("good game の略");
+    expect(items[0]).toHaveTextContent("試合終了時の定番の挨拶");
+    expect(items[1]).toHaveTextContent("スラング");
+  });
+
+  it("注目語句が無い場合は見出しもリストも表示しない", () => {
+    render(<ExplanationResultView result={{ ...サンプル解説, items: [] }} />);
+
+    expect(screen.queryByText("注目ポイント")).not.toBeInTheDocument();
+    expect(screen.queryByRole("list")).not.toBeInTheDocument();
+  });
+});

--- a/src/components/explanation-result-view.tsx
+++ b/src/components/explanation-result-view.tsx
@@ -1,0 +1,56 @@
+/**
+ * 発言1件の解説結果(`explanationSchema`: 訳・直訳・注目語句・難易度)を表示するコンポーネント。
+ *
+ * ホーム画面の右列「解説」の1行に埋め込まれる前提で、見出しは持たず縦に詰めて表示する。
+ * 語句の分類(`kind`)はモデルが返す英語の識別子のままではなく日本語ラベルに変換して示す。
+ * 単語帳への保存(旧「カード化」ボタン)は単語帳機能が未定のため持たない。
+ */
+import { Badge } from "@/components/ui/badge";
+import type { ExplanationItemKind, ExplanationResult } from "@/lib/ai/schemas";
+
+/** 語句の分類の日本語ラベル */
+const KIND_LABELS: Record<ExplanationItemKind, string> = {
+  slang: "スラング",
+  abbreviation: "略語",
+  idiom: "イディオム",
+  emote: "エモート",
+  grammar: "文法",
+  word: "単語",
+};
+
+/** `explanationSchema.difficulty` の上限(1〜5段階) */
+const MAX_DIFFICULTY = 5;
+
+export function ExplanationResultView({ result }: { result: ExplanationResult }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-start justify-between gap-2">
+        <p>{result.translation}</p>
+        <Badge variant="outline" className="shrink-0">
+          難易度 {result.difficulty}/{MAX_DIFFICULTY}
+        </Badge>
+      </div>
+      <p className="text-xs text-muted-foreground">
+        <span className="font-medium">直訳: </span>
+        {result.literal}
+      </p>
+      {result.items.length > 0 && (
+        <div className="flex flex-col gap-1">
+          <p className="text-xs font-medium">注目ポイント</p>
+          <ul className="flex flex-col gap-1">
+            {result.items.map((item, index) => (
+              <li key={index} className="rounded-md border px-2 py-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold">{item.term}</span>
+                  <Badge variant="secondary">{KIND_LABELS[item.kind]}</Badge>
+                </div>
+                <p className="text-muted-foreground">{item.meaning}</p>
+                <p className="text-xs text-muted-foreground">{item.note}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/store/explanations.test.ts
+++ b/src/store/explanations.test.ts
@@ -376,6 +376,53 @@ describe("requestExplanation", () => {
     expect(enqueue).not.toHaveBeenCalled();
   });
 
+  it("生成中に停止すると pending のエントリを取り除き、停止後にジョブが決着しても結果を書き込まない", async () => {
+    const first = createDeferred<string>();
+    const second = createDeferred<string>();
+    const { deps, setMessages } = createDeps({ promptResults: [first.promise, second.promise] });
+    const message1 = createMessage({ id: "msg-1" });
+    const message2 = createMessage({ id: "msg-2" });
+    setMessages([message1, message2]);
+    const stop = startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message1);
+    requestExplanation(message2);
+    await flush();
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "pending" });
+
+    stop();
+    expect(useExplanationStore.getState().entries["msg-1"]).toBeUndefined();
+    expect(useExplanationStore.getState().entries["msg-2"]).toBeUndefined();
+
+    // 停止後に前のジョブが成功・失敗しても、停止済みパイプラインは状態を書き込まない
+    first.resolve(JSON.stringify(サンプル解説));
+    second.reject(new Error("停止後の失敗"));
+    await flush();
+    expect(useExplanationStore.getState().entries).toEqual({});
+  });
+
+  it("停止後に再開すると、再度の要求で解説を生成できる", async () => {
+    const stalled = createDeferred<string>();
+    const { deps, setMessages } = createDeps({
+      promptResults: [stalled.promise, Promise.resolve(JSON.stringify(サンプル解説))],
+    });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    const stop = startExplanationPipeline(deps);
+    await flush();
+    requestExplanation(message);
+    await flush();
+    stop();
+
+    startExplanationPipeline(deps);
+    await flush();
+    requestExplanation(message);
+    await flush();
+
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "done", result: サンプル解説 });
+  });
+
   it("パイプラインが開始されていない状態で要求しても何もしない", () => {
     requestExplanation(createMessage({ id: "msg-1" }));
 

--- a/src/store/explanations.test.ts
+++ b/src/store/explanations.test.ts
@@ -1,0 +1,384 @@
+/**
+ * src/store/explanations.ts(解説結果ストア + 解説パイプライン)のテスト。
+ *
+ * 翻訳列と異なり解説は全発言に対して生成せず、利用者が `requestExplanation` で
+ * 明示的に要求した発言だけを高優先度ジョブとして投入する。その結果(生成中・完了・
+ * 失敗・Prompt API 利用不可)を発言 ID に紐づけて保持することを検証する。
+ * Prompt API・環境診断はすべてフェイクを注入し、実ブラウザAPIには触れない。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
+import type { ExplanationResult } from "@/lib/ai/schemas";
+import type { SessionPool } from "@/lib/ai/session-pool";
+import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+import {
+  requestExplanation,
+  resetExplanationStoreForTests,
+  startExplanationPipeline,
+  useExplanationStore,
+  type ExplanationPipelineDeps,
+} from "./explanations";
+
+/** テスト用のサンプル発言(実況チャットにありそうな「ナイスゲーム」の一言) */
+function createMessage(overrides: Partial<TwitchChatMessage> = {}): TwitchChatMessage {
+  return {
+    id: "msg-1",
+    channel: "example",
+    userId: "1234",
+    username: "viewer_taro",
+    displayName: "viewer_taro",
+    color: null,
+    text: "gg chat",
+    isAction: false,
+    emotes: [],
+    badges: [],
+    timestampMs: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+/** テスト用の解説結果(「gg」をスラングとして解説した想定) */
+const サンプル解説: ExplanationResult = {
+  translation: "ナイスゲーム、チャットのみんな",
+  literal: "良いゲーム、チャット",
+  items: [{ term: "gg", kind: "abbreviation", meaning: "good game の略", note: "試合終了時の定番の挨拶" }],
+  difficulty: 2,
+};
+
+/** Prompt API が利用可能/不可能な環境診断結果 */
+function createDiagnosis(overallReady: boolean): EnvironmentDiagnosis {
+  return {
+    chromeVersion: 150,
+    meetsMinimumChromeVersion: true,
+    languageModel: overallReady
+      ? { supported: true, availability: "available" }
+      : { supported: false, availability: null },
+    languageDetector: { supported: false, availability: null },
+    storageEstimate: { quota: null, usage: null },
+    overallReady,
+  };
+}
+
+/** Deferred パターン: テストから任意のタイミングで resolve/reject できる Promise */
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/**
+ * テスト用の依存性一式を組み立てる。
+ * `pool.enqueue` は run にフェイクセッションを渡し、prompt の結果は `promptResults` から順に取り出す
+ */
+function createDeps(options: { ready?: boolean; promptResults?: Array<Promise<string>> } = {}) {
+  let messages: TwitchChatMessage[] = [];
+  const promptResults = [...(options.promptResults ?? [])];
+
+  const enqueue = vi.fn(async (_priority: "high" | "low", run: (session: unknown) => Promise<string>) => {
+    const next = promptResults.shift();
+    if (!next) throw new Error("テストの promptResults が不足しています");
+    return run({ prompt: () => next });
+  });
+  const pool = { enqueue, warmUp: vi.fn(async () => {}) } as unknown as SessionPool;
+
+  const deps: ExplanationPipelineDeps = {
+    diagnose: vi.fn(async () => createDiagnosis(options.ready ?? true)),
+    loadSettings: () => ({ targetLang: "en", explainLang: "ja" }),
+    createPool: vi.fn(() => pool),
+    getMessages: () => messages,
+  };
+
+  function setMessages(next: TwitchChatMessage[]) {
+    messages = next;
+  }
+
+  return { deps, setMessages, enqueue };
+}
+
+/** 非同期の状態更新(診断 → 投入 → 完了)が落ち着くまでマイクロタスクをフラッシュする */
+async function flush(times = 10) {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+afterEach(() => {
+  resetExplanationStoreForTests();
+});
+
+describe("startExplanationPipeline", () => {
+  it("開始直後は Prompt API の状態が checking で、診断が成功すると ready になる", async () => {
+    const { deps } = createDeps({ ready: true });
+
+    startExplanationPipeline(deps);
+    expect(useExplanationStore.getState().promptApi).toEqual({ status: "checking" });
+
+    await flush();
+    expect(useExplanationStore.getState().promptApi).toEqual({ status: "ready" });
+  });
+
+  it("診断で Prompt API が使えない場合は理由付きで unavailable にする", async () => {
+    const { deps } = createDeps({ ready: false });
+
+    startExplanationPipeline(deps);
+    await flush();
+
+    const promptApi = useExplanationStore.getState().promptApi;
+    expect(promptApi.status).toBe("unavailable");
+    if (promptApi.status === "unavailable") expect(promptApi.reason).toContain("Prompt API");
+  });
+
+  it("診断そのものが失敗した場合も理由付きで unavailable にする", async () => {
+    const { deps } = createDeps();
+    deps.diagnose = vi.fn(async () => {
+      throw new Error("navigator が見つかりません");
+    });
+
+    startExplanationPipeline(deps);
+    await flush();
+
+    expect(useExplanationStore.getState().promptApi).toEqual({
+      status: "unavailable",
+      reason: "環境診断に失敗しました: navigator が見つかりません",
+    });
+  });
+});
+
+describe("requestExplanation", () => {
+  it("要求した発言を high 優先度で解説ジョブに積み、完了したら発言 ID に紐づけて結果を保持する", async () => {
+    const { deps, setMessages, enqueue } = createDeps({
+      promptResults: [Promise.resolve(JSON.stringify(サンプル解説))],
+    });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    await flush();
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    expect(enqueue.mock.calls[0][0]).toBe("high");
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "done", result: サンプル解説 });
+  });
+
+  it("解説ジョブが完了するまでは pending として保持する", async () => {
+    const deferred = createDeferred<string>();
+    const { deps, setMessages } = createDeps({ promptResults: [deferred.promise] });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    await flush();
+
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "pending" });
+
+    deferred.resolve(JSON.stringify(サンプル解説));
+    await flush();
+    expect(useExplanationStore.getState().entries["msg-1"]?.status).toBe("done");
+  });
+
+  it("解説ジョブが失敗した場合は理由付きで failed として保持する(暗黙のフォールバックはしない)", async () => {
+    const { deps, setMessages } = createDeps({ promptResults: [Promise.resolve("これはJSONではない")] });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    await flush();
+
+    const entry = useExplanationStore.getState().entries["msg-1"];
+    expect(entry?.status).toBe("failed");
+    if (entry?.status === "failed") expect(entry.reason).toContain("JSONとして解釈できませんでした");
+  });
+
+  it("生成中の発言を再度要求しても二重には投入しない", async () => {
+    const deferred = createDeferred<string>();
+    const { deps, setMessages, enqueue } = createDeps({ promptResults: [deferred.promise] });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    requestExplanation(message);
+    await flush();
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("完了済みの発言を再度要求しても再生成しない", async () => {
+    const { deps, setMessages, enqueue } = createDeps({
+      promptResults: [Promise.resolve(JSON.stringify(サンプル解説))],
+    });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    await flush();
+    requestExplanation(message);
+    await flush();
+
+    expect(enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("失敗した発言を再度要求すると再試行する", async () => {
+    const { deps, setMessages, enqueue } = createDeps({
+      promptResults: [Promise.resolve("壊れた応答"), Promise.resolve(JSON.stringify(サンプル解説))],
+    });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    await flush();
+    expect(useExplanationStore.getState().entries["msg-1"]?.status).toBe("failed");
+
+    requestExplanation(message);
+    await flush();
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    expect(useExplanationStore.getState().entries["msg-1"]?.status).toBe("done");
+  });
+
+  it("生成中に別の発言を要求した場合は前のジョブを中断せず、順に積んで両方の結果を保持する", async () => {
+    const first = createDeferred<string>();
+    const second = createDeferred<string>();
+    const { deps, setMessages, enqueue } = createDeps({ promptResults: [first.promise, second.promise] });
+    const message1 = createMessage({ id: "msg-1" });
+    const message2 = createMessage({ id: "msg-2", text: "this is so real" });
+    setMessages([message1, message2]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message1);
+    requestExplanation(message2);
+    await flush();
+
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "pending" });
+    expect(useExplanationStore.getState().entries["msg-2"]).toEqual({ status: "pending" });
+
+    first.resolve(JSON.stringify(サンプル解説));
+    second.resolve(JSON.stringify({ ...サンプル解説, translation: "これはマジでそう" }));
+    await flush();
+
+    expect(useExplanationStore.getState().entries["msg-1"]?.status).toBe("done");
+    expect(useExplanationStore.getState().entries["msg-2"]?.status).toBe("done");
+  });
+
+  it("Prompt API が利用できない環境で要求した発言は unavailable として保持し、ジョブは投入しない", async () => {
+    const { deps, setMessages, enqueue } = createDeps({ ready: false });
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message);
+    await flush();
+
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "unavailable" });
+  });
+
+  it("診断が終わる前に要求した発言も unavailable として保持し、ジョブは投入しない", async () => {
+    const { deps, setMessages, enqueue } = createDeps();
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    startExplanationPipeline(deps);
+
+    requestExplanation(message);
+
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(useExplanationStore.getState().entries["msg-1"]).toEqual({ status: "unavailable" });
+  });
+
+  it("ID を持たない発言は解説結果を紐づけられないため投入しない", async () => {
+    const { deps, enqueue } = createDeps();
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(createMessage({ id: null }));
+    await flush();
+
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(useExplanationStore.getState().entries).toEqual({});
+  });
+
+  it("表示用リングバッファから消えた発言の解説結果は、次の要求時に破棄する", async () => {
+    const { deps, setMessages } = createDeps({
+      promptResults: [
+        Promise.resolve(JSON.stringify(サンプル解説)),
+        Promise.resolve(JSON.stringify(サンプル解説)),
+      ],
+    });
+    const message1 = createMessage({ id: "msg-1" });
+    const message2 = createMessage({ id: "msg-2" });
+    setMessages([message1, message2]);
+    startExplanationPipeline(deps);
+    await flush();
+
+    requestExplanation(message1);
+    await flush();
+    expect(useExplanationStore.getState().entries["msg-1"]?.status).toBe("done");
+
+    // リングバッファから msg-1 が押し出された後に msg-2 を要求する
+    setMessages([message2]);
+    requestExplanation(message2);
+    await flush();
+
+    expect(useExplanationStore.getState().entries["msg-1"]).toBeUndefined();
+    expect(useExplanationStore.getState().entries["msg-2"]?.status).toBe("done");
+  });
+
+  it("設定の言語ペアでセッションプールを、最初の要求時に一度だけ生成する", async () => {
+    const { deps, setMessages } = createDeps({
+      promptResults: [
+        Promise.resolve(JSON.stringify(サンプル解説)),
+        Promise.resolve(JSON.stringify(サンプル解説)),
+      ],
+    });
+    const message1 = createMessage({ id: "msg-1" });
+    const message2 = createMessage({ id: "msg-2" });
+    setMessages([message1, message2]);
+    startExplanationPipeline(deps);
+    await flush();
+    expect(deps.createPool).not.toHaveBeenCalled();
+
+    requestExplanation(message1);
+    requestExplanation(message2);
+    await flush();
+
+    expect(deps.createPool).toHaveBeenCalledTimes(1);
+    expect(deps.createPool).toHaveBeenCalledWith({ targetLang: "en", explainLang: "ja" });
+  });
+
+  it("停止後に要求してもジョブを投入しない", async () => {
+    const { deps, setMessages, enqueue } = createDeps();
+    const message = createMessage({ id: "msg-1" });
+    setMessages([message]);
+    const stop = startExplanationPipeline(deps);
+    await flush();
+
+    stop();
+    requestExplanation(message);
+    await flush();
+
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("パイプラインが開始されていない状態で要求しても何もしない", () => {
+    requestExplanation(createMessage({ id: "msg-1" }));
+
+    expect(useExplanationStore.getState().entries).toEqual({});
+  });
+});

--- a/src/store/explanations.ts
+++ b/src/store/explanations.ts
@@ -1,0 +1,184 @@
+/**
+ * 右列「解説」の状態を保持するモジュールスコープのストアと、利用者の要求に応じて
+ * 発言の解説を生成するパイプライン。
+ *
+ * - 翻訳列(translations.ts)と異なり、解説は全発言に対して生成せず、利用者が
+ *   `requestExplanation` で明示的に要求した発言だけを `SessionPool` の高優先度ジョブとして積む
+ * - 解説結果は発言 ID(`TwitchChatMessage.id`)をキーに保持し、ページ側は
+ *   左列と同じ発言順で `entries[id]` を引いて描画する
+ * - 生成中に別の発言を要求した場合、前のジョブは中断せず順に積む(FIFO)。
+ *   同じ発言を生成中・完了済みに再要求しても二重には投入しない。失敗した発言は再要求で再試行する
+ * - セッションプールは翻訳用とは別に持つ(`translate.ts` に記載の issue #15 方針 (a))。
+ *   解説専用のシステムプロンプトを持つベースセッションを、最初の要求時に生成する。
+ *   要求は必ずボタンクリック(ユーザー操作)の延長で行われるため、モデル未ダウンロード時に
+ *   `LanguageModel.create()` が要求する user activation を満たし、翻訳列のようなウォームアップは不要
+ * - Prompt API が使えない環境では暗黙のフォールバックをせず、診断結果の理由を
+ *   `promptApi.reason` に保持して行ごとに「解説不可」を表示できるようにする
+ *
+ * `chat-connection.ts` と同様に、ページ遷移でホーム画面がアンマウントされても
+ * 解説結果を失わないよう、React ツリーの外(Zustand ストア)に状態を置く。
+ */
+import { create } from "zustand";
+import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
+import { describeDiagnosis } from "@/lib/ai/describeDiagnosis";
+import { createExplainBaseSessionFactory, explainChatMessage } from "@/lib/ai/explain";
+import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
+import type { ExplanationResult } from "@/lib/ai/schemas";
+import { createSessionPool, type SessionPool } from "@/lib/ai/session-pool";
+import { loadSettings, type Settings } from "@/lib/settings";
+import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+import { useChatConnectionStore } from "./chat-connection";
+import type { PromptApiStatus } from "./translations";
+
+/** 発言1件ぶんの解説の状態。要求されていない発言はエントリ自体を持たない */
+export type ExplanationEntry =
+  | { status: "pending" }
+  | { status: "done"; result: ExplanationResult }
+  | { status: "failed"; reason: string }
+  /** Prompt API が利用できない(または診断未完了の)状態で要求された */
+  | { status: "unavailable" };
+
+interface ExplanationState {
+  promptApi: PromptApiStatus;
+  /** 発言 ID → 解説の状態 */
+  entries: Record<string, ExplanationEntry>;
+}
+
+export const useExplanationStore = create<ExplanationState>(() => ({
+  promptApi: { status: "checking" },
+  entries: {},
+}));
+
+/** パイプラインが依存する外部処理。テストではすべてフェイクを注入する */
+export interface ExplanationPipelineDeps {
+  diagnose: () => Promise<EnvironmentDiagnosis>;
+  loadSettings: () => Settings;
+  createPool: (settings: Settings) => SessionPool;
+  /** 表示用リングバッファに現在残っている発言。ここから消えた発言の解説結果を破棄する */
+  getMessages: () => TwitchChatMessage[];
+}
+
+/** 現在動作中のパイプラインが公開する操作。`startExplanationPipeline` が設定し、停止時に外す */
+interface ActivePipeline {
+  request: (message: TwitchChatMessage) => void;
+}
+
+let activePipeline: ActivePipeline | null = null;
+
+const DEFAULT_DEPS: ExplanationPipelineDeps = {
+  diagnose: runBrowserDiagnosis,
+  loadSettings: () => loadSettings().settings,
+  createPool: (settings) =>
+    createSessionPool({
+      createBaseSession: createExplainBaseSessionFactory(settings.targetLang, settings.explainLang),
+    }),
+  getMessages: () => useChatConnectionStore.getState().messages,
+};
+
+function setEntry(id: string, entry: ExplanationEntry): void {
+  useExplanationStore.setState((prev) => ({ entries: { ...prev.entries, [id]: entry } }));
+}
+
+/** 表示用リングバッファに残っていない発言の解説結果を捨て、メモリが際限なく増えないようにする */
+function pruneEntries(messages: TwitchChatMessage[]): void {
+  const liveIds = new Set(messages.map((message) => message.id));
+  useExplanationStore.setState((prev) => ({
+    entries: Object.fromEntries(Object.entries(prev.entries).filter(([id]) => liveIds.has(id))),
+  }));
+}
+
+/** 環境診断結果から、利用者に見せる「Prompt API が使えない理由」を取り出す */
+function describePromptApiUnavailableReason(diagnosis: EnvironmentDiagnosis): string {
+  const message = describeDiagnosis(diagnosis).find((item) => item.id === "language-model");
+  return message?.message ?? "Prompt API を利用できません。";
+}
+
+/**
+ * 解説パイプラインを開始する。環境診断を行い Prompt API の利用可否を確定させる。
+ * 戻り値の関数を呼ぶと以後の要求を受け付けなくなり、待機中のジョブを中断する。
+ * ホーム画面のマウント時に1回呼び出す想定。
+ */
+export function startExplanationPipeline(deps: ExplanationPipelineDeps = DEFAULT_DEPS): () => void {
+  const controller = new AbortController();
+  const settings = deps.loadSettings();
+  let pool: SessionPool | null = null;
+
+  useExplanationStore.setState({ promptApi: { status: "checking" } });
+
+  function getPool(): SessionPool {
+    pool ??= deps.createPool(settings);
+    return pool;
+  }
+
+  function explain(message: TwitchChatMessage, id: string): void {
+    setEntry(id, { status: "pending" });
+    explainChatMessage(getPool(), message.text, { priority: "high", signal: controller.signal })
+      .then((result) => setEntry(id, { status: "done", result }))
+      .catch((error: unknown) => {
+        if (controller.signal.aborted) return;
+        setEntry(id, { status: "failed", reason: error instanceof Error ? error.message : String(error) });
+      });
+  }
+
+  function request(message: TwitchChatMessage): void {
+    // 発言 ID が無いと解説結果を行に紐づけられないため投入しない(ページ側で「IDなし」と明示する)
+    if (message.id === null) return;
+    pruneEntries(deps.getMessages());
+
+    if (useExplanationStore.getState().promptApi.status !== "ready") {
+      setEntry(message.id, { status: "unavailable" });
+      return;
+    }
+
+    // 生成中・完了済みの発言は再投入しない(失敗した発言のみ再試行を許す)
+    const current = useExplanationStore.getState().entries[message.id];
+    if (current?.status === "pending" || current?.status === "done") return;
+
+    explain(message, message.id);
+  }
+
+  void deps
+    .diagnose()
+    .then((diagnosis) => {
+      if (controller.signal.aborted) return;
+      useExplanationStore.setState({
+        promptApi: diagnosis.overallReady
+          ? { status: "ready" }
+          : { status: "unavailable", reason: describePromptApiUnavailableReason(diagnosis) },
+      });
+    })
+    .catch((error: unknown) => {
+      if (controller.signal.aborted) return;
+      useExplanationStore.setState({
+        promptApi: {
+          status: "unavailable",
+          reason: `環境診断に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+        },
+      });
+    });
+
+  const handle: ActivePipeline = { request };
+  activePipeline = handle;
+
+  return () => {
+    controller.abort();
+    if (activePipeline === handle) activePipeline = null;
+  };
+}
+
+/**
+ * 発言の解説を要求する。「解説」ボタンのクリックハンドラから呼ぶこと
+ * (モデル未ダウンロード時の `LanguageModel.create()` にはユーザー操作が必要)。
+ * パイプラインが開始されていない場合は何もしない。
+ */
+export function requestExplanation(message: TwitchChatMessage): void {
+  activePipeline?.request(message);
+}
+
+/**
+ * テスト専用: ストアを初期状態に戻す。各テストの afterEach で呼び出すこと。
+ */
+export function resetExplanationStoreForTests(): void {
+  activePipeline = null;
+  useExplanationStore.setState({ promptApi: { status: "checking" }, entries: {} });
+}

--- a/src/store/explanations.ts
+++ b/src/store/explanations.ts
@@ -79,6 +79,13 @@ function setEntry(id: string, entry: ExplanationEntry): void {
   useExplanationStore.setState((prev) => ({ entries: { ...prev.entries, [id]: entry } }));
 }
 
+function removeEntries(ids: Iterable<string>): void {
+  const removing = new Set(ids);
+  useExplanationStore.setState((prev) => ({
+    entries: Object.fromEntries(Object.entries(prev.entries).filter(([id]) => !removing.has(id))),
+  }));
+}
+
 /** 表示用リングバッファに残っていない発言の解説結果を捨て、メモリが際限なく増えないようにする */
 function pruneEntries(messages: TwitchChatMessage[]): void {
   const liveIds = new Set(messages.map((message) => message.id));
@@ -95,13 +102,16 @@ function describePromptApiUnavailableReason(diagnosis: EnvironmentDiagnosis): st
 
 /**
  * 解説パイプラインを開始する。環境診断を行い Prompt API の利用可否を確定させる。
- * 戻り値の関数を呼ぶと以後の要求を受け付けなくなり、待機中のジョブを中断する。
+ * 戻り値の関数を呼ぶと以後の要求を受け付けなくなり、待機中のジョブを中断して
+ * 生成中(pending)だったエントリを取り除く。
  * ホーム画面のマウント時に1回呼び出す想定。
  */
 export function startExplanationPipeline(deps: ExplanationPipelineDeps = DEFAULT_DEPS): () => void {
   const controller = new AbortController();
   const settings = deps.loadSettings();
   let pool: SessionPool | null = null;
+  /** このパイプラインが投入して未決着のジョブの発言 ID。停止時に pending のまま残さないよう取り除く */
+  const pendingIds = new Set<string>();
 
   useExplanationStore.setState({ promptApi: { status: "checking" } });
 
@@ -112,12 +122,18 @@ export function startExplanationPipeline(deps: ExplanationPipelineDeps = DEFAULT
 
   function explain(message: TwitchChatMessage, id: string): void {
     setEntry(id, { status: "pending" });
+    pendingIds.add(id);
     explainChatMessage(getPool(), message.text, { priority: "high", signal: controller.signal })
-      .then((result) => setEntry(id, { status: "done", result }))
+      .then((result) => {
+        // 停止後に決着したジョブの結果は、再開後のパイプラインの状態を上書きしないよう捨てる
+        if (controller.signal.aborted) return;
+        setEntry(id, { status: "done", result });
+      })
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;
         setEntry(id, { status: "failed", reason: error instanceof Error ? error.message : String(error) });
-      });
+      })
+      .finally(() => pendingIds.delete(id));
   }
 
   function request(message: TwitchChatMessage): void {
@@ -162,6 +178,9 @@ export function startExplanationPipeline(deps: ExplanationPipelineDeps = DEFAULT
 
   return () => {
     controller.abort();
+    // 中断したジョブのエントリを pending のまま残さず取り除き、再開後に改めて要求できるようにする
+    removeEntries(pendingIds);
+    pendingIds.clear();
     if (activePipeline === handle) activePipeline = null;
   };
 }


### PR DESCRIPTION
## Summary

3カラム構成の右列「解説」を実装しました。翻訳列と異なり全発言には生成せず、利用者が各行の「解説」ボタンを押した発言だけを Gemini Nano(Prompt API)に解説させて対応する行に表示します。

### 設計判断

- **生成トリガー**: 候補 (b)「各行の『解説』ボタン」を採用。ボタンは解説列の各行に置き、ぼかし ON でも操作できるよう **完了した解説のある行だけをぼかす**(ボタン・状態表示はぼかさない)
- **セッションプール**: `translate.ts` に記載の issue #15 方針 (a) に従い翻訳用とは **別のプール**(解説専用システムプロンプト)を `explanations` ストアが持つ。要求は必ずクリックの延長で行われるため、翻訳列のようなウォームアップは不要
- **多重要求時の挙動**: 生成中に別の発言を要求した場合は **前のジョブを中断せず順に積む**(FIFO)。同じ発言の再要求は生成中・完了済みなら無視し、失敗時のみ再試行する
- **優先度**: `explainChatMessage` の既定どおり `priority: "high"` で投入
- **行の揃え方**: 翻訳列(PR #18)と同じ subgrid + 発言 ID の共通キー方式

### 変更内容

- `src/store/explanations.ts`(新規): 解説結果ストア + パイプライン。`runBrowserDiagnosis` による利用可否判定、`createExplainBaseSessionFactory` + 言語ペア設定でのプール生成、発言 ID 紐づけ、リングバッファから消えた発言の結果破棄、停止時の pending 除去
- `src/components/explanation-result-view.tsx`(新規): 訳・直訳・注目語句(分類は日本語ラベル)・難易度の表示。PR #14 で削除した `ExplanationResultView` を単語帳保存なしで再構成
- `src/app/page.tsx`: 解説列に「解説」ボタンと生成中・失敗(再試行ボタン付き)・Prompt API 利用不可(見出しに理由)・診断中・IDなしの各状態を表示

### 完了条件との対応

- [x] 各行の「解説」ボタンから要求し、結果が右列の対応する行に表示される
- [x] 既存の `explainChatMessage`(訳・直訳・注目語句・難易度)をそのまま使用
- [x] 生成中・失敗・Prompt API 利用不可の各状態を行ごとに明示
- [x] 「解説をぼかす」トグルは初期値 ON のまま
- [x] 生成中の別発言要求は「中断せず順に積む」と定めテストで固定

## Test plan

- [x] `npm test`(223 件パス)/ `npm run type-check` / `npm run lint` / `npm run build`
- [x] CodeRabbit レビュー(指摘1件: 停止時の pending 残留 → 対応済み)
- [ ] Chrome(Prompt API 有効)で実チャンネルに接続し、「解説」ボタン → 解説表示・ぼかし解除・再試行を手動確認

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH