### PR TITLE
fix: 翻訳列・Pick up — Gemini Nano の応答 JSON が壊れていた場合に限り、新しいジョブとして1回だけ明示的に再試行する (#19, #31)

### DIFF
--- a/src/lib/ai/pickup.test.ts
+++ b/src/lib/ai/pickup.test.ts
@@ -8,13 +8,19 @@
  * (`LanguageModel` はブラウザ組み込みAPIのため `vi.stubGlobal` でモックする)。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { createPickupBaseSessionFactory, pickUpExpressions } from "./pickup";
+import { createPickupBaseSessionFactory, PICKUP_MAX_ATTEMPTS, pickUpExpressions } from "./pickup";
 import { buildExplainSystemPrompt, buildTranslateSystemPrompt } from "./prompts";
 import type { SessionPool } from "./session-pool";
 
 /** テスト用の最小限の SessionPool フェイク。enqueue の run をそのまま呼び出し、prompt の引数を記録する */
-function createFakeSessionPool(promptResult: string) {
-  const prompt = vi.fn(async () => promptResult);
+/** 配列を渡した場合は、呼び出しごとに先頭から順に応答を返す(再試行の検証用) */
+function createFakeSessionPool(promptResult: string | string[]) {
+  const results = Array.isArray(promptResult) ? [...promptResult] : [promptResult];
+  const prompt = vi.fn(async () => {
+    const next = results.shift();
+    if (next === undefined) throw new Error("テスト用の応答が尽きました");
+    return next;
+  });
   const enqueue = vi.fn(async (_priority: "high" | "low", run: (session: unknown) => Promise<string>) => {
     return run({ prompt });
   });
@@ -77,6 +83,52 @@ describe("pickUpExpressions", () => {
     const pool = createFakeSessionPool(JSON.stringify({ items: [{ term: "gg", meaning: "x" }] }));
 
     await expect(pickUpExpressions(pool, "hello")).rejects.toThrow();
+  });
+});
+
+describe("pickUpExpressions(JSON 解釈失敗時の再試行、issue #19)", () => {
+  it("応答が正常な場合は1回しか enqueue しない", async () => {
+    const pool = createFakeSessionPool(JSON.stringify({ terms: [] }));
+
+    await pickUpExpressions(pool, "hello");
+
+    expect(pool.enqueue).toHaveBeenCalledTimes(1);
+  });
+
+  it("応答 JSON が途中で切れていた場合は、新しいジョブとして1回だけ再試行し、成功した結果を返す", async () => {
+    const truncated = '{"terms":[{"term":"gg","meaning":"お疲れ';
+    const pool = createFakeSessionPool([truncated, JSON.stringify({ terms: [{ term: "gg", meaning: "お疲れ様" }] })]);
+
+    const result = await pickUpExpressions(pool, "gg chat");
+
+    expect(result).toEqual({ terms: [{ term: "gg", meaning: "お疲れ様" }] });
+    expect(pool.enqueue).toHaveBeenCalledTimes(2);
+    expect(pool.enqueue).toHaveBeenNthCalledWith(2, "low", expect.any(Function), undefined);
+  });
+
+  it("再試行しても JSON として解釈できない場合は、それ以上再試行せず試行回数を含めたエラーを投げる", async () => {
+    const pool = createFakeSessionPool(['{"terms":[{"term":"gg"', '{"terms":[']);
+
+    await expect(pickUpExpressions(pool, "gg chat")).rejects.toThrow(
+      `Prompt APIの応答をJSONとして解釈できませんでした(${PICKUP_MAX_ATTEMPTS}回試行): {"terms":[`,
+    );
+    expect(pool.enqueue).toHaveBeenCalledTimes(PICKUP_MAX_ATTEMPTS);
+  });
+
+  it("JSON としては解釈できるがスキーマに合わない応答や、原文に無い語句を返した応答は再試行しない", async () => {
+    const schemaMismatch = createFakeSessionPool([
+      JSON.stringify({ items: [] }),
+      JSON.stringify({ terms: [] }),
+    ]);
+    await expect(pickUpExpressions(schemaMismatch, "hello")).rejects.toThrow();
+    expect(schemaMismatch.enqueue).toHaveBeenCalledTimes(1);
+
+    const unknownTerm = createFakeSessionPool([
+      JSON.stringify({ terms: [{ term: "了解", meaning: "分かった" }] }),
+      JSON.stringify({ terms: [] }),
+    ]);
+    await expect(pickUpExpressions(unknownTerm, "hello")).rejects.toThrow();
+    expect(unknownTerm.enqueue).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/lib/ai/pickup.ts
+++ b/src/lib/ai/pickup.ts
@@ -10,6 +10,9 @@
  *   登場することを照合してから返す(モデルが解説言語の語や言い換えを「原文の語句」として
  *   返した応答は失敗として扱う)。自由文をパースする脆い処理は行わない。
  *   emote だけの発言のように渡す本文が空になる場合は LLM を呼ばず、空の結果を返す(issue #26)。
+ *   Gemini Nano は `responseConstraint` 指定時でも応答 JSON を途中で打ち切ることがある
+ *   (issue #19)ため、JSON として解釈できなかった場合に限り、新しいジョブとして
+ *   `PICKUP_MAX_ATTEMPTS` 回まで明示的に試行し直す。スキーマ不一致・照合失敗は再試行しない。
  * - `createPickupBaseSessionFactory`: Pick up 専用のシステムプロンプトを持つ
  *   ベースセッションの生成関数を組み立てる。`session-pool.ts` はベースセッションを
  *   1つしか持たないため、翻訳用・解説用とはプールを分ける前提(issue #15 の方針 (a))。
@@ -19,6 +22,12 @@ import { filterPickupTerms, preparePickupInput } from "./pickup-filter";
 import { buildPickupSystemPrompt, buildPickupUserPrompt, type SupportedLanguage } from "./prompts";
 import { buildPickupResponseConstraint, pickupSchema, type PickupResult } from "./schemas";
 import type { JobPriority, PromptSessionLike, SessionPool } from "./session-pool";
+
+/**
+ * 抽出1件あたりの最大試行回数(初回 + 再試行1回)。
+ * 応答 JSON の打ち切り(issue #19)への対処として、JSON 解釈失敗時に限り1回だけやり直す。
+ */
+export const PICKUP_MAX_ATTEMPTS = 2;
 
 export interface PickupOptions {
   /** 抽出は受信した全発言を自動で処理するバックグラウンド生成のため、既定は low */
@@ -34,6 +43,8 @@ export interface PickupOptions {
  * チャット本文から注目の表現を抽出する。
  * Prompt API の応答は必ず JSON 文字列として返るため、`JSON.parse` → `pickupSchema.parse` →
  * 決定的な後段フィルタ → 本文との照合の順で処理し、パース・照合に失敗した場合はエラーを投げる。
+ * `JSON.parse` に失敗した場合だけは、直前の応答がコンテキストに残らないよう別ジョブ
+ * (新しいクローンセッション)として `PICKUP_MAX_ATTEMPTS` 回まで試行し直す。
  * 照合は大文字小文字を区別しない(「W」を「w」として返す程度の揺れは原文の語句とみなす)。
  */
 export async function pickUpExpressions(
@@ -47,21 +58,7 @@ export async function pickUpExpressions(
     return { terms: [] };
   }
 
-  const raw = await sessionPool.enqueue(
-    priority,
-    (session) =>
-      session.prompt(buildPickupUserPrompt(prepared.text), {
-        responseConstraint: buildPickupResponseConstraint(),
-      }),
-    options.signal,
-  );
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした: ${raw}`, { cause: error });
-  }
+  const parsed = await promptForPickupJson(sessionPool, priority, prepared.text, options.signal);
 
   const terms = filterPickupTerms(pickupSchema.parse(parsed).terms, prepared, options.excludedNames ?? []);
   const normalizedText = prepared.text.toLowerCase();
@@ -70,6 +67,35 @@ export async function pickUpExpressions(
     throw new Error(`Prompt APIが原文に登場しない語句を返しました: ${unknownTerm.term}`);
   }
   return { terms };
+}
+
+/**
+ * Pick up 用のプロンプトを投げ、応答を JSON として解釈した値を返す。
+ * 解釈に失敗した場合は `PICKUP_MAX_ATTEMPTS` 回まで別ジョブとして試行し直し、それでも失敗すればエラーを投げる。
+ */
+async function promptForPickupJson(
+  sessionPool: SessionPool,
+  priority: JobPriority,
+  preparedText: string,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  for (let attempt = 1; ; attempt++) {
+    const raw = await sessionPool.enqueue(
+      priority,
+      (session) =>
+        session.prompt(buildPickupUserPrompt(preparedText), {
+          responseConstraint: buildPickupResponseConstraint(),
+        }),
+      signal,
+    );
+
+    try {
+      return JSON.parse(raw);
+    } catch (error) {
+      if (attempt < PICKUP_MAX_ATTEMPTS) continue;
+      throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした(${attempt}回試行): ${raw}`, { cause: error });
+    }
+  }
 }
 
 /**

--- a/src/lib/ai/translate.test.ts
+++ b/src/lib/ai/translate.test.ts
@@ -10,11 +10,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildExplainSystemPrompt } from "./prompts";
 import type { SessionPool } from "./session-pool";
-import { createTranslateBaseSessionFactory, translateChatMessage } from "./translate";
+import { createTranslateBaseSessionFactory, TRANSLATE_MAX_ATTEMPTS, translateChatMessage } from "./translate";
 
-/** テスト用の最小限の SessionPool フェイク。enqueue の run をそのまま呼び出し、prompt の引数を記録する */
-function createFakeSessionPool(promptResult: string) {
-  const prompt = vi.fn(async () => promptResult);
+/**
+ * テスト用の最小限の SessionPool フェイク。enqueue の run をそのまま呼び出し、prompt の引数を記録する。
+ * 配列を渡した場合は、呼び出しごとに先頭から順に応答を返す(再試行の検証用)。
+ */
+function createFakeSessionPool(promptResult: string | string[]) {
+  const results = Array.isArray(promptResult) ? [...promptResult] : [promptResult];
+  const prompt = vi.fn(async () => {
+    const next = results.shift();
+    if (next === undefined) throw new Error("テスト用の応答が尽きました");
+    return next;
+  });
   const enqueue = vi.fn(async (_priority: "high" | "low", run: (session: unknown) => Promise<string>) => {
     return run({ prompt });
   });
@@ -70,6 +78,47 @@ describe("translateChatMessage", () => {
     const pool = createFakeSessionPool(JSON.stringify({ text: "訳文がtranslationキーに入っていない" }));
 
     await expect(translateChatMessage(pool, "hello")).rejects.toThrow();
+  });
+
+  describe("JSON 解釈失敗時の再試行(issue #19)", () => {
+    it("応答が正常な場合は1回しか enqueue しない", async () => {
+      const pool = createFakeSessionPool(JSON.stringify({ translation: "マジか！" }));
+
+      await translateChatMessage(pool, "no way");
+
+      expect(pool.enqueue).toHaveBeenCalledTimes(1);
+    });
+
+    it("応答 JSON が途中で切れていた場合は、新しいジョブとして1回だけ再試行し、成功した結果を返す", async () => {
+      const truncated = '{"translation":"マジか！';
+      const pool = createFakeSessionPool([truncated, JSON.stringify({ translation: "マジか！" })]);
+
+      const result = await translateChatMessage(pool, "no way");
+
+      expect(result).toEqual({ translation: "マジか！" });
+      expect(pool.enqueue).toHaveBeenCalledTimes(2);
+      // 2回目も同じ優先度・signal で積み直す
+      expect(pool.enqueue).toHaveBeenNthCalledWith(2, "low", expect.any(Function), undefined);
+    });
+
+    it("再試行しても JSON として解釈できない場合は、それ以上再試行せず試行回数を含めたエラーを投げる", async () => {
+      const pool = createFakeSessionPool(['{"translation":"へー、なしか。', '{"translation":"へー、']);
+
+      await expect(translateChatMessage(pool, "oh no way")).rejects.toThrow(
+        `Prompt APIの応答をJSONとして解釈できませんでした(${TRANSLATE_MAX_ATTEMPTS}回試行): {"translation":"へー、`,
+      );
+      expect(pool.enqueue).toHaveBeenCalledTimes(TRANSLATE_MAX_ATTEMPTS);
+    });
+
+    it("JSON としては解釈できるがスキーマに合わない応答は再試行しない", async () => {
+      const pool = createFakeSessionPool([
+        JSON.stringify({ text: "キー違い" }),
+        JSON.stringify({ translation: "再試行されれば返る訳文" }),
+      ]);
+
+      await expect(translateChatMessage(pool, "hello")).rejects.toThrow();
+      expect(pool.enqueue).toHaveBeenCalledTimes(1);
+    });
   });
 });
 

--- a/src/lib/ai/translate.ts
+++ b/src/lib/ai/translate.ts
@@ -5,6 +5,9 @@
  *
  * - `translateChatMessage`: `SessionPool` にジョブを積み、返ってきたJSON文字列を
  *   `translationSchema` で検証してから返す。自由文をパースする脆い処理は行わない。
+ *   Gemini Nano は `responseConstraint` 指定時でも応答 JSON を途中で打ち切ることがある
+ *   (issue #19)ため、JSON として解釈できなかった場合に限り、新しいジョブとして
+ *   `TRANSLATE_MAX_ATTEMPTS` 回まで明示的に試行し直す。スキーマ不一致は再試行しない。
  * - `createTranslateBaseSessionFactory`: 翻訳専用のシステムプロンプトを持つ
  *   ベースセッションの生成関数を組み立てる。`session-pool.ts` はベースセッションを
  *   1つしか持たないため、翻訳用と解説用でプールを分ける前提(issue #15 の方針 (a))。
@@ -12,6 +15,12 @@
 import { buildTranslateSystemPrompt, buildTranslateUserPrompt, type SupportedLanguage } from "./prompts";
 import { buildTranslationResponseConstraint, translationSchema, type TranslationResult } from "./schemas";
 import type { JobPriority, PromptSessionLike, SessionPool } from "./session-pool";
+
+/**
+ * 翻訳1件あたりの最大試行回数(初回 + 再試行1回)。
+ * 応答 JSON の打ち切り(issue #19)への対処として、JSON 解釈失敗時に限り1回だけやり直す。
+ */
+export const TRANSLATE_MAX_ATTEMPTS = 2;
 
 export interface TranslateOptions {
   /** 翻訳は受信した全発言を自動で処理するバックグラウンド生成のため、既定は low */
@@ -22,7 +31,9 @@ export interface TranslateOptions {
 /**
  * チャット本文の翻訳を生成する。
  * Prompt API の応答は必ず JSON 文字列として返るため、`JSON.parse` → `translationSchema.parse`
- * の順で検証し、いずれかに失敗した場合はエラーを投げる。
+ * の順で検証する。`JSON.parse` に失敗した場合は、直前の応答がコンテキストに残らないよう
+ * 別ジョブ(新しいクローンセッション)として `TRANSLATE_MAX_ATTEMPTS` 回まで試行し直し、
+ * それでも解釈できなければエラーを投げる。スキーマ不一致は再試行せず即座にエラーを投げる。
  */
 export async function translateChatMessage(
   sessionPool: SessionPool,
@@ -31,23 +42,26 @@ export async function translateChatMessage(
 ): Promise<TranslationResult> {
   const priority = options.priority ?? "low";
 
-  const raw = await sessionPool.enqueue(
-    priority,
-    (session) =>
-      session.prompt(buildTranslateUserPrompt(chatMessageText), {
-        responseConstraint: buildTranslationResponseConstraint(),
-      }),
-    options.signal,
-  );
+  for (let attempt = 1; ; attempt++) {
+    const raw = await sessionPool.enqueue(
+      priority,
+      (session) =>
+        session.prompt(buildTranslateUserPrompt(chatMessageText), {
+          responseConstraint: buildTranslationResponseConstraint(),
+        }),
+      options.signal,
+    );
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした: ${raw}`, { cause: error });
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (error) {
+      if (attempt < TRANSLATE_MAX_ATTEMPTS) continue;
+      throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした(${attempt}回試行): ${raw}`, { cause: error });
+    }
+
+    return translationSchema.parse(parsed);
   }
-
-  return translationSchema.parse(parsed);
 }
 
 /**


### PR DESCRIPTION
## Summary

Gemini Nano(Prompt API)は `responseConstraint` を渡していても、応答 JSON を途中で打ち切ったり(#19: `{"translation":"マジか！`)、閉じ引用符を `」` にしてしまったり(#31)することがあります。これは `JSON.parse` で例外になり、行に「翻訳に失敗」「抽出に失敗」が表示されていました。

このPRでは、**`JSON.parse` に失敗した場合に限り**、明示的な仕様として新しいジョブを1回だけ積み直して再試行します(暗黙のフォールバックではありません)。

- `src/lib/ai/translate.ts`: `TRANSLATE_MAX_ATTEMPTS = 2`(初回 + 再試行1回)。`JSON.parse` 失敗時は同じ優先度・`signal` で `SessionPool.enqueue` し直す。再試行を同一セッション内ではなく別ジョブ(新しいクローンセッション)にしているのは、失敗した応答がコンテキストに残らないようにするため。
- `src/lib/ai/pickup.ts`: 同じ方針で `PICKUP_MAX_ATTEMPTS = 2`。プロンプト〜`JSON.parse` を `promptForPickupJson` に切り出し。
- 2回とも失敗した場合は `Prompt APIの応答をJSONとして解釈できませんでした(2回試行): <生の応答>` を投げ、行の failed 表示は従来どおり。
- スキーマ不一致(zod)・原文に無い語句(pickup の照合)は再試行しません。

## Test plan

- [x] `translate.test.ts` / `pickup.test.ts` に、成功時は1回のみ enqueue・途中で切れた応答→再試行で成功・2回失敗で試行回数入りエラー(3回目なし)・スキーマ不一致は再試行しない、の各ケースを追加
- [x] `npm test`(288件)/ `npm run lint` / `npm run type-check` / `npm run build` すべて通過
- [x] CodeRabbit CLI: 指摘0件
- [ ] 実ブラウザ(Chrome + Prompt API)で、翻訳列・Pick up の失敗表示が減ることを確認

#31 の対処案 (b)(failed 表示を短くして生の応答は `console.warn` へ)は本PRには含めていません。

Closes #19
Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH