### PR TITLE
feat: 翻訳列 — 翻訳文中に残る emote 名を左列と同じ emote 画像として表示する (#28)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -160,6 +160,27 @@ describe("Home(翻訳列)", () => {
     expect(rows[1]).toHaveTextContent("これはマジでそう");
   });
 
+  it("翻訳文中に残った emote 名は、左列と同じ emote 画像として表示する(issue #28)", () => {
+    const emote付き発言: TwitchChatMessage = {
+      ...サンプル発言,
+      text: "why sayuwuLul lol",
+      emotes: [{ id: "emotesv2_1", start: 4, end: 12 }],
+    };
+    useChatConnectionStore.setState({ messages: [emote付き発言] });
+    useTranslationStore.setState({
+      promptApi: { status: "ready" },
+      entries: { "msg-1": { status: "done", translation: "なんでsayuwuLulそんな" } },
+    });
+
+    render(<Home />);
+
+    const translationColumn = screen.getByRole("region", { name: "翻訳" });
+    const image = within(translationColumn).getByRole("img", { name: "sayuwuLul" });
+    expect(image).toHaveAttribute("src", expect.stringContaining("/emotesv2_1/"));
+    expect(within(translationColumn).queryByText(/sayuwuLul/)).not.toBeInTheDocument();
+    expect(within(translationColumn).getByText("なんで")).toBeInTheDocument();
+  });
+
   it("翻訳列の各行は対応する発言の ID と紐づく(行の高さを左列と揃えるための共通キー)", () => {
     useChatConnectionStore.setState({ messages: [サンプル発言] });
     useTranslationStore.setState({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -31,7 +31,7 @@ import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
 import type { ConnectionState } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
-import { buildEmoteImageUrl, splitMessageIntoSegments } from "@/lib/twitch/emotes";
+import { buildEmoteImageUrl, splitMessageIntoSegments, splitTextByEmoteNames, type MessageSegment } from "@/lib/twitch/emotes";
 import { hydrateBotFilterStore } from "@/store/bot-filter";
 import { useChatConnectionStore } from "@/store/chat-connection";
 import { startPickupPipeline, usePickupStore, warmUpPickupPipeline, type PickupEntry } from "@/store/pickups";
@@ -287,7 +287,7 @@ function TranslationCellContent({
     case "pending":
       return <span className="text-muted-foreground">翻訳中...</span>;
     case "done":
-      return <span>{entry.translation}</span>;
+      return <TranslationText message={message} translation={entry.translation} />;
     case "failed":
       return <span className="text-destructive">翻訳に失敗: {entry.reason}</span>;
     case "dropped":
@@ -339,6 +339,42 @@ function PickupCellContent({
   }
 }
 
+/**
+ * 翻訳文の中身。翻訳は emote 名をそのまま残す設計のため、元の発言に含まれていた emote 名が
+ * 文字列として現れた箇所を左列と同じ emote 画像に置き換えて表示する(issue #28)
+ */
+function TranslationText({ message, translation }: { message: TwitchChatMessage; translation: string }) {
+  const segments = useMemo(() => {
+    const knownEmotes = splitMessageIntoSegments(message.text, message.emotes).filter(
+      (segment) => segment.type === "emote",
+    );
+    return splitTextByEmoteNames(translation, knownEmotes);
+  }, [message.text, message.emotes, translation]);
+
+  return (
+    <span>
+      <MessageSegments segments={segments} />
+    </span>
+  );
+}
+
+/** テキスト/emote セグメント列を、テキストはそのまま・emote は画像として描画する(左列・翻訳列で共通) */
+function MessageSegments({ segments }: { segments: MessageSegment[] }) {
+  return segments.map((segment, index) =>
+    segment.type === "text" ? (
+      <span key={index}>{segment.text}</span>
+    ) : (
+      // eslint-disable-next-line @next/next/no-img-element -- Twitch CDNの外部画像のためnext/imageのドメイン許可設定は不要な単純imgで表示する
+      <img
+        key={index}
+        src={buildEmoteImageUrl(segment.id)}
+        alt={segment.text}
+        className="mx-0.5 inline-block h-6 align-text-bottom"
+      />
+    ),
+  );
+}
+
 function ChatMessageRow({ message }: { message: TwitchChatMessage }) {
   const segments = useMemo(
     () => splitMessageIntoSegments(message.text, message.emotes),
@@ -351,19 +387,7 @@ function ChatMessageRow({ message }: { message: TwitchChatMessage }) {
         {message.displayName}
       </span>
       <span>: </span>
-      {segments.map((segment, index) =>
-        segment.type === "text" ? (
-          <span key={index}>{segment.text}</span>
-        ) : (
-          // eslint-disable-next-line @next/next/no-img-element -- Twitch CDNの外部画像のためnext/imageのドメイン許可設定は不要な単純imgで表示する
-          <img
-            key={index}
-            src={buildEmoteImageUrl(segment.id)}
-            alt={segment.text}
-            className="mx-0.5 inline-block h-6 align-text-bottom"
-          />
-        ),
-      )}
+      <MessageSegments segments={segments} />
     </Row>
   );
 }

--- a/src/lib/twitch/emotes.test.ts
+++ b/src/lib/twitch/emotes.test.ts
@@ -6,7 +6,7 @@
  * 描画用セグメントに変換する純関数を検証する。
  */
 import { describe, expect, it } from "vitest";
-import { buildEmoteImageUrl, splitMessageIntoSegments, splitTextByEmoteNames } from "./emotes";
+import { buildEmoteImageUrl, isEmoteOnlyMessage, splitMessageIntoSegments, splitTextByEmoteNames } from "./emotes";
 import type { EmotePosition } from "./irc-parser";
 
 describe("buildEmoteImageUrl", () => {
@@ -111,5 +111,27 @@ describe("splitTextByEmoteNames", () => {
     const segments = splitTextByEmoteNames("kappa lol", 既知のemote);
 
     expect(segments).toEqual([{ type: "text", text: "kappa lol" }]);
+  });
+});
+
+describe("isEmoteOnlyMessage", () => {
+  it("emote だけ(空白区切りの繰り返しを含む)の発言は true", () => {
+    const emotes: EmotePosition[] = [
+      { id: "25", start: 0, end: 4 },
+      { id: "25", start: 6, end: 10 },
+    ];
+
+    expect(isEmoteOnlyMessage("Kappa Kappa", emotes)).toBe(true);
+  });
+
+  it("emote 以外の文字がある発言は false", () => {
+    const emotes: EmotePosition[] = [{ id: "25", start: 5, end: 9 }];
+
+    expect(isEmoteOnlyMessage("nice Kappa", emotes)).toBe(false);
+  });
+
+  it("emote が無い発言は false(空文字列でも翻訳側の判断に委ねる)", () => {
+    expect(isEmoteOnlyMessage("hello", [])).toBe(false);
+    expect(isEmoteOnlyMessage("", [])).toBe(false);
   });
 });

--- a/src/lib/twitch/emotes.test.ts
+++ b/src/lib/twitch/emotes.test.ts
@@ -6,7 +6,7 @@
  * 描画用セグメントに変換する純関数を検証する。
  */
 import { describe, expect, it } from "vitest";
-import { buildEmoteImageUrl, splitMessageIntoSegments } from "./emotes";
+import { buildEmoteImageUrl, splitMessageIntoSegments, splitTextByEmoteNames } from "./emotes";
 import type { EmotePosition } from "./irc-parser";
 
 describe("buildEmoteImageUrl", () => {
@@ -65,5 +65,51 @@ describe("splitMessageIntoSegments", () => {
     const segments = splitMessageIntoSegments("Kappa", emotes);
 
     expect(segments).toEqual([{ type: "emote", id: "25", text: "Kappa" }]);
+  });
+});
+
+describe("splitTextByEmoteNames", () => {
+  /** 元の発言に含まれていた emote(名前と ID の対応) */
+  const 既知のemote = [
+    { id: "emotesv2_1", text: "sayuwuLul" },
+    { id: "25", text: "Kappa" },
+  ];
+
+  it("既知の emote が無い場合はテキスト1件のセグメントを返す", () => {
+    expect(splitTextByEmoteNames("マジで?", [])).toEqual([{ type: "text", text: "マジで?" }]);
+  });
+
+  it("翻訳文中に現れる emote 名を、日本語に隣接していても emote セグメントに置き換える", () => {
+    const segments = splitTextByEmoteNames("なんでsayuwuLulそんな flagged したの", 既知のemote);
+
+    expect(segments).toEqual([
+      { type: "text", text: "なんで" },
+      { type: "emote", id: "emotesv2_1", text: "sayuwuLul" },
+      { type: "text", text: "そんな flagged したの" },
+    ]);
+  });
+
+  it("複数種類・複数回の emote 名をすべて置き換える", () => {
+    const segments = splitTextByEmoteNames("Kappa 草 sayuwuLul Kappa", 既知のemote);
+
+    expect(segments).toEqual([
+      { type: "emote", id: "25", text: "Kappa" },
+      { type: "text", text: " 草 " },
+      { type: "emote", id: "emotesv2_1", text: "sayuwuLul" },
+      { type: "text", text: " " },
+      { type: "emote", id: "25", text: "Kappa" },
+    ]);
+  });
+
+  it("英数字の単語の一部として含まれる場合は emote とみなさない(Kappajapan の Kappa など)", () => {
+    const segments = splitTextByEmoteNames("Kappajapan に行く", 既知のemote);
+
+    expect(segments).toEqual([{ type: "text", text: "Kappajapan に行く" }]);
+  });
+
+  it("emote 名の大文字小文字は区別する(kappa は Kappa とみなさない)", () => {
+    const segments = splitTextByEmoteNames("kappa lol", 既知のemote);
+
+    expect(segments).toEqual([{ type: "text", text: "kappa lol" }]);
   });
 });

--- a/src/lib/twitch/emotes.ts
+++ b/src/lib/twitch/emotes.ts
@@ -4,6 +4,8 @@
  * `irc-parser.ts` が emotes タグから抽出した位置情報(EmotePosition[])を、
  * (1) 実際に読み込む画像CDN URL、(2) テキスト/画像が交互に並ぶ描画用セグメント
  * に変換する。ライブチャットUIはこのセグメント列をそのまま描画すればよい。
+ * また、翻訳文のように位置情報を持たないテキストに対しては、元の発言に含まれていた
+ * emote 名を手がかりに同じセグメント列へ分割する(`splitTextByEmoteNames`、issue #28)。
  *
  * 注意: emote の開始・終了位置は文字列の(UTF-16コードユニット単位の)インデックスであるため、
  * サロゲートペアとなる絵文字を本文中に含むメッセージでは位置がずれる可能性がある。
@@ -71,5 +73,51 @@ export function splitMessageIntoSegments(text: string, emotes: EmotePosition[]):
     segments.push({ type: "text", text: text.slice(cursor) });
   }
 
+  return segments;
+}
+
+/** 正規表現のメタ文字をエスケープする(emote 名は英数字のみだが念のため) */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * 位置情報を持たないテキスト(翻訳文など)を、既知の emote 名を手がかりにテキスト/emote セグメントに分割する。
+ *
+ * - `knownEmotes` は元の発言の `splitMessageIntoSegments` から得た emote セグメント(名前と ID の対応)
+ * - 名前の照合は大文字小文字を区別する(Twitch の emote 名は大文字小文字を区別するため)
+ * - 英数字の単語の一部(例: `Kappajapan` 内の `Kappa`)は emote とみなさないが、
+ *   日本語などの非英数字には隣接していてもよい(翻訳文では `なんでsayuwuLulそんな` のように連結されるため)
+ * - 同じ名前が複数の ID で登録されている場合は先勝ちとする
+ */
+export function splitTextByEmoteNames(text: string, knownEmotes: Array<Pick<EmoteSegment, "id" | "text">>): MessageSegment[] {
+  if (knownEmotes.length === 0 || text === "") {
+    return [{ type: "text", text }];
+  }
+
+  const idByName = new Map<string, string>();
+  for (const emote of knownEmotes) {
+    if (!idByName.has(emote.text)) idByName.set(emote.text, emote.id);
+  }
+  // 長い名前を先に並べ、ある emote 名が別の emote 名の接頭辞になっている場合でも長い方を優先する
+  const names = [...idByName.keys()].sort((a, b) => b.length - a.length);
+  const pattern = new RegExp(`(?<![A-Za-z0-9_])(?:${names.map(escapeRegExp).join("|")})(?![A-Za-z0-9_])`, "g");
+
+  const segments: MessageSegment[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(pattern)) {
+    const name = match[0];
+    const id = idByName.get(name);
+    // パターンは idByName のキーから組み立てているため必ず見つかるが、型上の未定義を Fail-Fast で弾く
+    if (id === undefined) throw new Error(`emote 名に対応する ID がありません: ${name}`);
+    if (match.index > cursor) {
+      segments.push({ type: "text", text: text.slice(cursor, match.index) });
+    }
+    segments.push({ type: "emote", id, text: name });
+    cursor = match.index + name.length;
+  }
+  if (cursor < text.length || segments.length === 0) {
+    segments.push({ type: "text", text: text.slice(cursor) });
+  }
   return segments;
 }

--- a/src/lib/twitch/emotes.ts
+++ b/src/lib/twitch/emotes.ts
@@ -76,6 +76,18 @@ export function splitMessageIntoSegments(text: string, emotes: EmotePosition[]):
   return segments;
 }
 
+/**
+ * emote だけ(空白を除いてすべてが emote)の発言かを判定する。
+ * 訳すべきテキストが無いため、翻訳側は LLM を呼ばずに原文をそのまま扱える(issue #28)。
+ * emote が無い発言は、本文が空であっても false を返す(emote 以外の理由での空は呼び出し側の判断に委ねる)。
+ */
+export function isEmoteOnlyMessage(text: string, emotes: EmotePosition[]): boolean {
+  if (emotes.length === 0) return false;
+  return splitMessageIntoSegments(text, emotes).every(
+    (segment) => segment.type === "emote" || segment.text.trim() === "",
+  );
+}
+
 /** 正規表現のメタ文字をエスケープする(emote 名は英数字のみだが念のため) */
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");

--- a/src/store/translations.test.ts
+++ b/src/store/translations.test.ts
@@ -159,6 +159,31 @@ describe("startTranslationPipeline", () => {
     stop();
   });
 
+  it("emote だけの発言は訳すものが無いため LLM を呼ばず、原文をそのまま訳文として done にする(issue #28)", async () => {
+    const { deps, emit, enqueue } = createDeps();
+
+    const stop = startTranslationPipeline(deps);
+    await flush();
+    emit(
+      createMessage({
+        id: "msg-1",
+        text: "sayuwuKuru sayuwuKuru",
+        emotes: [
+          { id: "emotesv2_1", start: 0, end: 9 },
+          { id: "emotesv2_1", start: 11, end: 20 },
+        ],
+      }),
+    );
+    await flush();
+
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(useTranslationStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      translation: "sayuwuKuru sayuwuKuru",
+    });
+    stop();
+  });
+
   it("翻訳ジョブが完了するまでは pending として保持する", async () => {
     const deferred = createDeferred<string>();
     const { deps, emit } = createDeps({ promptResults: [deferred.promise] });

--- a/src/store/translations.ts
+++ b/src/store/translations.ts
@@ -21,6 +21,7 @@ import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
 import { createSessionPool, LowPriorityQueueOverflowError, type SessionPool } from "@/lib/ai/session-pool";
 import { createTranslateBaseSessionFactory, translateChatMessage } from "@/lib/ai/translate";
 import { loadSettings, type Settings } from "@/lib/settings";
+import { isEmoteOnlyMessage } from "@/lib/twitch/emotes";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
 
@@ -124,6 +125,12 @@ export function startTranslationPipeline(deps: TranslationPipelineDeps = DEFAULT
   }
 
   function translate(message: TwitchChatMessage, id: string): void {
+    // emote だけの発言は訳すものが無い。LLM に渡すと emote 名を訳してしまうことがあるため、
+    // 原文をそのまま訳文として確定させる(ページ側が emote 名を画像として描画する、issue #28)
+    if (isEmoteOnlyMessage(message.text, message.emotes)) {
+      setEntry(id, { status: "done", translation: message.text });
+      return;
+    }
     setEntry(id, { status: "pending" });
     translateChatMessage(getPool(), message.text, { priority: "low", signal: controller.signal })
       .then((result) => setEntry(id, { status: "done", translation: result.translation }))


### PR DESCRIPTION
## 概要

翻訳列は「emote 名はそのまま残す」設計のため、翻訳文の中に `sayuwuLul` のような emote 名が文字列で埋め込まれ読みにくかった(issue #28)。LLM には手を入れず、決定的な処理で emote 名を左列と同じ emote 画像に置き換えて描画します。あわせて、emote だけの発言は LLM を呼ばないようにしました(Gemini Nano が emote 名を `笑笑笑…` のように訳してしまう実例への対処)。

## 変更内容

- **`src/lib/twitch/emotes.ts`**
  - `splitTextByEmoteNames(text, knownEmotes)` を追加。元の発言の `splitMessageIntoSegments` から得た emote セグメント(名前 → ID)を手がかりに、翻訳文をテキスト/emote セグメントに分割する
    - 大文字小文字を区別する(Twitch の emote 名の仕様に合わせる)
    - 英数字の単語の一部(`Kappajapan` 内の `Kappa`)は emote とみなさないが、`なんでsayuwuLulそんな` のように日本語と隣接する場合は置き換える
  - `isEmoteOnlyMessage(text, emotes)` を追加。空白を除いてすべてが emote の発言を判定する
- **`src/store/translations.ts`**: emote だけの発言は LLM を呼ばず、原文をそのまま `translation` として `done` にする(ページ側で emote 画像として描画される)
- **`src/app/page.tsx`**: セグメント描画を `MessageSegments` に共通化し、左列 `ChatMessageRow` と翻訳列の done 状態(`TranslationText`)の両方で使用する

emote 名と普通の文が混在する発言で LLM が emote 名を訳してしまうケースは決定的に防げないため対象外です。

## テスト

- `src/lib/twitch/emotes.test.ts`(8件追加)
- `src/store/translations.test.ts`(1件追加)
- `src/app/page.test.tsx`(1件追加: 翻訳列に `alt="sayuwuLul"` の画像が出て、文字列は残らないこと)
- `npm run lint` / `npm run type-check` / `npm test`(251件)すべて成功

## 補足

PR #27(emote 位置のコードポイント対応)とは独立していますが、🏴‍☠️ などの絵文字の後ろにある emote は PR #27 がマージされるまで名前が欠けて一致しない場合があります。PR #27 → 本 PR の順にマージしてください。

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH