### PR TITLE
fix: SessionPool の直列キューを翻訳列・Pick up 列で共有し、Gemini Nano への同時実行数をアプリ全体で 1 に保つ (#23)

### DIFF
--- a/src/lib/ai/pickup.ts
+++ b/src/lib/ai/pickup.ts
@@ -11,7 +11,7 @@
  *   「原文の語句」として返した応答は失敗として扱い、再試行しない)。
  *   emote だけの発言のように渡す本文が空になる場合は LLM を呼ばず、空の結果を返す(issue #26)。
  * - `createPickupBaseSessionFactory`: Pick up 専用のシステムプロンプトを持つベースセッションの生成関数を組み立てる。
- *   翻訳用とはプールを分ける前提(issue #15 の方針 (a))
+ *   翻訳用とはプール(ベースセッション)を分ける前提(issue #15 の方針 (a))。直列キューは共有する(issue #23)
  */
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
 import { filterPickupTerms, preparePickupInput } from "./pickup-filter";

--- a/src/lib/ai/session-pool.test.ts
+++ b/src/lib/ai/session-pool.test.ts
@@ -2,12 +2,19 @@
  * src/lib/ai/session-pool.ts のテスト。
  *
  * Prompt API(Gemini Nano)はメインスレッドで動作しWeb Workerが使えないため、
- * 単一のベースセッション + 優先度付き直列キューでUIをブロックしないよう制御する。
+ * 用途ごとのベースセッション + アプリ全体で 1 つの優先度付き直列キュー(`createPromptJobQueue`)で
+ * UIをブロックしないよう制御する。
  * 実際の LanguageModel は使わず、フェイクセッション(手動で resolve/reject できる
- * Deferred Promise)を注入して、直列性・優先度・キュー溢れ・中断を検証する。
+ * Deferred Promise)を注入して、直列性・優先度・キュー溢れ・中断・複数プール間のキュー共有(issue #23)を検証する。
  */
 import { describe, expect, it, vi } from "vitest";
-import { createSessionPool, LowPriorityQueueOverflowError, type PromptSessionLike } from "./session-pool";
+import {
+  createPromptJobQueue,
+  createSessionPool,
+  LowPriorityQueueOverflowError,
+  type PromptJobQueue,
+  type PromptSessionLike,
+} from "./session-pool";
 
 /**
  * キューは `getBaseSession()` → `clone()` → `run()` と複数回 await を挟んでから
@@ -45,11 +52,16 @@ function createFakeSession(log: string[], label: string): PromptSessionLike {
   };
 }
 
+/** テスト用にプールを 1 つ作る。キューを省略した場合はそのプール専用のキューを新しく作る */
+function createPool(createBaseSession: () => Promise<PromptSessionLike>, queue: PromptJobQueue = createPromptJobQueue()) {
+  return createSessionPool({ createBaseSession, queue });
+}
+
 describe("createSessionPool", () => {
   it("enqueueしたジョブにクローンしたセッションを渡し、成功後にクローンをdestroyする", async () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
-    const pool = createSessionPool({ createBaseSession: async () => baseSession });
+    const pool = createPool(async () => baseSession);
 
     const result = await pool.enqueue("high", async (session) => {
       const text = await session.prompt("hello");
@@ -64,7 +76,7 @@ describe("createSessionPool", () => {
   it("複数ジョブは同時実行せず、前のジョブが完了してから次を実行する(直列性)", async () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
-    const pool = createSessionPool({ createBaseSession: async () => baseSession });
+    const pool = createPool(async () => baseSession);
     const deferred1 = createDeferred<string>();
 
     const order: string[] = [];
@@ -92,7 +104,7 @@ describe("createSessionPool", () => {
   it("高優先度ジョブは、待機中の低優先度ジョブより先に実行される", async () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
-    const pool = createSessionPool({ createBaseSession: async () => baseSession });
+    const pool = createPool(async () => baseSession);
     const blocker = createDeferred<string>();
 
     const order: string[] = [];
@@ -125,7 +137,7 @@ describe("createSessionPool", () => {
   it("低優先度キューが上限を超えた場合、最も古い低優先度ジョブを破棄する(高優先度は破棄しない)", async () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
-    const pool = createSessionPool({ createBaseSession: async () => baseSession, maxLowPriorityQueueLength: 2 });
+    const pool = createPool(async () => baseSession, createPromptJobQueue({ maxLowPriorityQueueLength: 2 }));
     const blocker = createDeferred<string>();
 
     // ジョブ実行中にしてキューが溜まる状況を作る
@@ -152,7 +164,7 @@ describe("createSessionPool", () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
     const createBaseSession = vi.fn(async () => baseSession);
-    const pool = createSessionPool({ createBaseSession });
+    const pool = createPool(createBaseSession);
     const controller = new AbortController();
     controller.abort();
 
@@ -166,7 +178,7 @@ describe("createSessionPool", () => {
   it("待機中にsignalがabortされたジョブは実行されず拒否され、他のジョブには影響しない", async () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
-    const pool = createSessionPool({ createBaseSession: async () => baseSession });
+    const pool = createPool(async () => baseSession);
     const blocker = createDeferred<string>();
     const controller = new AbortController();
 
@@ -195,7 +207,7 @@ describe("createSessionPool", () => {
       .fn()
       .mockRejectedValueOnce(new Error("モデルが利用できません"))
       .mockResolvedValueOnce(createFakeSession(log, "base"));
-    const pool = createSessionPool({ createBaseSession });
+    const pool = createPool(createBaseSession);
 
     await expect(pool.enqueue("high", async () => "x")).rejects.toThrow("モデルが利用できません");
 
@@ -208,7 +220,7 @@ describe("createSessionPool", () => {
     const log: string[] = [];
     const baseSession = createFakeSession(log, "base");
     const createBaseSession = vi.fn(async () => baseSession);
-    const pool = createSessionPool({ createBaseSession });
+    const pool = createPool(createBaseSession);
 
     await pool.warmUp();
     expect(createBaseSession).toHaveBeenCalledTimes(1);
@@ -219,12 +231,116 @@ describe("createSessionPool", () => {
   });
 
   it("warmUp() でベースセッション生成に失敗した場合はその例外をそのまま投げる", async () => {
-    const pool = createSessionPool({
-      createBaseSession: async () => {
-        throw new Error("ユーザー操作なしではモデルをダウンロードできません");
-      },
+    const pool = createPool(async () => {
+      throw new Error("ユーザー操作なしではモデルをダウンロードできません");
     });
 
     await expect(pool.warmUp()).rejects.toThrow("ユーザー操作なしではモデルをダウンロードできません");
+  });
+});
+
+/**
+ * issue #23: 翻訳用・Pick up 用のようにベースセッション(システムプロンプト)が異なるプールでも、
+ * 同じキューを共有していれば Gemini Nano への呼び出しはアプリ全体で常に 1 つずつになること。
+ */
+describe("createSessionPool: 複数プールでのキュー共有(issue #23)", () => {
+  it("同じキューを共有する 2 つのプールのジョブは並走せず、積んだ順に直列で実行される", async () => {
+    const log: string[] = [];
+    const queue = createPromptJobQueue();
+    const translatePool = createPool(async () => createFakeSession(log, "translate-base"), queue);
+    const pickupPool = createPool(async () => createFakeSession(log, "pickup-base"), queue);
+    const blocker = createDeferred<string>();
+
+    const order: string[] = [];
+    const pTranslate = translatePool.enqueue("low", async () => {
+      order.push("translate:start");
+      await blocker.promise;
+      order.push("translate:end");
+      return "翻訳結果";
+    });
+    const pPickup = pickupPool.enqueue("low", async () => {
+      order.push("pickup:start");
+      return "抽出結果";
+    });
+
+    // 翻訳ジョブが完了するまで、別プールの Pick up ジョブは開始しない
+    await flushMicrotasks();
+    expect(order).toEqual(["translate:start"]);
+
+    blocker.resolve("released");
+    expect(await pTranslate).toBe("翻訳結果");
+    expect(await pPickup).toBe("抽出結果");
+    expect(order).toEqual(["translate:start", "translate:end", "pickup:start"]);
+  });
+
+  it("各プールは自分のベースセッションからクローンしてジョブに渡す(キューを共有してもセッションは混ざらない)", async () => {
+    const log: string[] = [];
+    const queue = createPromptJobQueue();
+    const translateBase = createFakeSession(log, "translate-base");
+    const pickupBase = createFakeSession(log, "pickup-base");
+    const translatePool = createPool(async () => translateBase, queue);
+    const pickupPool = createPool(async () => pickupBase, queue);
+
+    const translateResult = await translatePool.enqueue("low", (session) => session.prompt("gg"));
+    const pickupResult = await pickupPool.enqueue("low", (session) => session.prompt("gg"));
+
+    expect(translateResult).toMatch(/^response from translate-base-clone/);
+    expect(pickupResult).toMatch(/^response from pickup-base-clone/);
+  });
+
+  it("高優先度ジョブは、別プールで待機中の低優先度ジョブより先に実行される", async () => {
+    const log: string[] = [];
+    const queue = createPromptJobQueue();
+    const translatePool = createPool(async () => createFakeSession(log, "translate-base"), queue);
+    const pickupPool = createPool(async () => createFakeSession(log, "pickup-base"), queue);
+    const blocker = createDeferred<string>();
+
+    const order: string[] = [];
+    const pBlocking = translatePool.enqueue("low", async () => {
+      await blocker.promise;
+      return "blocking done";
+    });
+    await Promise.resolve();
+
+    const pLow = translatePool.enqueue("low", async () => {
+      order.push("translate:low");
+      return "low";
+    });
+    const pHigh = pickupPool.enqueue("high", async () => {
+      order.push("pickup:high");
+      return "high";
+    });
+
+    blocker.resolve("released");
+    await pBlocking;
+    await pHigh;
+    await pLow;
+
+    expect(order).toEqual(["pickup:high", "translate:low"]);
+  });
+
+  it("低優先度キューの上限はキューを共有するプール全体で 1 つであり、溢れた場合はプールを問わず最も古いジョブを破棄する", async () => {
+    const log: string[] = [];
+    const queue = createPromptJobQueue({ maxLowPriorityQueueLength: 2 });
+    const translatePool = createPool(async () => createFakeSession(log, "translate-base"), queue);
+    const pickupPool = createPool(async () => createFakeSession(log, "pickup-base"), queue);
+    const blocker = createDeferred<string>();
+
+    const pBlocking = translatePool.enqueue("high", async () => {
+      await blocker.promise;
+      return "blocking done";
+    });
+    await Promise.resolve();
+
+    const pTranslate1 = translatePool.enqueue("low", async () => "translate1");
+    const pPickup1 = pickupPool.enqueue("low", async () => "pickup1");
+    const pTranslate2 = translatePool.enqueue("low", async () => "translate2"); // 上限(2)を超えるため translate1 が破棄される
+
+    await expect(pTranslate1).rejects.toBeInstanceOf(LowPriorityQueueOverflowError);
+    blocker.resolve("released");
+    await pBlocking;
+
+    expect(await pPickup1).toBe("pickup1");
+    expect(await pTranslate2).toBe("translate2");
   });
 });

--- a/src/lib/ai/session-pool.test.ts
+++ b/src/lib/ai/session-pool.test.ts
@@ -239,6 +239,33 @@ describe("createSessionPool", () => {
   });
 });
 
+describe("createPromptJobQueue", () => {
+  it.each([-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY])(
+    "maxLowPriorityQueueLength に非負整数以外(%s)を渡した場合は生成時点で例外を投げる(Fail-Fast)",
+    (invalid) => {
+      expect(() => createPromptJobQueue({ maxLowPriorityQueueLength: invalid })).toThrow(/maxLowPriorityQueueLength/);
+    },
+  );
+
+  it("maxLowPriorityQueueLength に 0 を渡した場合は、待機中の低優先度ジョブをすべて破棄する", async () => {
+    const log: string[] = [];
+    const pool = createPool(async () => createFakeSession(log, "base"), createPromptJobQueue({ maxLowPriorityQueueLength: 0 }));
+    const blocker = createDeferred<string>();
+
+    const pBlocking = pool.enqueue("high", async () => {
+      await blocker.promise;
+      return "blocking done";
+    });
+    await Promise.resolve();
+
+    const pLow = pool.enqueue("low", async () => "low");
+    await expect(pLow).rejects.toBeInstanceOf(LowPriorityQueueOverflowError);
+
+    blocker.resolve("released");
+    expect(await pBlocking).toBe("blocking done");
+  });
+});
+
 /**
  * issue #23: 翻訳用・Pick up 用のようにベースセッション(システムプロンプト)が異なるプールでも、
  * 同じキューを共有していれば Gemini Nano への呼び出しはアプリ全体で常に 1 つずつになること。

--- a/src/lib/ai/session-pool.ts
+++ b/src/lib/ai/session-pool.ts
@@ -100,6 +100,10 @@ function abortReason(signal: AbortSignal): unknown {
 
 export function createPromptJobQueue(options: PromptJobQueueOptions = {}): PromptJobQueue {
   const maxLowPriorityQueueLength = options.maxLowPriorityQueueLength ?? DEFAULT_MAX_LOW_PRIORITY_QUEUE_LENGTH;
+  // 負数・小数・NaN・Infinity は溢れ判定(`lowQueue.length > 上限`)の意味が壊れるため、暗黙に丸めず生成時点で失敗させる
+  if (!Number.isInteger(maxLowPriorityQueueLength) || maxLowPriorityQueueLength < 0) {
+    throw new Error(`maxLowPriorityQueueLength は 0 以上の整数である必要があります: ${maxLowPriorityQueueLength}`);
+  }
 
   const highQueue: QueuedJob[] = [];
   const lowQueue: QueuedJob[] = [];

--- a/src/lib/ai/session-pool.ts
+++ b/src/lib/ai/session-pool.ts
@@ -1,19 +1,24 @@
 /**
- * Gemini Nano(Prompt API)へのアクセスを、単一のベースセッション + 優先度付き直列キューで
- * 制御するモジュール。
+ * Gemini Nano(Prompt API)へのアクセスを、用途ごとのベースセッション + アプリ全体で 1 つの
+ * 優先度付き直列キューで制御するモジュール。
  *
  * Prompt API は Web Worker で使えずメインスレッドで動作するため、無制御に
  * 呼び出すと UI がブロックされる。そのためここでは以下を保証する。
  *
- * - 同時実行数は常に1(直列処理)
+ * - 同時実行数は常に1(直列処理)。翻訳用・Pick up 用のようにシステムプロンプト(ベースセッション)が
+ *   異なるプールでも、同じ `PromptJobQueue` を共有すればアプリ全体で 1 つずつしか `prompt()` を投げない(issue #23)
  * - 優先度は2段階("high" = 利用者の明示的な操作, "low" = バックグラウンド生成)。
  *   高優先度ジョブは、待機中の低優先度ジョブより必ず先に処理される
- * - 低優先度キューには上限を設け、溢れた場合は最も古いものから破棄する
+ * - 低優先度キューには上限を設け、溢れた場合はプールを問わず最も古いものから破棄する
  *   (高優先度キューは利用者の明示的な操作なので上限を設けない)
  * - 各ジョブは `AbortSignal` を受け取れ、実行前に中断されていれば実行しない
  * - ベースセッションは `session.clone()` して使い捨てのブランチを都度作ることで、
  *   システムプロンプトのウォームアップ(初回生成コスト)を再利用しつつ、
  *   ジョブ間でコンテキストが汚染されないようにする
+ *
+ * 役割分担:
+ * - `createPromptJobQueue`: 優先度・上限・中断を扱う直列キュー。ベースセッションのことは知らない
+ * - `createSessionPool`: ベースセッション 1 つを保持し、ジョブをクローンセッション付きでキューに積む
  */
 
 /** Prompt API の `LanguageModel` セッションが最低限備えるべきインターフェース */
@@ -28,11 +33,28 @@ export interface PromptSessionLike {
 
 export type JobPriority = "high" | "low";
 
+export interface PromptJobQueueOptions {
+  /** 低優先度キューの最大長。超えた分は古いものから破棄する。省略時 20 */
+  maxLowPriorityQueueLength?: number;
+}
+
+/**
+ * Prompt API 呼び出しの直列キュー。複数の `SessionPool` で 1 つを共有し、
+ * アプリ全体の同時実行数を 1 に保つ。
+ */
+export interface PromptJobQueue {
+  /**
+   * ジョブをキューに積み、完了(または拒否)した際に解決される Promise を返す。
+   * `run` は前のジョブが完了してから呼び出される。
+   */
+  enqueue<T>(priority: JobPriority, run: () => Promise<T>, signal?: AbortSignal): Promise<T>;
+}
+
 export interface SessionPoolDeps {
   /** ベースセッションを生成する。言語ペア(system prompt)は呼び出し側が組み立てて渡す */
   createBaseSession: () => Promise<PromptSessionLike>;
-  /** 低優先度キューの最大長。超えた分は古いものから破棄する。省略時 20 */
-  maxLowPriorityQueueLength?: number;
+  /** ジョブを積む直列キュー。用途の異なるプール間で同じものを渡し、並走を防ぐ */
+  queue: PromptJobQueue;
 }
 
 export interface SessionPool {
@@ -64,7 +86,7 @@ export class LowPriorityQueueOverflowError extends Error {
 }
 
 interface QueuedJob {
-  run: (session: PromptSessionLike) => Promise<unknown>;
+  run: () => Promise<unknown>;
   resolve: (value: unknown) => void;
   reject: (reason: unknown) => void;
   signal?: AbortSignal;
@@ -76,24 +98,12 @@ function abortReason(signal: AbortSignal): unknown {
   return signal.reason ?? new DOMException("Aborted", "AbortError");
 }
 
-export function createSessionPool(deps: SessionPoolDeps): SessionPool {
-  const maxLowPriorityQueueLength = deps.maxLowPriorityQueueLength ?? DEFAULT_MAX_LOW_PRIORITY_QUEUE_LENGTH;
+export function createPromptJobQueue(options: PromptJobQueueOptions = {}): PromptJobQueue {
+  const maxLowPriorityQueueLength = options.maxLowPriorityQueueLength ?? DEFAULT_MAX_LOW_PRIORITY_QUEUE_LENGTH;
 
   const highQueue: QueuedJob[] = [];
   const lowQueue: QueuedJob[] = [];
-  let baseSessionPromise: Promise<PromptSessionLike> | null = null;
   let isProcessing = false;
-
-  function getBaseSession(): Promise<PromptSessionLike> {
-    if (!baseSessionPromise) {
-      baseSessionPromise = deps.createBaseSession().catch((error: unknown) => {
-        // 生成に失敗したら次回 enqueue 時に再試行できるようキャッシュを捨てる
-        baseSessionPromise = null;
-        throw error;
-      });
-    }
-    return baseSessionPromise;
-  }
 
   function dropOldestLowPriorityJobIfOverCapacity() {
     while (lowQueue.length > maxLowPriorityQueueLength) {
@@ -120,14 +130,7 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
     isProcessing = true;
     void (async () => {
       try {
-        const baseSession = await getBaseSession();
-        const jobSession = await baseSession.clone();
-        try {
-          const result = await job.run(jobSession);
-          job.resolve(result);
-        } finally {
-          jobSession.destroy();
-        }
+        job.resolve(await job.run());
       } catch (error) {
         job.reject(error);
       } finally {
@@ -138,10 +141,7 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
   }
 
   return {
-    async warmUp() {
-      await getBaseSession();
-    },
-    enqueue<T>(priority: JobPriority, run: (session: PromptSessionLike) => Promise<T>, signal?: AbortSignal): Promise<T> {
+    enqueue<T>(priority: JobPriority, run: () => Promise<T>, signal?: AbortSignal): Promise<T> {
       return new Promise<T>((resolve, reject) => {
         if (signal?.aborted) {
           reject(abortReason(signal));
@@ -149,7 +149,7 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
         }
 
         const job: QueuedJob = {
-          run: run as (session: PromptSessionLike) => Promise<unknown>,
+          run,
           resolve: resolve as (value: unknown) => void,
           reject,
           signal,
@@ -177,6 +177,43 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
 
         processNext();
       });
+    },
+  };
+}
+
+export function createSessionPool(deps: SessionPoolDeps): SessionPool {
+  let baseSessionPromise: Promise<PromptSessionLike> | null = null;
+
+  function getBaseSession(): Promise<PromptSessionLike> {
+    if (!baseSessionPromise) {
+      baseSessionPromise = deps.createBaseSession().catch((error: unknown) => {
+        // 生成に失敗したら次回 enqueue 時に再試行できるようキャッシュを捨てる
+        baseSessionPromise = null;
+        throw error;
+      });
+    }
+    return baseSessionPromise;
+  }
+
+  return {
+    async warmUp() {
+      await getBaseSession();
+    },
+    enqueue<T>(priority: JobPriority, run: (session: PromptSessionLike) => Promise<T>, signal?: AbortSignal): Promise<T> {
+      // ベースセッションの生成・クローンもキューの中で行い、`LanguageModel.create()` を含めて直列にする
+      return deps.queue.enqueue(
+        priority,
+        async () => {
+          const baseSession = await getBaseSession();
+          const jobSession = await baseSession.clone();
+          try {
+            return await run(jobSession);
+          } finally {
+            jobSession.destroy();
+          }
+        },
+        signal,
+      );
     },
   };
 }

--- a/src/lib/ai/structured-prompt.ts
+++ b/src/lib/ai/structured-prompt.ts
@@ -10,8 +10,9 @@
  *   (新しいクローンセッション)として `STRUCTURED_PROMPT_MAX_ATTEMPTS` 回まで試行し直す。
  *   スキーマ不一致は再試行せず即座にエラーを投げる(自由文をパースする脆いフォールバックはしない)。
  * - `createBaseSessionFactory`: 用途ごとのシステムプロンプトを持つベースセッションの生成関数を組み立てる。
- *   `window.LanguageModel` を実際に呼び出す唯一の場所。`session-pool.ts` はベースセッションを
+ *   `window.LanguageModel` を実際に呼び出す唯一の場所。`SessionPool` はベースセッションを
  *   1 つしか持たないため、用途ごとにプールを分ける前提(issue #15 の方針 (a))。
+ *   ただし直列キュー(`PromptJobQueue`)は用途をまたいで 1 つを共有し、並走させない(issue #23)。
  */
 import type { z } from "zod";
 import type { SupportedLanguage } from "./prompts";

--- a/src/lib/ai/translate.ts
+++ b/src/lib/ai/translate.ts
@@ -6,7 +6,7 @@
  *
  * - `translateChatMessage`: 翻訳用ユーザープロンプトと `translationSchema` で `runStructuredPrompt` を呼ぶ
  * - `createTranslateBaseSessionFactory`: 翻訳専用のシステムプロンプトを持つベースセッションの生成関数を組み立てる。
- *   Pick up 用とはプールを分ける前提(issue #15 の方針 (a))
+ *   Pick up 用とはプール(ベースセッション)を分ける前提(issue #15 の方針 (a))。直列キューは共有する(issue #23)
  */
 import { buildTranslateSystemPrompt, buildTranslateUserPrompt, type SupportedLanguage } from "./prompts";
 import { translationSchema, type TranslationResult } from "./schemas";

--- a/src/store/auto-pipeline.ts
+++ b/src/store/auto-pipeline.ts
@@ -6,6 +6,9 @@
  * - 結果は発言 ID(`TwitchChatMessage.id`)をキーに保持し、ページ側は左列と同じ発言順で `entries[id]` を引いて描画する
  * - ジョブは「自動で全件」を基本とし、`SessionPool` の低優先度キューに積む。
  *   流量が多く追いつかない分はキュー側で古いものから破棄され、`dropped` として明示する
+ * - セッションプールはパイプラインごと(用途ごとのシステムプロンプト)に持つが、ジョブを流す直列キューは
+ *   このモジュールで 1 つだけ作り、全パイプラインで共有する。Gemini Nano への `prompt()` が翻訳と Pick up で
+ *   並走しないようにするため(issue #23)
  * - Prompt API の利用可否は `prompt-api.ts` の共有ストアに集約する。パイプラインは診断を 1 回だけ
  *   `ensurePromptApiDiagnosed` に依頼し、自分のセッションプールのウォームアップだけを担当する。
  *   使えない環境では暗黙のフォールバックをせず、行ごとに `unavailable` を保持する
@@ -22,6 +25,7 @@ import { create, type StoreApi, type UseBoundStore } from "zustand";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
 import {
+  createPromptJobQueue,
   createSessionPool,
   LowPriorityQueueOverflowError,
   type PromptSessionLike,
@@ -108,6 +112,12 @@ interface ActivePipeline {
   warmUp: () => void;
 }
 
+/**
+ * 全パイプラインで共有する Prompt API の直列キュー(issue #23)。
+ * 言語ペアに依存しないため、パイプラインを再起動してもこのキューは作り直さない
+ */
+const sharedPromptJobQueue = createPromptJobQueue();
+
 export function createAutoPipeline<TDone extends object>(config: AutoPipelineConfig<TDone>): AutoPipeline<TDone> {
   const useStore = create<AutoPipelineState<TDone>>(() => ({ entries: {} }));
 
@@ -122,7 +132,8 @@ export function createAutoPipeline<TDone extends object>(config: AutoPipelineCon
       if (!hydrated) throw new Error("設定が未復元です。hydrateSettingsStore() を先に呼び出してください");
       return settings;
     },
-    createPool: (settings) => createSessionPool({ createBaseSession: config.createBaseSession(settings) }),
+    createPool: (settings) =>
+      createSessionPool({ createBaseSession: config.createBaseSession(settings), queue: sharedPromptJobQueue }),
     subscribeToChatMessages,
     getMessages: () => useChatConnectionStore.getState().messages,
   };

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -9,7 +9,8 @@
  *   `terms` が空の `done` にする(emote だけの発言は `pickUpExpressions` 側が LLM を呼ばず空を返す。issue #26)
  * - ジョブ: `pickUpExpressions` を低優先度で実行し、表示中の発言者名(username / displayName)を
  *   除外名として渡す(@ 無しで本文に書かれたユーザー名を抽出結果から落とすため)
- * - セッションプールは翻訳用とは別に持つ(`structured-prompt.ts` に記載の issue #15 方針 (a))
+ * - セッションプール(ベースセッション)は翻訳用とは別に持つ(`structured-prompt.ts` に記載の issue #15 方針 (a))が、
+ *   ジョブを流す直列キューは `auto-pipeline.ts` で翻訳列と共有する(issue #23)
  * - Prompt API の利用可否は `prompt-api.ts` の共有ストアを参照する(翻訳列と共通)
  */
 import { createPickupBaseSessionFactory, pickUpExpressions } from "@/lib/ai/pickup";


### PR DESCRIPTION
## Summary

翻訳用と Pick up 用の `SessionPool` がそれぞれ独立した直列キュー(`isProcessing`)を持っていたため、Gemini Nano に `prompt()` が 2 つ同時に投げられ、低優先度キューの上限(20)もプールごとに独立して溢れていました。

- `src/lib/ai/session-pool.ts`: 優先度・低優先度上限・abort を扱う直列キューを `createPromptJobQueue()` / `PromptJobQueue` として切り出し、`createSessionPool({ createBaseSession, queue })` はベースセッションの保持とクローンだけを担当するようにしました。ベースセッションの生成・クローンもキューの中で行うため、`LanguageModel.create()` を含めて直列になります
- `src/store/auto-pipeline.ts`: モジュール単位で 1 つの共有キューを作り、全パイプラインのプールに渡します。キューは言語ペアに依存しないため、言語ペア変更でパイプラインを再起動しても作り直しません
- 用途ごとのベースセッション(issue #15 方針 (a))はそのまま維持し、`translate.ts` / `pickup.ts` / `structured-prompt.ts` の呼び出し側 API は変更していません
- `maxLowPriorityQueueLength` が 0 以上の整数でない場合は生成時点で例外を投げます(CodeRabbit 指摘対応)

### issue の提案との違い

issue では `enqueue(priority, run, signal, sessionKey)` のように 1 つのプールに複数ベースセッションを持たせる案でしたが、共有すべきもの(キュー)は言語ペア設定に依存しない一方、ベースセッションは言語ペアごとに作り直す必要があります。キューだけを切り出して共有する形にすると、設定変更時の再生成をパイプライン側(既存の仕組み)に任せたまま「同時実行数 1」「低優先度上限の一本化」の両方を満たせるため、この形にしました。

## Test plan

- [x] `src/lib/ai/session-pool.test.ts`: 同じキューを共有する 2 プール間で直列に実行されること・優先度がプールをまたいで効くこと・低優先度上限が全体で 1 つであること・各プールが自分のベースセッションからクローンすること・上限値の検証を追加
- [x] `npm run lint` / `npm run type-check` / `npm test`(333 件)/ `npm run build` すべて成功
- [x] CodeRabbit レビュー実施(指摘 1 件に対応済み)

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH