### PR TITLE
feat: Pick up — emote 名・@メンション・URL を送信前に除き、返ってきた語句からも決定的に除外する (#26)

### DIFF
--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -102,6 +102,26 @@ describe("filterPickupTerms", () => {
     expect(filterPickupTerms(terms, 前処理済み)).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
   });
 
+  it("! で始まる語句(チャットコマンド)を落とす", () => {
+    const terms = [
+      { term: "!chimkin", meaning: "鶏肉のミーム" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, 前処理済み)).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
+  });
+
+  it("追加で指定した除外名(表示中の発言者名など)と一致する語句を落とす(大文字小文字は区別しない)", () => {
+    const terms = [
+      { term: "space_toilet_master", meaning: "配信の常連" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, 前処理済み, ["Space_Toilet_Master"])).toEqual([
+      { term: "sticky", meaning: "スタン状態にする" },
+    ]);
+  });
+
   it("落とす対象が無ければ元の配列と同じ内容を返す", () => {
     const terms = [{ term: "sticky", meaning: "スタン状態にする" }];
 

--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -122,6 +122,20 @@ describe("filterPickupTerms", () => {
     ]);
   });
 
+  it("同じ語句が複数回返ってきた場合は最初の1件だけ残す(大文字小文字は区別しない)", () => {
+    const terms = [
+      { term: "sayuwuKuru", meaning: "意味不明な文字列" },
+      { term: "sayuwukuru", meaning: "繰り返される" },
+      { term: "sticky", meaning: "スタン状態にする" },
+      { term: "sayuwuKuru", meaning: "意味不明な文字列" },
+    ];
+
+    expect(filterPickupTerms(terms, { text: "sayuwuKuru sticky", emoteNames: [], mentionNames: [] })).toEqual([
+      { term: "sayuwuKuru", meaning: "意味不明な文字列" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ]);
+  });
+
   it("落とす対象が無ければ元の配列と同じ内容を返す", () => {
     const terms = [{ term: "sticky", meaning: "スタン状態にする" }];
 

--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -1,0 +1,110 @@
+/**
+ * src/lib/ai/pickup-filter.ts のテスト。
+ *
+ * Pick up の前後に置く決定的(LLM を使わない)処理を検証する(issue #26)。
+ * - `preparePickupInput`: emote・@メンション・URL を本文から除き、LLM に渡す本文を組み立てる
+ * - `filterPickupTerms`: LLM が返した語句のうち emote 名・@メンション・文字を含まない語句を落とす
+ */
+import { describe, expect, it } from "vitest";
+import { filterPickupTerms, preparePickupInput } from "./pickup-filter";
+import type { EmotePosition } from "@/lib/twitch/irc-parser";
+
+describe("preparePickupInput", () => {
+  it("emote が無く特殊なトークンも無い本文はそのまま返す", () => {
+    const prepared = preparePickupInput("bro is cooked lmao", []);
+
+    expect(prepared).toEqual({ text: "bro is cooked lmao", emoteNames: [], mentionNames: [] });
+  });
+
+  it("emotes タグの位置にある emote 名を本文から除き、除いた emote 名を保持する", () => {
+    // "xqcPeepo DID THAT NOT STICKY HIM" の xqcPeepo(0-7文字目)が emote
+    const emotes: EmotePosition[] = [{ id: "emotesv2_1", start: 0, end: 7 }];
+
+    const prepared = preparePickupInput("xqcPeepo DID THAT NOT STICKY HIM", emotes);
+
+    expect(prepared.text).toBe("DID THAT NOT STICKY HIM");
+    expect(prepared.emoteNames).toEqual(["xqcPeepo"]);
+  });
+
+  it("同じ emote が複数回登場しても emote 名は重複なく保持する", () => {
+    const emotes: EmotePosition[] = [
+      { id: "25", start: 0, end: 4 },
+      { id: "25", start: 10, end: 14 },
+    ];
+
+    const prepared = preparePickupInput("Kappa lol Kappa", emotes);
+
+    expect(prepared.text).toBe("lol");
+    expect(prepared.emoteNames).toEqual(["Kappa"]);
+  });
+
+  it("emote だけの発言は本文が空文字列になる", () => {
+    const emotes: EmotePosition[] = [{ id: "25", start: 0, end: 4 }];
+
+    const prepared = preparePickupInput("Kappa", emotes);
+
+    expect(prepared.text).toBe("");
+    expect(prepared.emoteNames).toEqual(["Kappa"]);
+  });
+
+  it("@メンションを本文から除き、@ を外したユーザー名を保持する", () => {
+    const prepared = preparePickupInput("@AUBREY that was a W", []);
+
+    expect(prepared.text).toBe("that was a W");
+    expect(prepared.mentionNames).toEqual(["AUBREY"]);
+  });
+
+  it("URL を本文から除く", () => {
+    const prepared = preparePickupInput("check this https://example.com/clip lol", []);
+
+    expect(prepared.text).toBe("check this lol");
+  });
+
+  it("除去によって生じた連続する空白は1つにまとめ、前後の空白を落とす", () => {
+    const emotes: EmotePosition[] = [{ id: "25", start: 4, end: 8 }];
+
+    const prepared = preparePickupInput("gg  Kappa  chat ", emotes);
+
+    expect(prepared.text).toBe("gg chat");
+  });
+});
+
+describe("filterPickupTerms", () => {
+  const 前処理済み = { text: "DID THAT NOT STICKY HIM", emoteNames: ["xqcPeepo"], mentionNames: ["AUBREY"] };
+
+  it("emote 名と一致する語句を落とす(大文字小文字は区別しない)", () => {
+    const terms = [
+      { term: "xqcpeepo", meaning: "特定の配信者関連の絵文字" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, 前処理済み)).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
+  });
+
+  it("@ で始まる語句と、@メンションのユーザー名と一致する語句を落とす", () => {
+    const terms = [
+      { term: "@AUBREY", meaning: "特定の視聴者への呼称" },
+      { term: "aubrey", meaning: "特定の視聴者への呼称" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, 前処理済み)).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
+  });
+
+  it("文字を1つも含まない語句(数字や記号だけ)を落とす", () => {
+    const terms = [
+      { term: "67", meaning: "日付や時間を示す可能性" },
+      { term: "10:30", meaning: "時刻" },
+      { term: "???", meaning: "困惑" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, 前処理済み)).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
+  });
+
+  it("落とす対象が無ければ元の配列と同じ内容を返す", () => {
+    const terms = [{ term: "sticky", meaning: "スタン状態にする" }];
+
+    expect(filterPickupTerms(terms, 前処理済み)).toEqual(terms);
+  });
+});

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -8,7 +8,8 @@
  * - `preparePickupInput`: 送信前の足切り。emote・@メンション・URL を本文から除き、
  *   LLM に渡す本文と、後段フィルタで照合するための emote 名・メンション名を返す
  * - `filterPickupTerms`: 後段フィルタ。返ってきた語句のうち emote 名・@メンション・
- *   文字を1つも含まない語句(数字や記号だけ)を落とす
+ *   `!` で始まるチャットコマンド・文字を1つも含まない語句(数字や記号だけ)・
+ *   呼び出し側が指定した除外名(表示中の発言者名など)を落とす
  *
  * 翻訳列は「emote 名はそのまま残す」設計のため、この処理は Pick up 専用である。
  */
@@ -68,14 +69,21 @@ export function preparePickupInput(text: string, emotes: EmotePosition[]): Prepa
 /**
  * LLM が返した語句から、決定的に「注目の表現ではない」と判別できるものを落とす。
  * 照合は大文字小文字を区別しない(`pickup.ts` の原文照合と同じ基準)。
+ *
+ * @param extraExcludedNames 呼び出し側が追加で除外したい名前(表示中の発言者名など)
  */
-export function filterPickupTerms(terms: PickupTerm[], prepared: PreparedPickupInput): PickupTerm[] {
+export function filterPickupTerms(
+  terms: PickupTerm[],
+  prepared: PreparedPickupInput,
+  extraExcludedNames: string[] = [],
+): PickupTerm[] {
   const excludedNames = new Set(
-    [...prepared.emoteNames, ...prepared.mentionNames].map((name) => name.toLowerCase()),
+    [...prepared.emoteNames, ...prepared.mentionNames, ...extraExcludedNames].map((name) => name.toLowerCase()),
   );
   return terms.filter((item) => {
     const normalized = item.term.trim().toLowerCase();
-    if (normalized.startsWith("@")) return false;
+    // @メンションと、`!chimkin` のようなチャットコマンドは学ぶべき表現ではない
+    if (normalized.startsWith("@") || normalized.startsWith("!")) return false;
     if (excludedNames.has(normalized)) return false;
     if (NO_LETTER_PATTERN.test(normalized)) return false;
     return true;

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -1,0 +1,83 @@
+/**
+ * Pick up(注目の表現の抽出)の前後に置く、LLM を使わない決定的な処理(issue #26)。
+ *
+ * Gemini Nano はプロンプトで「emote 名・数字・@メンションは含めない」と指示しても
+ * それらを「特殊な表現」として返すことがある。emote の位置は Twitch IRC の `emotes` タグで
+ * 確定しているため、LLM に判断させず同じ入力なら必ず同じ結果になる処理で扱う。
+ *
+ * - `preparePickupInput`: 送信前の足切り。emote・@メンション・URL を本文から除き、
+ *   LLM に渡す本文と、後段フィルタで照合するための emote 名・メンション名を返す
+ * - `filterPickupTerms`: 後段フィルタ。返ってきた語句のうち emote 名・@メンション・
+ *   文字を1つも含まない語句(数字や記号だけ)を落とす
+ *
+ * 翻訳列は「emote 名はそのまま残す」設計のため、この処理は Pick up 専用である。
+ */
+import { splitMessageIntoSegments } from "@/lib/twitch/emotes";
+import type { EmotePosition } from "@/lib/twitch/irc-parser";
+import type { PickupTerm } from "./schemas";
+
+/** `preparePickupInput` の結果。LLM に渡す本文と、後段フィルタの照合に使う情報 */
+export interface PreparedPickupInput {
+  /** LLM に渡す本文。emote・@メンション・URL を除き、連続する空白を1つにまとめた文字列 */
+  text: string;
+  /** 本文から除いた emote 名(重複なし) */
+  emoteNames: string[];
+  /** 本文から除いた @メンションのユーザー名(@ を外したもの、重複なし) */
+  mentionNames: string[];
+}
+
+/** `@username` 形式のメンション。Twitch のユーザー名は英数字とアンダースコアのみ */
+const MENTION_PATTERN = /@(\w+)/g;
+/** http(s) で始まる URL。空白までを1つの URL とみなす */
+const URL_PATTERN = /https?:\/\/\S+/g;
+/** 文字(どの言語の文字でもよい)を1つも含まない語句にマッチする */
+const NO_LETTER_PATTERN = /^[^\p{L}]*$/u;
+
+/**
+ * チャット本文から Pick up の対象にならないトークンを除き、LLM に渡す本文を組み立てる。
+ * emote だけの発言では `text` が空文字列になる(呼び出し側は LLM を呼ばずに済ませられる)。
+ */
+export function preparePickupInput(text: string, emotes: EmotePosition[]): PreparedPickupInput {
+  const emoteNames = new Set<string>();
+  const textWithoutEmotes = splitMessageIntoSegments(text, emotes)
+    .map((segment) => {
+      if (segment.type === "emote") {
+        emoteNames.add(segment.text);
+        // 前後の語が連結しないよう、emote の位置は空白に置き換える
+        return " ";
+      }
+      return segment.text;
+    })
+    .join("");
+
+  const mentionNames = new Set<string>();
+  const stripped = textWithoutEmotes
+    .replace(MENTION_PATTERN, (_match, name: string) => {
+      mentionNames.add(name);
+      return " ";
+    })
+    .replace(URL_PATTERN, " ");
+
+  return {
+    text: stripped.replace(/\s+/g, " ").trim(),
+    emoteNames: [...emoteNames],
+    mentionNames: [...mentionNames],
+  };
+}
+
+/**
+ * LLM が返した語句から、決定的に「注目の表現ではない」と判別できるものを落とす。
+ * 照合は大文字小文字を区別しない(`pickup.ts` の原文照合と同じ基準)。
+ */
+export function filterPickupTerms(terms: PickupTerm[], prepared: PreparedPickupInput): PickupTerm[] {
+  const excludedNames = new Set(
+    [...prepared.emoteNames, ...prepared.mentionNames].map((name) => name.toLowerCase()),
+  );
+  return terms.filter((item) => {
+    const normalized = item.term.trim().toLowerCase();
+    if (normalized.startsWith("@")) return false;
+    if (excludedNames.has(normalized)) return false;
+    if (NO_LETTER_PATTERN.test(normalized)) return false;
+    return true;
+  });
+}

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -9,7 +9,7 @@
  *   LLM に渡す本文と、後段フィルタで照合するための emote 名・メンション名を返す
  * - `filterPickupTerms`: 後段フィルタ。返ってきた語句のうち emote 名・@メンション・
  *   `!` で始まるチャットコマンド・文字を1つも含まない語句(数字や記号だけ)・
- *   呼び出し側が指定した除外名(表示中の発言者名など)を落とす
+ *   呼び出し側が指定した除外名(表示中の発言者名など)を落とし、重複する語句は1件にまとめる
  *
  * 翻訳列は「emote 名はそのまま残す」設計のため、この処理は Pick up 専用である。
  */
@@ -80,12 +80,16 @@ export function filterPickupTerms(
   const excludedNames = new Set(
     [...prepared.emoteNames, ...prepared.mentionNames, ...extraExcludedNames].map((name) => name.toLowerCase()),
   );
+  /** 既に残した語句(小文字化済み)。同じ語句が繰り返し返ってきても最初の1件だけ残す */
+  const seen = new Set<string>();
   return terms.filter((item) => {
     const normalized = item.term.trim().toLowerCase();
     // @メンションと、`!chimkin` のようなチャットコマンドは学ぶべき表現ではない
     if (normalized.startsWith("@") || normalized.startsWith("!")) return false;
     if (excludedNames.has(normalized)) return false;
     if (NO_LETTER_PATTERN.test(normalized)) return false;
+    if (seen.has(normalized)) return false;
+    seen.add(normalized);
     return true;
   });
 }

--- a/src/lib/ai/pickup.test.ts
+++ b/src/lib/ai/pickup.test.ts
@@ -96,6 +96,58 @@ describe("pickUpExpressions(原文との照合)", () => {
   });
 });
 
+describe("pickUpExpressions(決定的な足切りと後段フィルタ、issue #26)", () => {
+  it("emote だけの発言は LLM を呼ばずに terms が空の結果を返す", async () => {
+    const pool = createFakeSessionPool(JSON.stringify({ terms: [{ term: "Kappa", meaning: "皮肉" }] }));
+
+    const result = await pickUpExpressions(pool, "Kappa", { emotes: [{ id: "25", start: 0, end: 4 }] });
+
+    expect(result).toEqual({ terms: [] });
+    expect(pool.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("emote・@メンション・URL を除いた本文をユーザープロンプトに渡す", async () => {
+    const pool = createFakeSessionPool(JSON.stringify({ terms: [] }));
+
+    await pickUpExpressions(pool, "xqcPeepo @AUBREY DID THAT https://example.com/clip", {
+      emotes: [{ id: "emotesv2_1", start: 0, end: 7 }],
+    });
+
+    const [userPrompt] = pool.prompt.mock.calls[0] as unknown as [string];
+    expect(userPrompt).toContain("DID THAT");
+    expect(userPrompt).not.toContain("xqcPeepo");
+    expect(userPrompt).not.toContain("@AUBREY");
+    expect(userPrompt).not.toContain("https://example.com/clip");
+  });
+
+  it("モデルが emote 名・@メンション・数字だけの語句を返しても、エラーにせず結果から落とす", async () => {
+    const pool = createFakeSessionPool(
+      JSON.stringify({
+        terms: [
+          { term: "xqcPeepo", meaning: "配信者関連の絵文字" },
+          { term: "@AUBREY", meaning: "視聴者への呼称" },
+          { term: "67", meaning: "数字のミーム" },
+          { term: "sticky", meaning: "スタン状態にする" },
+        ],
+      }),
+    );
+
+    const result = await pickUpExpressions(pool, "xqcPeepo @AUBREY 67 sticky", {
+      emotes: [{ id: "emotesv2_1", start: 0, end: 7 }],
+    });
+
+    expect(result.terms).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
+  });
+
+  it("emotes を省略した場合は emote 除去を行わず、本文をそのまま渡す", async () => {
+    const pool = createFakeSessionPool(JSON.stringify({ terms: [] }));
+
+    await pickUpExpressions(pool, "Kappa lol");
+
+    expect(pool.prompt).toHaveBeenCalledWith(expect.stringContaining("Kappa lol"), expect.anything());
+  });
+});
+
 describe("createPickupBaseSessionFactory", () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/src/lib/ai/pickup.test.ts
+++ b/src/lib/ai/pickup.test.ts
@@ -139,6 +139,23 @@ describe("pickUpExpressions(決定的な足切りと後段フィルタ、issue #
     expect(result.terms).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
   });
 
+  it("excludedNames に指定した発言者名を、モデルが語句として返しても結果から落とす", async () => {
+    const pool = createFakeSessionPool(
+      JSON.stringify({
+        terms: [
+          { term: "space_toilet_master", meaning: "配信の常連" },
+          { term: "sticky", meaning: "スタン状態にする" },
+        ],
+      }),
+    );
+
+    const result = await pickUpExpressions(pool, "Welcome back space_toilet_master! sticky", {
+      excludedNames: ["space_toilet_master"],
+    });
+
+    expect(result.terms).toEqual([{ term: "sticky", meaning: "スタン状態にする" }]);
+  });
+
   it("emotes を省略した場合は emote 除去を行わず、本文をそのまま渡す", async () => {
     const pool = createFakeSessionPool(JSON.stringify({ terms: [] }));
 

--- a/src/lib/ai/pickup.ts
+++ b/src/lib/ai/pickup.ts
@@ -26,6 +26,8 @@ export interface PickupOptions {
   signal?: AbortSignal;
   /** Twitch IRC の `emotes` タグから得た emote の位置。省略時は emote の除去を行わない */
   emotes?: EmotePosition[];
+  /** 結果から落とす名前(表示中の発言者名など)。@ 無しで本文に書かれたユーザー名は LLM が語句として返しやすい */
+  excludedNames?: string[];
 }
 
 /**
@@ -61,7 +63,7 @@ export async function pickUpExpressions(
     throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした: ${raw}`, { cause: error });
   }
 
-  const terms = filterPickupTerms(pickupSchema.parse(parsed).terms, prepared);
+  const terms = filterPickupTerms(pickupSchema.parse(parsed).terms, prepared, options.excludedNames ?? []);
   const normalizedText = prepared.text.toLowerCase();
   const unknownTerm = terms.find((term) => !normalizedText.includes(term.term.toLowerCase()));
   if (unknownTerm) {

--- a/src/lib/ai/pickup.ts
+++ b/src/lib/ai/pickup.ts
@@ -4,14 +4,18 @@
  *
  * `translate.ts` と同じ構造で、Pick up 専用のプロンプト・スキーマを使う。
  *
- * - `pickUpExpressions`: `SessionPool` にジョブを積み、返ってきたJSON文字列を
- *   `pickupSchema` で検証し、さらに各語句が原文に登場することを照合してから返す
- *   (モデルが解説言語の語や言い換えを「原文の語句」として返した応答は失敗として扱う)。
- *   自由文をパースする脆い処理は行わない。
+ * - `pickUpExpressions`: `pickup-filter.ts` で emote・@メンション・URL を除いた本文を
+ *   `SessionPool` のジョブに積み、返ってきたJSON文字列を `pickupSchema` で検証し、
+ *   emote 名などの決定的に除外できる語句を落としたうえで、各語句が LLM に渡した本文に
+ *   登場することを照合してから返す(モデルが解説言語の語や言い換えを「原文の語句」として
+ *   返した応答は失敗として扱う)。自由文をパースする脆い処理は行わない。
+ *   emote だけの発言のように渡す本文が空になる場合は LLM を呼ばず、空の結果を返す(issue #26)。
  * - `createPickupBaseSessionFactory`: Pick up 専用のシステムプロンプトを持つ
  *   ベースセッションの生成関数を組み立てる。`session-pool.ts` はベースセッションを
  *   1つしか持たないため、翻訳用・解説用とはプールを分ける前提(issue #15 の方針 (a))。
  */
+import type { EmotePosition } from "@/lib/twitch/irc-parser";
+import { filterPickupTerms, preparePickupInput } from "./pickup-filter";
 import { buildPickupSystemPrompt, buildPickupUserPrompt, type SupportedLanguage } from "./prompts";
 import { buildPickupResponseConstraint, pickupSchema, type PickupResult } from "./schemas";
 import type { JobPriority, PromptSessionLike, SessionPool } from "./session-pool";
@@ -20,12 +24,14 @@ export interface PickupOptions {
   /** 抽出は受信した全発言を自動で処理するバックグラウンド生成のため、既定は low */
   priority?: JobPriority;
   signal?: AbortSignal;
+  /** Twitch IRC の `emotes` タグから得た emote の位置。省略時は emote の除去を行わない */
+  emotes?: EmotePosition[];
 }
 
 /**
  * チャット本文から注目の表現を抽出する。
  * Prompt API の応答は必ず JSON 文字列として返るため、`JSON.parse` → `pickupSchema.parse` →
- * 原文との照合の順で検証し、いずれかに失敗した場合はエラーを投げる。
+ * 決定的な後段フィルタ → 本文との照合の順で処理し、パース・照合に失敗した場合はエラーを投げる。
  * 照合は大文字小文字を区別しない(「W」を「w」として返す程度の揺れは原文の語句とみなす)。
  */
 export async function pickUpExpressions(
@@ -34,11 +40,15 @@ export async function pickUpExpressions(
   options: PickupOptions = {},
 ): Promise<PickupResult> {
   const priority = options.priority ?? "low";
+  const prepared = preparePickupInput(chatMessageText, options.emotes ?? []);
+  if (prepared.text === "") {
+    return { terms: [] };
+  }
 
   const raw = await sessionPool.enqueue(
     priority,
     (session) =>
-      session.prompt(buildPickupUserPrompt(chatMessageText), {
+      session.prompt(buildPickupUserPrompt(prepared.text), {
         responseConstraint: buildPickupResponseConstraint(),
       }),
     options.signal,
@@ -51,13 +61,13 @@ export async function pickUpExpressions(
     throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした: ${raw}`, { cause: error });
   }
 
-  const result = pickupSchema.parse(parsed);
-  const normalizedText = chatMessageText.toLowerCase();
-  const unknownTerm = result.terms.find((term) => !normalizedText.includes(term.term.toLowerCase()));
+  const terms = filterPickupTerms(pickupSchema.parse(parsed).terms, prepared);
+  const normalizedText = prepared.text.toLowerCase();
+  const unknownTerm = terms.find((term) => !normalizedText.includes(term.term.toLowerCase()));
   if (unknownTerm) {
     throw new Error(`Prompt APIが原文に登場しない語句を返しました: ${unknownTerm.term}`);
   }
-  return result;
+  return { terms };
 }
 
 /**

--- a/src/lib/twitch/emotes.test.ts
+++ b/src/lib/twitch/emotes.test.ts
@@ -66,4 +66,29 @@ describe("splitMessageIntoSegments", () => {
 
     expect(segments).toEqual([{ type: "emote", id: "25", text: "Kappa" }]);
   });
+
+  it("サロゲートペアの絵文字が前にあっても、コードポイント単位の位置から emote を正しく切り出す", () => {
+    // Twitch の emotes タグはコードポイント単位。"🌿 haddyHiya" は 🌿(1コードポイント・UTF-16では2単位)の後、
+    // 空白を挟んで 2-10 コードポイント目が emote
+    const emotes: EmotePosition[] = [{ id: "emotesv2_1", start: 2, end: 10 }];
+
+    const segments = splitMessageIntoSegments("🌿 haddyHiya", emotes);
+
+    expect(segments).toEqual([
+      { type: "text", text: "🌿 " },
+      { type: "emote", id: "emotesv2_1", text: "haddyHiya" },
+    ]);
+  });
+
+  it("絵文字が複数ある場合も、絵文字の数だけずれずに emote を切り出す", () => {
+    // "💻hugs💻 haddyHiya": 💻(0) h(1) u g s(4) 💻(5) 空白(6) haddyHiya(7-15)
+    const emotes: EmotePosition[] = [{ id: "emotesv2_1", start: 7, end: 15 }];
+
+    const segments = splitMessageIntoSegments("💻hugs💻 haddyHiya", emotes);
+
+    expect(segments).toEqual([
+      { type: "text", text: "💻hugs💻 " },
+      { type: "emote", id: "emotesv2_1", text: "haddyHiya" },
+    ]);
+  });
 });

--- a/src/lib/twitch/emotes.ts
+++ b/src/lib/twitch/emotes.ts
@@ -5,9 +5,10 @@
  * (1) 実際に読み込む画像CDN URL、(2) テキスト/画像が交互に並ぶ描画用セグメント
  * に変換する。ライブチャットUIはこのセグメント列をそのまま描画すればよい。
  *
- * 注意: emote の開始・終了位置は文字列の(UTF-16コードユニット単位の)インデックスであるため、
- * サロゲートペアとなる絵文字を本文中に含むメッセージでは位置がずれる可能性がある。
- * MVPでは英語圏チャンネルの一般的なメッセージを主対象とするため、簡易な文字列スライスで扱う。
+ * 注意: Twitch の emotes タグの開始・終了位置は Unicode コードポイント単位である。
+ * JavaScript の文字列インデックスは UTF-16 コードユニット単位のため、サロゲートペアとなる
+ * 絵文字(🌿 など)が emote より前にあると位置がずれる。`splitMessageIntoSegments` は
+ * コードポイント位置を UTF-16 位置に変換してから切り出す(issue #26 の実ブラウザ確認で発覚)。
  */
 import type { EmotePosition } from "./irc-parser";
 
@@ -45,6 +46,22 @@ export function buildEmoteImageUrl(emoteId: string, options: EmoteImageOptions =
 }
 
 /**
+ * コードポイント単位の位置を UTF-16 コードユニット単位の位置に変換する表を作る。
+ * `offsets[i]` はi番目のコードポイントの開始位置。末尾に文字列長を番兵として持ち、
+ * 範囲外の位置を引いても文字列末尾に丸められるようにする。
+ */
+function buildCodePointOffsets(text: string): number[] {
+  const offsets: number[] = [];
+  let offset = 0;
+  for (const codePoint of text) {
+    offsets.push(offset);
+    offset += codePoint.length;
+  }
+  offsets.push(text.length);
+  return offsets;
+}
+
+/**
  * メッセージ本文を、テキストセグメントとemoteセグメントが交互に並ぶ配列に分割する。
  * emote が無い場合はテキスト1件のみの配列を返す。
  */
@@ -55,16 +72,23 @@ export function splitMessageIntoSegments(text: string, emotes: EmotePosition[]):
 
   // タグの記載順が文字位置順とは限らないため、開始位置で並べ替えてから走査する
   const sortedEmotes = [...emotes].sort((a, b) => a.start - b.start);
+  const offsets = buildCodePointOffsets(text);
+  const lastIndex = offsets.length - 1;
+  /** コードポイント位置(inclusive の end も含む)を UTF-16 の開始位置に変換する */
+  const toUtf16 = (codePointIndex: number): number => offsets[Math.min(codePointIndex, lastIndex)];
 
   const segments: MessageSegment[] = [];
   let cursor = 0;
 
   for (const emote of sortedEmotes) {
-    if (emote.start > cursor) {
-      segments.push({ type: "text", text: text.slice(cursor, emote.start) });
+    const start = toUtf16(emote.start);
+    // end は inclusive なので、次のコードポイントの開始位置を exclusive な終端として使う
+    const end = toUtf16(emote.end + 1);
+    if (start > cursor) {
+      segments.push({ type: "text", text: text.slice(cursor, start) });
     }
-    segments.push({ type: "emote", id: emote.id, text: text.slice(emote.start, emote.end + 1) });
-    cursor = emote.end + 1;
+    segments.push({ type: "emote", id: emote.id, text: text.slice(start, end) });
+    cursor = end;
   }
 
   if (cursor < text.length) {

--- a/src/store/pickups.test.ts
+++ b/src/store/pickups.test.ts
@@ -165,6 +165,19 @@ describe("startPickupPipeline", () => {
     stop();
   });
 
+  it("emote だけの発言は LLM を呼ばずに terms が空の done として保持する(issue #26)", async () => {
+    const { deps, emit, enqueue } = createDeps();
+
+    const stop = startPickupPipeline(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "Kappa", emotes: [{ id: "25", start: 0, end: 4 }] }));
+    await flush();
+
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({ status: "done", terms: [] });
+    stop();
+  });
+
   it("抽出ジョブが完了するまでは pending として保持する", async () => {
     const deferred = createDeferred<string>();
     const { deps, emit } = createDeps({ promptResults: [deferred.promise] });

--- a/src/store/pickups.test.ts
+++ b/src/store/pickups.test.ts
@@ -178,6 +178,34 @@ describe("startPickupPipeline", () => {
     stop();
   });
 
+  it("表示中の発言者名(username / displayName)を除外名として渡し、モデルが返しても結果から落とす(issue #26)", async () => {
+    const { deps, emit, setMessages } = createDeps({
+      promptResults: [
+        Promise.resolve(
+          JSON.stringify({
+            terms: [
+              { term: "space_toilet_master", meaning: "配信の常連" },
+              { term: "gg", meaning: "good game の略" },
+            ],
+          }),
+        ),
+      ],
+    });
+    const stop = startPickupPipeline(deps);
+    await flush();
+    const 常連の発言 = createMessage({ id: "msg-0", username: "space_toilet_master", displayName: "Space_Toilet_Master" });
+    const 歓迎の発言 = createMessage({ id: "msg-1", text: "Welcome back space_toilet_master! gg" });
+    setMessages([常連の発言, 歓迎の発言]);
+    emit(歓迎の発言);
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "gg", meaning: "good game の略" }],
+    });
+    stop();
+  });
+
   it("抽出ジョブが完了するまでは pending として保持する", async () => {
     const deferred = createDeferred<string>();
     const { deps, emit } = createDeps({ promptResults: [deferred.promise] });

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -129,7 +129,7 @@ export function startPickupPipeline(deps: PickupPipelineDeps = DEFAULT_DEPS): ()
 
   function pickUp(message: TwitchChatMessage, id: string): void {
     setEntry(id, { status: "pending" });
-    pickUpExpressions(getPool(), message.text, { priority: "low", signal: controller.signal })
+    pickUpExpressions(getPool(), message.text, { priority: "low", signal: controller.signal, emotes: message.emotes })
       .then((result) => setEntry(id, { status: "done", terms: result.terms }))
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -127,9 +127,19 @@ export function startPickupPipeline(deps: PickupPipelineDeps = DEFAULT_DEPS): ()
     return pool;
   }
 
+  /** 表示中の発言者名(username / displayName)。@ 無しで本文に書かれたユーザー名を抽出結果から落とすために渡す */
+  function collectSpeakerNames(): string[] {
+    return deps.getMessages().flatMap((item) => [item.username, item.displayName]);
+  }
+
   function pickUp(message: TwitchChatMessage, id: string): void {
     setEntry(id, { status: "pending" });
-    pickUpExpressions(getPool(), message.text, { priority: "low", signal: controller.signal, emotes: message.emotes })
+    pickUpExpressions(getPool(), message.text, {
+      priority: "low",
+      signal: controller.signal,
+      emotes: message.emotes,
+      excludedNames: collectSpeakerNames(),
+    })
       .then((result) => setEntry(id, { status: "done", terms: result.terms }))
       .catch((error: unknown) => {
         if (controller.signal.aborted) return;


### PR DESCRIPTION
## 概要

Pick up 列で Gemini Nano が emote 名・普通の語・数字・@メンションを「特殊な表現」として返す過剰抽出(issue #26)に対し、LLM を使わない決定的な処理を前後に置きました。あわせて実ブラウザ確認で見つかった emote 位置ずれ(サロゲートペア絵文字)を修正しました。

## 変更内容

### 決定的な足切り・後段フィルタ(issue #26)
- **`src/lib/ai/pickup-filter.ts`(新設)**
  - `preparePickupInput(text, emotes)`: 送信前の足切り。`splitMessageIntoSegments` で emote セグメントを除き、さらに `@username` と `http(s)://` URL を除いた本文を組み立てる。除いた emote 名・メンション名を後段フィルタ用に返す
  - `filterPickupTerms(terms, prepared, extraExcludedNames)`: 後段フィルタ。emote 名・`@` 始まり・`!` 始まり(チャットコマンド)・メンション名・追加の除外名・文字を1つも含まない語句(数字や記号だけ)を落とす(大文字小文字は区別しない)
- **`src/lib/ai/pickup.ts`**: `pickUpExpressions` に `emotes` / `excludedNames` オプションを追加。足切り後の本文が空(emote だけの発言)なら LLM を呼ばず `{ terms: [] }` を返す。応答は `pickupSchema.parse` → 後段フィルタ → 本文との照合の順で処理する
- **`src/store/pickups.ts`**: `TwitchChatMessage.emotes` と、表示中の発言者名(`username` / `displayName`)を `pickUpExpressions` に渡す(`@` 無しで本文に書かれたユーザー名を落とすため)

### emote 位置ずれの修正
- **`src/lib/twitch/emotes.ts`**: Twitch の `emotes` タグはコードポイント単位だが、`splitMessageIntoSegments` が UTF-16 単位で `slice` していたため、🌿 や 💻 のようなサロゲートペア絵文字の後ろにある emote が絵文字1つにつき1文字ずつずれていた(左列に `[emote]a` のような残骸が出る)。コードポイント位置を UTF-16 位置に変換してから切り出すよう修正。表示と Pick up の emote 除去の両方に効く

翻訳列は「emote 名はそのまま残す」設計のため変更していません。issue の提案 3(頻出語リスト・定型句辞書によるスコアリング。`hi ladies` のような普通の語句の過剰抽出)は対象外です。

## テスト

- `src/lib/ai/pickup-filter.test.ts`(新設、13件)
- `src/lib/ai/pickup.test.ts`(5件追加)
- `src/store/pickups.test.ts`(2件追加)
- `src/lib/twitch/emotes.test.ts`(2件追加)
- `npm run lint` / `npm run type-check` / `npm test`(263件)すべて成功

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH