### PR TITLE
feat: UI 文字列を英語に統一する(言語学習用ツールのため UI は英語で固定)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "chat-sensei",
   description:
-    "Twitch のライブチャットを 生IRC / 翻訳 / Pick up の3カラムで読む、Chrome内蔵AI(Gemini Nano)で完結するクライアントサイド専用ツール。",
+    "Read Twitch live chat in three columns — raw IRC, translation, and Pick up — powered entirely by Chrome's built-in AI (Gemini Nano). Runs fully client-side.",
 };
 
 export default function RootLayout({
@@ -26,7 +26,7 @@ export default function RootLayout({
 }>) {
   return (
     <html
-      lang="ja"
+      lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -94,8 +94,8 @@ describe("Home(3カラム構成)", () => {
   it("生IRC・翻訳・Pick upの3列を見出し付きで表示する", () => {
     render(<Home />);
 
-    expect(screen.getByRole("region", { name: "生IRC" })).toBeInTheDocument();
-    expect(screen.getByRole("region", { name: "翻訳" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Raw IRC" })).toBeInTheDocument();
+    expect(screen.getByRole("region", { name: "Translation" })).toBeInTheDocument();
     expect(screen.getByRole("region", { name: "Pick up" })).toBeInTheDocument();
   });
 
@@ -104,7 +104,7 @@ describe("Home(3カラム構成)", () => {
 
     render(<Home />);
 
-    const rawColumn = screen.getByRole("region", { name: "生IRC" });
+    const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
     expect(within(rawColumn).getByText("viewer_taro")).toBeInTheDocument();
     expect(within(rawColumn).getByText("gg no re chat")).toBeInTheDocument();
   });
@@ -113,14 +113,14 @@ describe("Home(3カラム構成)", () => {
     const user = userEvent.setup();
     render(<Home />);
 
-    const translationColumn = screen.getByRole("region", { name: "翻訳" });
+    const translationColumn = screen.getByRole("region", { name: "Translation" });
     const pickupColumn = screen.getByRole("region", { name: "Pick up" });
     expect(translationColumn).toHaveAttribute("data-blurred", "true");
     expect(pickupColumn).toHaveAttribute("data-blurred", "true");
 
     // トグルは各列の見出し(ヘッダー)内に目のアイコンとして置く
-    const translationToggle = within(translationColumn).getByRole("switch", { name: "翻訳をぼかす" });
-    const pickupToggle = within(pickupColumn).getByRole("switch", { name: "Pick upをぼかす" });
+    const translationToggle = within(translationColumn).getByRole("switch", { name: "Blur translation" });
+    const pickupToggle = within(pickupColumn).getByRole("switch", { name: "Blur Pick up" });
     expect(translationToggle).toHaveAttribute("aria-checked", "true");
     expect(pickupToggle).toHaveAttribute("aria-checked", "true");
 
@@ -138,7 +138,7 @@ describe("Home(3カラム構成)", () => {
     const user = userEvent.setup();
     render(<Home />);
 
-    const toggle = screen.getByRole("switch", { name: "翻訳をぼかす" });
+    const toggle = screen.getByRole("switch", { name: "Blur translation" });
     expect(toggle.querySelector(".lucide-eye-off")).not.toBeNull();
     expect(toggle.querySelector(".lucide-eye")).toBeNull();
 
@@ -153,8 +153,8 @@ describe("Home(3カラム構成)", () => {
     useChatConnectionStore.setState({ connect: vi.fn() });
     render(<Home />);
 
-    await user.type(screen.getByLabelText("チャンネル名"), "example");
-    await user.click(screen.getByRole("button", { name: "接続する" }));
+    await user.type(screen.getByLabelText("Channel"), "example");
+    await user.click(screen.getByRole("button", { name: "Connect" }));
 
     expect(mockWarmUpTranslationPipeline).toHaveBeenCalledTimes(1);
     expect(mockWarmUpPickupPipeline).toHaveBeenCalledTimes(1);
@@ -183,7 +183,7 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    const translationColumn = screen.getByRole("region", { name: "翻訳" });
+    const translationColumn = screen.getByRole("region", { name: "Translation" });
     const rows = within(translationColumn).getAllByRole("listitem");
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveTextContent("ナイスゲーム、再戦なし、チャット");
@@ -212,7 +212,7 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    const translationColumn = screen.getByRole("region", { name: "翻訳" });
+    const translationColumn = screen.getByRole("region", { name: "Translation" });
     const image = within(translationColumn).getByRole("img", { name: "sayuwuLul" });
     expect(image).toHaveAttribute("src", expect.stringContaining("/emotesv2_1/"));
     expect(within(translationColumn).queryByText(/sayuwuLul/)).not.toBeInTheDocument();
@@ -225,8 +225,8 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    const rawRow = within(screen.getByRole("region", { name: "生IRC" })).getByRole("listitem");
-    const translationRow = within(screen.getByRole("region", { name: "翻訳" })).getByRole("listitem");
+    const rawRow = within(screen.getByRole("region", { name: "Raw IRC" })).getByRole("listitem");
+    const translationRow = within(screen.getByRole("region", { name: "Translation" })).getByRole("listitem");
     expect(rawRow).toHaveAttribute("data-message-id", "msg-1");
     expect(translationRow).toHaveAttribute("data-message-id", "msg-1");
   });
@@ -237,7 +237,7 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "翻訳" })).getByText("翻訳中...")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Translation" })).getByText("Translating...")).toBeInTheDocument();
   });
 
   it("失敗した行は理由付きで「翻訳に失敗」と表示する", () => {
@@ -248,8 +248,8 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    const translationColumn = screen.getByRole("region", { name: "翻訳" });
-    expect(within(translationColumn).getByText(/翻訳に失敗/)).toBeInTheDocument();
+    const translationColumn = screen.getByRole("region", { name: "Translation" });
+    expect(within(translationColumn).getByText(/Translation failed/)).toBeInTheDocument();
     expect(within(translationColumn).getByText(/応答をJSONとして解釈できませんでした/)).toBeInTheDocument();
   });
 
@@ -259,7 +259,7 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "翻訳" })).getByText("未翻訳(流量超過)")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Translation" })).getByText("Not translated (too many messages)")).toBeInTheDocument();
   });
 
   it("Prompt API が利用できない環境では、行ごとに「翻訳不可」と表示し、列の見出し付近に理由を表示する", () => {
@@ -271,8 +271,8 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    const translationColumn = screen.getByRole("region", { name: "翻訳" });
-    expect(within(translationColumn).getByText("翻訳不可")).toBeInTheDocument();
+    const translationColumn = screen.getByRole("region", { name: "Translation" });
+    expect(within(translationColumn).getByText("Translation unavailable")).toBeInTheDocument();
     expect(within(translationColumn).getByText(/window\.LanguageModel/)).toBeInTheDocument();
   });
 
@@ -282,7 +282,7 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "翻訳" })).getByText("未翻訳(IDなし)")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Translation" })).getByText("Not translated (no message ID)")).toBeInTheDocument();
   });
 
   it("翻訳をぼかしている間は翻訳列の各行がぼかされ、解除すると外れる", async () => {
@@ -292,10 +292,10 @@ describe("Home(翻訳列)", () => {
 
     render(<Home />);
 
-    const translationRow = within(screen.getByRole("region", { name: "翻訳" })).getByRole("listitem");
+    const translationRow = within(screen.getByRole("region", { name: "Translation" })).getByRole("listitem");
     expect(translationRow).toHaveClass("blur-sm");
 
-    await user.click(screen.getByRole("switch", { name: "翻訳をぼかす" }));
+    await user.click(screen.getByRole("switch", { name: "Blur translation" }));
     expect(translationRow).not.toHaveClass("blur-sm");
   });
 });
@@ -335,7 +335,7 @@ describe("Home(Pick up列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("なし")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("None")).toBeInTheDocument();
   });
 
   it("生成中の行は「抽出中」と表示する", () => {
@@ -344,7 +344,7 @@ describe("Home(Pick up列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("抽出中...")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("Extracting...")).toBeInTheDocument();
   });
 
   it("失敗した行は理由付きで「抽出に失敗」と表示する", () => {
@@ -356,7 +356,7 @@ describe("Home(Pick up列)", () => {
     render(<Home />);
 
     const pickupColumn = screen.getByRole("region", { name: "Pick up" });
-    expect(within(pickupColumn).getByText(/抽出に失敗/)).toBeInTheDocument();
+    expect(within(pickupColumn).getByText(/Extraction failed/)).toBeInTheDocument();
     expect(within(pickupColumn).getByText(/応答をJSONとして解釈できませんでした/)).toBeInTheDocument();
   });
 
@@ -366,7 +366,7 @@ describe("Home(Pick up列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("未抽出(流量超過)")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("Not extracted (too many messages)")).toBeInTheDocument();
   });
 
   it("Prompt API が利用できない環境では、行ごとに「抽出不可」と表示し、列の見出し付近に理由を表示する", () => {
@@ -379,7 +379,7 @@ describe("Home(Pick up列)", () => {
     render(<Home />);
 
     const pickupColumn = screen.getByRole("region", { name: "Pick up" });
-    expect(within(pickupColumn).getByText("抽出不可")).toBeInTheDocument();
+    expect(within(pickupColumn).getByText("Extraction unavailable")).toBeInTheDocument();
     expect(within(pickupColumn).getByText(/window\.LanguageModel/)).toBeInTheDocument();
   });
 
@@ -389,7 +389,7 @@ describe("Home(Pick up列)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("未抽出(IDなし)")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("Not extracted (no message ID)")).toBeInTheDocument();
   });
 
   it("Pick upをぼかしている間はPick up列の各行がぼかされ、解除すると外れる", async () => {
@@ -402,7 +402,7 @@ describe("Home(Pick up列)", () => {
     const row = within(screen.getByRole("region", { name: "Pick up" })).getByRole("listitem");
     expect(row).toHaveClass("blur-sm");
 
-    await user.click(screen.getByRole("switch", { name: "Pick upをぼかす" }));
+    await user.click(screen.getByRole("switch", { name: "Blur Pick up" }));
     expect(row).not.toHaveClass("blur-sm");
   });
 });
@@ -413,11 +413,11 @@ describe("Home(bot除外設定)", () => {
     useBotFilterStore.getState().setPatterns(["nightbot", "*trans"]);
     render(<Home />);
 
-    const rawColumn = screen.getByRole("region", { name: "生IRC" });
-    await user.click(within(rawColumn).getByRole("button", { name: "bot除外設定" }));
+    const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
+    await user.click(within(rawColumn).getByRole("button", { name: "Bot filter" }));
 
-    const dialog = await screen.findByRole("dialog", { name: "bot除外設定" });
-    expect(within(dialog).getByRole("textbox", { name: "除外するユーザー名" })).toHaveValue("nightbot\n*trans");
+    const dialog = await screen.findByRole("dialog", { name: "Bot filter" });
+    expect(within(dialog).getByRole("textbox", { name: "Usernames to hide" })).toHaveValue("nightbot\n*trans");
   });
 
   it("パターンを編集して保存すると、ストアに反映され LocalStorage にも保存される", async () => {
@@ -425,12 +425,12 @@ describe("Home(bot除外設定)", () => {
     useBotFilterStore.getState().setPatterns([]);
     render(<Home />);
 
-    await user.click(screen.getByRole("button", { name: "bot除外設定" }));
-    const dialog = await screen.findByRole("dialog", { name: "bot除外設定" });
-    const textbox = within(dialog).getByRole("textbox", { name: "除外するユーザー名" });
+    await user.click(screen.getByRole("button", { name: "Bot filter" }));
+    const dialog = await screen.findByRole("dialog", { name: "Bot filter" });
+    const textbox = within(dialog).getByRole("textbox", { name: "Usernames to hide" });
     await user.clear(textbox);
     await user.type(textbox, "StreamElements{enter}*bot");
-    await user.click(within(dialog).getByRole("button", { name: "保存する" }));
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
     expect(useBotFilterStore.getState().patterns).toEqual(["streamelements", "*bot"]);
     expect(JSON.parse(window.localStorage.getItem("chat-sensei:bot-filter") ?? "null")).toEqual([
@@ -452,10 +452,10 @@ describe("Home(bot除外設定)", () => {
     window.localStorage.setItem("chat-sensei:bot-filter", "壊れたデータ");
     render(<Home />);
 
-    await user.click(screen.getByRole("button", { name: "bot除外設定" }));
+    await user.click(screen.getByRole("button", { name: "Bot filter" }));
 
-    const dialog = await screen.findByRole("dialog", { name: "bot除外設定" });
-    expect(within(dialog).getByText(/デフォルトに戻しました/)).toBeInTheDocument();
+    const dialog = await screen.findByRole("dialog", { name: "Bot filter" });
+    expect(within(dialog).getByText(/reset to the defaults/)).toBeInTheDocument();
   });
 });
 
@@ -468,13 +468,13 @@ describe("Home(Prompt API の利用可否)", () => {
 
     render(<Home />);
 
-    const translationColumn = screen.getByRole("region", { name: "翻訳" });
+    const translationColumn = screen.getByRole("region", { name: "Translation" });
     const pickupColumn = screen.getByRole("region", { name: "Pick up" });
     expect(within(translationColumn).getByText(/window\.LanguageModel/)).toBeInTheDocument();
     expect(within(pickupColumn).getByText(/window\.LanguageModel/)).toBeInTheDocument();
     // エントリが無い行も、共有の状態を見て両列とも「不可」になる
-    expect(within(translationColumn).getByText("翻訳不可")).toBeInTheDocument();
-    expect(within(pickupColumn).getByText("抽出不可")).toBeInTheDocument();
+    expect(within(translationColumn).getByText("Translation unavailable")).toBeInTheDocument();
+    expect(within(pickupColumn).getByText("Extraction unavailable")).toBeInTheDocument();
   });
 
   it("診断中は両列とも「準備中...」と表示する", () => {
@@ -482,8 +482,8 @@ describe("Home(Prompt API の利用可否)", () => {
 
     render(<Home />);
 
-    expect(within(screen.getByRole("region", { name: "翻訳" })).getByText("準備中...")).toBeInTheDocument();
-    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("準備中...")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Translation" })).getByText("Preparing...")).toBeInTheDocument();
+    expect(within(screen.getByRole("region", { name: "Pick up" })).getByText("Preparing...")).toBeInTheDocument();
   });
 });
 
@@ -493,11 +493,11 @@ describe("Home(設定ダイアログ)", () => {
     window.localStorage.setItem("chat-sensei:settings", JSON.stringify({ targetLang: "es", explainLang: "en" }));
     render(<Home />);
 
-    await user.click(screen.getByRole("button", { name: "設定" }));
+    await user.click(screen.getByRole("button", { name: "Settings" }));
 
-    const dialog = await screen.findByRole("dialog", { name: "設定" });
-    expect(within(dialog).getByRole("combobox", { name: "学ぶ言語" })).toHaveValue("es");
-    expect(within(dialog).getByRole("combobox", { name: "解説言語" })).toHaveValue("en");
+    const dialog = await screen.findByRole("dialog", { name: "Settings" });
+    expect(within(dialog).getByRole("combobox", { name: "Learning language" })).toHaveValue("es");
+    expect(within(dialog).getByRole("combobox", { name: "Explanation language" })).toHaveValue("en");
   });
 
   it("マウント時に LocalStorage から言語ペアを復元してから、パイプラインを開始する", () => {
@@ -515,10 +515,10 @@ describe("Home(設定ダイアログ)", () => {
     render(<Home />);
     expect(mockStartTranslationPipeline).toHaveBeenCalledTimes(1);
 
-    await user.click(screen.getByRole("button", { name: "設定" }));
-    const dialog = await screen.findByRole("dialog", { name: "設定" });
-    await user.selectOptions(within(dialog).getByRole("combobox", { name: "学ぶ言語" }), "de");
-    await user.click(within(dialog).getByRole("button", { name: "保存する" }));
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    const dialog = await screen.findByRole("dialog", { name: "Settings" });
+    await user.selectOptions(within(dialog).getByRole("combobox", { name: "Learning language" }), "de");
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
     expect(mockStopPipeline).toHaveBeenCalledTimes(1);
     expect(mockStopPickupPipeline).toHaveBeenCalledTimes(1);
@@ -530,9 +530,9 @@ describe("Home(設定ダイアログ)", () => {
     const user = userEvent.setup();
     render(<Home />);
 
-    await user.click(screen.getByRole("button", { name: "設定" }));
-    const dialog = await screen.findByRole("dialog", { name: "設定" });
-    await user.click(within(dialog).getByRole("button", { name: "保存する" }));
+    await user.click(screen.getByRole("button", { name: "Settings" }));
+    const dialog = await screen.findByRole("dialog", { name: "Settings" });
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
     expect(mockStopPipeline).not.toHaveBeenCalled();
     expect(mockStartTranslationPipeline).toHaveBeenCalledTimes(1);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,11 +52,37 @@ import {
 } from "@/store/translations";
 
 const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
-  idle: "待機中",
-  connecting: "接続中...",
-  open: "接続済み",
-  reconnecting: "再接続中...",
-  closed: "切断済み",
+  idle: "Idle",
+  connecting: "Connecting...",
+  open: "Connected",
+  reconnecting: "Reconnecting...",
+  closed: "Disconnected",
+};
+
+/** 翻訳列・Pick up 列の行に表示する状態文言。列ごとに動詞が異なるため文言一式で受け取る */
+interface PipelineCellLabels {
+  /** 未処理(例: "Not translated") */
+  notYet: string;
+  /** 処理中(例: "Translating...") */
+  pending: string;
+  /** 失敗(例: "Translation failed") */
+  failed: string;
+  /** Prompt API 利用不可(例: "Translation unavailable") */
+  unavailable: string;
+}
+
+const TRANSLATION_LABELS: PipelineCellLabels = {
+  notYet: "Not translated",
+  pending: "Translating...",
+  failed: "Translation failed",
+  unavailable: "Translation unavailable",
+};
+
+const PICKUP_LABELS: PipelineCellLabels = {
+  notYet: "Not extracted",
+  pending: "Extracting...",
+  failed: "Extraction failed",
+  unavailable: "Extraction unavailable",
 };
 
 /** 接続中とみなす状態(切断ボタンに切り替える基準) */
@@ -119,28 +145,28 @@ export default function Home() {
     <div className="flex w-full flex-1 flex-col gap-4 p-6">
       <div className="flex flex-wrap items-end gap-4">
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor="channel-input">チャンネル名</Label>
+          <Label htmlFor="channel-input">Channel</Label>
           <div className="flex items-center gap-2">
             <Input
               id="channel-input"
-              placeholder="例: zackrawrr"
+              placeholder="e.g. zackrawrr"
               value={channelInput}
               onChange={(e) => setChannelInput(e.target.value)}
               disabled={connected}
             />
             {connected ? (
               <Button onClick={disconnect} variant="outline">
-                切断する
+                Disconnect
               </Button>
             ) : (
               <Button onClick={handleConnect} disabled={channelInput.trim().length === 0}>
-                接続する
+                Connect
               </Button>
             )}
             <SettingsDialog />
           </div>
           <p className="text-xs text-muted-foreground" role="status">
-            状態: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
+            Status: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
           </p>
         </div>
       </div>
@@ -151,7 +177,7 @@ export default function Home() {
           // 見出し1行 + 発言数ぶんの行。各列は subgrid でこの行トラックを共有する
           style={{ gridTemplateRows: `auto repeat(${messages.length}, auto)` }}
         >
-          <Column title="生IRC" blurred={false} headerAction={<BotFilterDialog />}>
+          <Column title="Raw IRC" blurred={false} headerAction={<BotFilterDialog />}>
             <div role="list" className="contents">
               {messages.map((message, index) => (
                 <ChatMessageRow key={messageKey(message, index)} message={message} />
@@ -159,10 +185,10 @@ export default function Home() {
             </div>
           </Column>
           <Column
-            title="翻訳"
+            title="Translation"
             blurred={translationBlurred}
             headerAction={
-              <BlurToggle label="翻訳をぼかす" blurred={translationBlurred} onBlurredChange={setTranslationBlurred} />
+              <BlurToggle label="Blur translation" blurred={translationBlurred} onBlurredChange={setTranslationBlurred} />
             }
             headerExtra={<PromptApiUnavailableReason promptApi={promptApi} />}
           >
@@ -173,7 +199,7 @@ export default function Home() {
                     message={message}
                     entry={message.id === null ? undefined : translationEntries[message.id]}
                     promptApi={promptApi}
-                    noun="翻訳"
+                    labels={TRANSLATION_LABELS}
                     renderDone={(done) => <TranslationText segments={done.segments} />}
                   />
                 </Row>
@@ -183,7 +209,7 @@ export default function Home() {
           <Column
             title="Pick up"
             blurred={pickupBlurred}
-            headerAction={<BlurToggle label="Pick upをぼかす" blurred={pickupBlurred} onBlurredChange={setPickupBlurred} />}
+            headerAction={<BlurToggle label="Blur Pick up" blurred={pickupBlurred} onBlurredChange={setPickupBlurred} />}
             headerExtra={<PromptApiUnavailableReason promptApi={promptApi} />}
           >
             <div role="list" className="contents">
@@ -193,7 +219,7 @@ export default function Home() {
                     message={message}
                     entry={message.id === null ? undefined : pickupEntries[message.id]}
                     promptApi={promptApi}
-                    noun="抽出"
+                    labels={PICKUP_LABELS}
                     renderDone={(done) => <PickupTerms terms={done.terms} />}
                   />
                 </Row>
@@ -220,7 +246,7 @@ function BlurToggle({
   blurred,
   onBlurredChange,
 }: {
-  /** スクリーンリーダー向けの名前(例: "翻訳をぼかす") */
+  /** スクリーンリーダー向けの名前(例: "Blur translation") */
   label: string;
   blurred: boolean;
   onBlurredChange: (blurred: boolean) => void;
@@ -309,53 +335,53 @@ function PromptApiUnavailableReason({ promptApi }: { promptApi: PromptApiStatus 
 
 /**
  * 翻訳列・Pick up列で共通の1行の中身。生成中・失敗・キュー溢れ・Prompt API 利用不可の各状態を
- * 暗黙に隠さず明示する。表示文言は `noun`(「翻訳」「抽出」)から組み立て、完了時の描画だけを
+ * 暗黙に隠さず明示する。表示文言は `labels`(翻訳列・Pick up 列ごとの文言一式)から選び、完了時の描画だけを
  * `renderDone` で列ごとに差し替える。
  */
 function PipelineCellContent<TDone extends object>({
   message,
   entry,
   promptApi,
-  noun,
+  labels,
   renderDone,
 }: {
   message: TwitchChatMessage;
   entry: PipelineEntry<TDone> | undefined;
   promptApi: PromptApiStatus;
-  /** 状態表示の文言に使う処理名(例: "翻訳" → 「翻訳中...」「未翻訳」「翻訳不可」) */
-  noun: string;
+  /** 状態表示の文言一式(翻訳列なら `TRANSLATION_LABELS`) */
+  labels: PipelineCellLabels;
   /** 完了した結果の描画 */
   renderDone: (done: TDone) => React.ReactNode;
 }) {
   if (message.id === null) {
-    return <span className="text-muted-foreground">未{noun}(IDなし)</span>;
+    return <span className="text-muted-foreground">{labels.notYet} (no message ID)</span>;
   }
   if (!entry) {
-    if (promptApi.status === "unavailable") return <span className="text-muted-foreground">{noun}不可</span>;
-    if (promptApi.status === "checking") return <span className="text-muted-foreground">準備中...</span>;
-    return <span className="text-muted-foreground">未{noun}</span>;
+    if (promptApi.status === "unavailable") return <span className="text-muted-foreground">{labels.unavailable}</span>;
+    if (promptApi.status === "checking") return <span className="text-muted-foreground">Preparing...</span>;
+    return <span className="text-muted-foreground">{labels.notYet}</span>;
   }
   switch (entry.status) {
     case "pending":
-      return <span className="text-muted-foreground">{noun}中...</span>;
+      return <span className="text-muted-foreground">{labels.pending}</span>;
     case "done":
       return renderDone(entry);
     case "failed":
       return (
         <span className="text-destructive">
-          {noun}に失敗: {entry.reason}
+          {labels.failed}: {entry.reason}
         </span>
       );
     case "dropped":
-      return <span className="text-muted-foreground">未{noun}(流量超過)</span>;
+      return <span className="text-muted-foreground">{labels.notYet} (too many messages)</span>;
     case "unavailable":
-      return <span className="text-muted-foreground">{noun}不可</span>;
+      return <span className="text-muted-foreground">{labels.unavailable}</span>;
   }
 }
 
-/** Pick up列の完了した結果。該当する表現が無い場合は「なし」と控えめに表示する */
+/** Pick up列の完了した結果。該当する表現が無い場合は「None」と控えめに表示する */
 function PickupTerms({ terms }: { terms: PickupDone["terms"] }) {
-  if (terms.length === 0) return <span className="text-muted-foreground">なし</span>;
+  if (terms.length === 0) return <span className="text-muted-foreground">None</span>;
   return (
     <dl className="flex flex-col gap-0.5">
       {terms.map((term, index) => (

--- a/src/components/bot-filter-dialog.tsx
+++ b/src/components/bot-filter-dialog.tsx
@@ -29,7 +29,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { formatBotFilterPatterns, parseBotFilterPatterns } from "@/lib/bot-filter";
 import { useBotFilterStore } from "@/store/bot-filter";
 
-const DIALOG_TITLE = "bot除外設定";
+const DIALOG_TITLE = "Bot filter";
 const TEXTAREA_ID = "bot-filter-patterns";
 const TEXTAREA_ROWS = 10;
 
@@ -61,17 +61,17 @@ export function BotFilterDialog() {
         <DialogHeader>
           <DialogTitle>{DIALOG_TITLE}</DialogTitle>
           <DialogDescription>
-            除外するユーザー名を1行に1つずつ入力してください。<code>*</code> は任意の文字列に一致します(例:{" "}
-            <code>*trans</code>, <code>*bot</code>)。
+            Enter one username per line to hide. <code>*</code> matches any characters (e.g. <code>*trans</code>,{" "}
+            <code>*bot</code>).
           </DialogDescription>
         </DialogHeader>
         {wasCorrupted && (
           <p className="text-xs text-destructive" role="alert">
-            保存されていた設定が壊れていたため、デフォルトに戻しました。保存し直すと解消します。
+            Your saved settings were corrupted and have been reset to the defaults. Save again to clear this notice.
           </p>
         )}
         <div className="flex flex-col gap-1.5">
-          <Label htmlFor={TEXTAREA_ID}>除外するユーザー名</Label>
+          <Label htmlFor={TEXTAREA_ID}>Usernames to hide</Label>
           <Textarea
             id={TEXTAREA_ID}
             rows={TEXTAREA_ROWS}
@@ -82,8 +82,8 @@ export function BotFilterDialog() {
           />
         </div>
         <DialogFooter>
-          <DialogClose render={<Button variant="outline" />}>キャンセル</DialogClose>
-          <Button onClick={handleSave}>保存する</Button>
+          <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+          <Button onClick={handleSave}>Save</Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/settings-dialog.test.tsx
+++ b/src/components/settings-dialog.test.tsx
@@ -43,15 +43,15 @@ afterEach(() => {
 
 /** ダイアログを開き、ダイアログ要素を返す */
 async function openDialog(user: ReturnType<typeof userEvent.setup>) {
-  await user.click(screen.getByRole("button", { name: "設定" }));
-  return screen.findByRole("dialog", { name: "設定" });
+  await user.click(screen.getByRole("button", { name: "Settings" }));
+  return screen.findByRole("dialog", { name: "Settings" });
 }
 
 describe("SettingsDialog(言語ペア)", () => {
   it("ストアが LocalStorage から未復元の間は、設定ボタンを無効にして開けないようにする(デフォルト設定で上書きしないため)", () => {
     render(<SettingsDialog />);
 
-    expect(screen.getByRole("button", { name: "設定" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Settings" })).toBeDisabled();
   });
 
   it("設定ボタンから開くと、学ぶ言語・解説言語のセレクトに現在の設定が入っている", async () => {
@@ -62,8 +62,8 @@ describe("SettingsDialog(言語ペア)", () => {
 
     const dialog = await openDialog(user);
 
-    expect(within(dialog).getByRole("combobox", { name: "学ぶ言語" })).toHaveValue("es");
-    expect(within(dialog).getByRole("combobox", { name: "解説言語" })).toHaveValue("en");
+    expect(within(dialog).getByRole("combobox", { name: "Learning language" })).toHaveValue("es");
+    expect(within(dialog).getByRole("combobox", { name: "Explanation language" })).toHaveValue("en");
   });
 
   it("言語ペアを変更して保存すると、ストアに反映され LocalStorage にも保存され、ダイアログが閉じる", async () => {
@@ -72,15 +72,15 @@ describe("SettingsDialog(言語ペア)", () => {
     render(<SettingsDialog />);
 
     const dialog = await openDialog(user);
-    await user.selectOptions(within(dialog).getByRole("combobox", { name: "学ぶ言語" }), "de");
-    await user.click(within(dialog).getByRole("button", { name: "保存する" }));
+    await user.selectOptions(within(dialog).getByRole("combobox", { name: "Learning language" }), "de");
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
     expect(useSettingsStore.getState().settings).toEqual({ targetLang: "de", explainLang: "ja" });
     expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "null")).toEqual({
       targetLang: "de",
       explainLang: "ja",
     });
-    expect(screen.queryByRole("dialog", { name: "設定" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog", { name: "Settings" })).not.toBeInTheDocument();
   });
 
   it("学ぶ言語と解説言語に同じ言語を選んで保存するとエラーを表示し、保存しない", async () => {
@@ -89,13 +89,13 @@ describe("SettingsDialog(言語ペア)", () => {
     render(<SettingsDialog />);
 
     const dialog = await openDialog(user);
-    await user.selectOptions(within(dialog).getByRole("combobox", { name: "学ぶ言語" }), "ja");
-    await user.click(within(dialog).getByRole("button", { name: "保存する" }));
+    await user.selectOptions(within(dialog).getByRole("combobox", { name: "Learning language" }), "ja");
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
-    expect(within(dialog).getByRole("alert")).toHaveTextContent("異なる言語を指定してください");
+    expect(within(dialog).getByRole("alert")).toHaveTextContent("must be different");
     expect(useSettingsStore.getState().settings).toEqual(DEFAULT_SETTINGS);
     expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
-    expect(screen.getByRole("dialog", { name: "設定" })).toBeInTheDocument();
+    expect(screen.getByRole("dialog", { name: "Settings" })).toBeInTheDocument();
   });
 
   it("保存データが壊れていた場合は、デフォルトに戻した旨を表示する", async () => {
@@ -106,7 +106,7 @@ describe("SettingsDialog(言語ペア)", () => {
 
     const dialog = await openDialog(user);
 
-    expect(within(dialog).getByText(/デフォルトに戻しました/)).toBeInTheDocument();
+    expect(within(dialog).getByText(/reset to the defaults/)).toBeInTheDocument();
   });
 
   it("「設定を初期化する」で LocalStorage の設定を削除し、セレクトもデフォルトに戻る", async () => {
@@ -116,12 +116,12 @@ describe("SettingsDialog(言語ペア)", () => {
     render(<SettingsDialog />);
 
     const dialog = await openDialog(user);
-    await user.click(within(dialog).getByRole("button", { name: "設定を初期化する" }));
+    await user.click(within(dialog).getByRole("button", { name: "Reset settings" }));
 
     expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
     expect(useSettingsStore.getState().settings).toEqual(DEFAULT_SETTINGS);
-    expect(within(dialog).getByRole("combobox", { name: "学ぶ言語" })).toHaveValue("en");
-    expect(within(dialog).getByRole("combobox", { name: "解説言語" })).toHaveValue("ja");
+    expect(within(dialog).getByRole("combobox", { name: "Learning language" })).toHaveValue("en");
+    expect(within(dialog).getByRole("combobox", { name: "Explanation language" })).toHaveValue("ja");
   });
 });
 
@@ -137,9 +137,9 @@ describe("SettingsDialog(環境診断)", () => {
     const items = await within(dialog).findAllByRole("listitem");
     expect(items.map((item) => item.textContent)).toEqual([
       expect.stringContaining("Chrome 150"),
-      expect.stringContaining("Prompt API はすぐに利用できます"),
-      expect.stringContaining("Language Detector API は利用可能です"),
-      expect.stringContaining("約10.0GB"),
+      expect.stringContaining("The Prompt API is ready to use"),
+      expect.stringContaining("The Language Detector API is available"),
+      expect.stringContaining("about 10.0GB"),
     ]);
   });
 
@@ -151,7 +151,7 @@ describe("SettingsDialog(環境診断)", () => {
 
     const dialog = await openDialog(user);
 
-    expect(within(dialog).getByText("診断中...")).toBeInTheDocument();
+    expect(within(dialog).getByText("Checking...")).toBeInTheDocument();
   });
 
   it("診断そのものが失敗した場合は理由を表示する(暗黙に利用可能扱いにしない)", async () => {
@@ -163,7 +163,7 @@ describe("SettingsDialog(環境診断)", () => {
     const dialog = await openDialog(user);
 
     expect(await within(dialog).findByRole("alert")).toHaveTextContent(
-      "環境診断に失敗しました: LanguageModel.availability がクラッシュしました",
+      "Environment check failed: LanguageModel.availability がクラッシュしました",
     );
   });
 });

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -39,7 +39,7 @@ import { LANGUAGE_DISPLAY_NAMES, settingsSchema, type Settings } from "@/lib/set
 import { cn } from "@/lib/utils";
 import { clearSettingsStore, useSettingsStore } from "@/store/settings";
 
-const DIALOG_TITLE = "設定";
+const DIALOG_TITLE = "Settings";
 /** セレクトの値(文字列)を対応言語コードに検証する。対応外の値は Fail-Fast で例外にする */
 const languageSchema = z.enum(SUPPORTED_LANGUAGES);
 const TARGET_LANG_SELECT_ID = "settings-target-lang";
@@ -79,7 +79,7 @@ export function SettingsDialog() {
   const handleSave = () => {
     const validation = settingsSchema.safeParse(draft);
     if (!validation.success) {
-      setSaveError(validation.error.issues[0]?.message ?? "設定が不正です");
+      setSaveError(validation.error.issues[0]?.message ?? "Invalid settings");
       return;
     }
     setSettings(validation.data);
@@ -102,27 +102,28 @@ export function SettingsDialog() {
         <DialogHeader>
           <DialogTitle>{DIALOG_TITLE}</DialogTitle>
           <DialogDescription>
-            学ぶ言語(チャットの原文の言語)と解説言語(翻訳・Pick up の意味を表示する言語)を選びます。
-            保存すると表示中の発言の翻訳・Pick up を新しい言語ペアで生成し直します。
+            Choose the language you are learning (the language of the chat) and the explanation language (used for
+            translations and Pick up meanings). Saving regenerates the translations and Pick ups for the messages
+            currently shown with the new language pair.
           </DialogDescription>
         </DialogHeader>
 
         {wasCorrupted && (
           <p className="text-xs text-destructive" role="alert">
-            保存されていた設定が壊れていたため、デフォルトに戻しました。保存し直すと解消します。
+            Your saved settings were corrupted and have been reset to the defaults. Save again to clear this notice.
           </p>
         )}
 
         <div className="grid grid-cols-2 gap-4">
           <LanguageSelect
             id={TARGET_LANG_SELECT_ID}
-            label="学ぶ言語"
+            label="Learning language"
             value={draft.targetLang}
             onChange={(targetLang) => setDraft((prev) => ({ ...prev, targetLang }))}
           />
           <LanguageSelect
             id={EXPLAIN_LANG_SELECT_ID}
-            label="解説言語"
+            label="Explanation language"
             value={draft.explainLang}
             onChange={(explainLang) => setDraft((prev) => ({ ...prev, explainLang }))}
           />
@@ -138,11 +139,11 @@ export function SettingsDialog() {
 
         <DialogFooter className="sm:justify-between">
           <Button variant="outline" onClick={handleClear}>
-            設定を初期化する
+            Reset settings
           </Button>
           <div className="flex gap-2">
-            <DialogClose render={<Button variant="outline" />}>キャンセル</DialogClose>
-            <Button onClick={handleSave}>保存する</Button>
+            <DialogClose render={<Button variant="outline" />}>Cancel</DialogClose>
+            <Button onClick={handleSave}>Save</Button>
           </div>
         </DialogFooter>
       </DialogContent>
@@ -208,12 +209,12 @@ function DiagnosisSection({ open }: { open: boolean }) {
   }, [open]);
 
   return (
-    <section aria-label="環境診断" className="flex flex-col gap-2 rounded-lg border p-3">
-      <h3 className="text-sm font-semibold">環境診断</h3>
-      {state.status === "loading" && <p className="text-xs text-muted-foreground">診断中...</p>}
+    <section aria-label="Environment check" className="flex flex-col gap-2 rounded-lg border p-3">
+      <h3 className="text-sm font-semibold">Environment check</h3>
+      {state.status === "loading" && <p className="text-xs text-muted-foreground">Checking...</p>}
       {state.status === "error" && (
         <p className="text-xs text-destructive" role="alert">
-          環境診断に失敗しました: {state.errorMessage}
+          Environment check failed: {state.errorMessage}
         </p>
       )}
       {state.status === "loaded" && (

--- a/src/components/twitch-embed-player.test.tsx
+++ b/src/components/twitch-embed-player.test.tsx
@@ -13,7 +13,7 @@ describe("TwitchEmbedPlayer", () => {
   it("指定したチャンネル名と現在のホスト名(parent)を含むiframeを表示する", () => {
     render(<TwitchEmbedPlayer channel="zackrawrr" />);
 
-    const iframe = screen.getByTitle("Twitch配信プレイヤー: zackrawrr");
+    const iframe = screen.getByTitle("Twitch player: zackrawrr");
     expect(iframe.tagName).toBe("IFRAME");
     const src = new URL(iframe.getAttribute("src") ?? "");
     expect(src.origin + src.pathname).toBe("https://player.twitch.tv/");
@@ -25,7 +25,7 @@ describe("TwitchEmbedPlayer", () => {
   it("自動再生時にブラウザの自動再生ポリシーでブロックされないよう、既定でミュート再生する", () => {
     render(<TwitchEmbedPlayer channel="zackrawrr" />);
 
-    const iframe = screen.getByTitle("Twitch配信プレイヤー: zackrawrr");
+    const iframe = screen.getByTitle("Twitch player: zackrawrr");
     const src = new URL(iframe.getAttribute("src") ?? "");
     expect(src.searchParams.get("muted")).toBe("true");
   });
@@ -34,7 +34,7 @@ describe("TwitchEmbedPlayer", () => {
     const { rerender } = render(<TwitchEmbedPlayer channel="zackrawrr" />);
     rerender(<TwitchEmbedPlayer channel="shroud" />);
 
-    const iframe = screen.getByTitle("Twitch配信プレイヤー: shroud");
+    const iframe = screen.getByTitle("Twitch player: shroud");
     const src = new URL(iframe.getAttribute("src") ?? "");
     expect(src.searchParams.get("channel")).toBe("shroud");
   });

--- a/src/components/twitch-embed-player.tsx
+++ b/src/components/twitch-embed-player.tsx
@@ -46,7 +46,7 @@ export function TwitchEmbedPlayer({ channel }: TwitchEmbedPlayerProps) {
   return (
     <iframe
       src={src.toString()}
-      title={`Twitch配信プレイヤー: ${channel}`}
+      title={`Twitch player: ${channel}`}
       allowFullScreen
       // Twitch embedの推奨最小サイズ(400x300px)を狭い画面でも下回らないようmin-h/min-wを設定する
       className="aspect-video w-full min-h-[300px] min-w-[300px]"

--- a/src/lib/ai/describeDiagnosis.test.ts
+++ b/src/lib/ai/describeDiagnosis.test.ts
@@ -73,7 +73,7 @@ describe("describeDiagnosis", () => {
 
     const lmMessage = messages.find((m) => m.id === "language-model");
     expect(lmMessage?.level).toBe("warning");
-    expect(lmMessage?.message).toContain("ダウンロード");
+    expect(lmMessage?.message).toContain("download");
   });
 
   it("LanguageModel.availability() が 'available' の場合は ok", () => {

--- a/src/lib/ai/describeDiagnosis.ts
+++ b/src/lib/ai/describeDiagnosis.ts
@@ -1,6 +1,6 @@
 /**
  * `EnvironmentDiagnosis`(環境診断結果)を、設定画面にそのまま表示できる
- * 日本語メッセージと重大度のリストに変換する純関数。
+ * 英語メッセージ(UI は言語学習用途のため英語で統一)と重大度のリストに変換する純関数。
  *
  * chat-sensei は「AIが使えない環境ではクラウドAPIに切り替える」といった
  * 暗黙のフォールバックを行わないため(CLAUDE.md の Fail-Fast 方針)、
@@ -26,20 +26,20 @@ function describeChromeVersion(diagnosis: EnvironmentDiagnosis): DiagnosisMessag
     return {
       id: "chrome-version",
       level: "ok",
-      message: `Chrome ${diagnosis.chromeVersion} を検出しました(Prompt API 対応)。`,
+      message: `Detected Chrome ${diagnosis.chromeVersion} (supports the Prompt API).`,
     };
   }
   if (diagnosis.chromeVersion === null) {
     return {
       id: "chrome-version",
       level: "error",
-      message: `Chrome を検出できませんでした。Prompt API は Chrome ${MINIMUM_CHROME_VERSION} 以降でのみ動作します。`,
+      message: `Chrome was not detected. The Prompt API only works in Chrome ${MINIMUM_CHROME_VERSION} or later.`,
     };
   }
   return {
     id: "chrome-version",
     level: "error",
-    message: `Chrome ${diagnosis.chromeVersion} を検出しましたが、Prompt API には Chrome ${MINIMUM_CHROME_VERSION} 以降が必要です。Chrome を最新版に更新してください。`,
+    message: `Detected Chrome ${diagnosis.chromeVersion}, but the Prompt API requires Chrome ${MINIMUM_CHROME_VERSION} or later. Please update Chrome.`,
   };
 }
 
@@ -48,27 +48,27 @@ function describeLanguageModel(diagnosis: EnvironmentDiagnosis): DiagnosisMessag
     return {
       id: "language-model",
       level: "error",
-      message: "この環境では Prompt API (window.LanguageModel) が見つかりません。翻訳・Pick up の生成は無効化されます。",
+      message: "The Prompt API (window.LanguageModel) was not found in this environment. Translation and Pick up are disabled.",
     };
   }
 
   switch (diagnosis.languageModel.availability) {
     case "available":
-      return { id: "language-model", level: "ok", message: "Prompt API はすぐに利用できます。" };
+      return { id: "language-model", level: "ok", message: "The Prompt API is ready to use." };
     case "downloadable":
       return {
         id: "language-model",
         level: "warning",
-        message: "Prompt API はモデルのダウンロードが必要です。次の操作でダウンロードを開始します。",
+        message: "The Prompt API needs to download its model. The download starts on your next action.",
       };
     case "downloading":
-      return { id: "language-model", level: "warning", message: "Prompt API のモデルをダウンロード中です。" };
+      return { id: "language-model", level: "warning", message: "The Prompt API model is downloading." };
     case "unavailable":
     default:
       return {
         id: "language-model",
         level: "error",
-        message: "この端末・環境では Prompt API を利用できません(非対応OS、または空き容量不足の可能性があります)。",
+        message: "The Prompt API is not available on this device (unsupported OS or not enough free disk space).",
       };
   }
 }
@@ -78,13 +78,13 @@ function describeLanguageDetector(diagnosis: EnvironmentDiagnosis): DiagnosisMes
     return {
       id: "language-detector",
       level: "warning",
-      message: "Language Detector API が利用できません。自動言語判定は無効化されますが、他の機能には影響しません。",
+      message: "The Language Detector API is not available. Automatic language detection is disabled; other features are unaffected.",
     };
   }
   return {
     id: "language-detector",
     level: "ok",
-    message: "Language Detector API は利用可能です。",
+    message: "The Language Detector API is available.",
   };
 }
 
@@ -102,14 +102,14 @@ function describeStorage(diagnosis: EnvironmentDiagnosis): DiagnosisMessage {
     return {
       id: "storage",
       level: "warning",
-      message: "このサイト用のストレージ割り当てを取得できませんでした。",
+      message: "Could not read the storage quota for this site.",
     };
   }
   const quotaGb = (quota / BYTES_PER_GB).toFixed(1);
   return {
     id: "storage",
     level: "ok",
-    message: `このサイト用のストレージ割り当ては約${quotaGb}GBです(参考値)。これは Prompt API のモデルダウンロードに必要な OS 側の空き容量${MINIMUM_STORAGE_GB}GBとは別の指標のため、ダウンロードに失敗する場合は OS のストレージ空き容量をご確認ください。`,
+    message: `The storage quota for this site is about ${quotaGb}GB (for reference). This is separate from the ${MINIMUM_STORAGE_GB}GB of free OS disk space the Prompt API model download requires, so if the download fails, check your OS free disk space.`,
   };
 }
 

--- a/src/lib/ai/pickup.test.ts
+++ b/src/lib/ai/pickup.test.ts
@@ -112,7 +112,7 @@ describe("pickUpExpressions(JSON 解釈失敗時の再試行、issue #19)", () =
     const pool = createFakeSessionPool(['{"terms":[{"term":"gg"', '{"terms":[']);
 
     await expect(pickUpExpressions(pool, "gg chat")).rejects.toThrow(
-      `Prompt APIの応答をJSONとして解釈できませんでした(${STRUCTURED_PROMPT_MAX_ATTEMPTS}回試行): {"terms":[`,
+      `Could not parse the Prompt API response as JSON (${STRUCTURED_PROMPT_MAX_ATTEMPTS} attempts): {"terms":[`,
     );
     expect(pool.enqueue).toHaveBeenCalledTimes(STRUCTURED_PROMPT_MAX_ATTEMPTS);
   });
@@ -146,7 +146,7 @@ describe("pickUpExpressions(原文との照合)", () => {
   it("原文に登場しない語句が含まれる場合はエラーを投げる(解説言語の語や言い換えを原文の語句として表示しない)", async () => {
     const pool = createFakeSessionPool(JSON.stringify({ terms: [{ term: "了解", meaning: "分かった" }] }));
 
-    await expect(pickUpExpressions(pool, "roger that")).rejects.toThrow(/原文に登場しない/);
+    await expect(pickUpExpressions(pool, "roger that")).rejects.toThrow(/does not appear in the message/);
   });
 });
 

--- a/src/lib/ai/pickup.ts
+++ b/src/lib/ai/pickup.ts
@@ -57,7 +57,7 @@ export async function pickUpExpressions(
   const normalizedText = prepared.text.toLowerCase();
   const unknownTerm = terms.find((term) => !normalizedText.includes(term.term.toLowerCase()));
   if (unknownTerm) {
-    throw new Error(`Prompt APIが原文に登場しない語句を返しました: ${unknownTerm.term}`);
+    throw new Error(`The Prompt API returned a term that does not appear in the message: ${unknownTerm.term}`);
   }
   return { terms };
 }

--- a/src/lib/ai/structured-prompt.test.ts
+++ b/src/lib/ai/structured-prompt.test.ts
@@ -103,7 +103,7 @@ describe("runStructuredPrompt", () => {
       await expect(
         runStructuredPrompt(pool, { userPrompt: "hello", schema: greetingSchema, priority: "low" }),
       ).rejects.toThrow(
-        `Prompt APIの応答をJSONとして解釈できませんでした(${STRUCTURED_PROMPT_MAX_ATTEMPTS}回試行): {"greeting":"`,
+        `Could not parse the Prompt API response as JSON (${STRUCTURED_PROMPT_MAX_ATTEMPTS} attempts): {"greeting":"`,
       );
       expect(pool.enqueue).toHaveBeenCalledTimes(STRUCTURED_PROMPT_MAX_ATTEMPTS);
     });

--- a/src/lib/ai/structured-prompt.ts
+++ b/src/lib/ai/structured-prompt.ts
@@ -57,7 +57,7 @@ export async function runStructuredPrompt<TSchema extends z.ZodType>(
       parsed = JSON.parse(raw);
     } catch (error) {
       if (attempt < STRUCTURED_PROMPT_MAX_ATTEMPTS) continue;
-      throw new Error(`Prompt APIの応答をJSONとして解釈できませんでした(${attempt}回試行): ${raw}`, { cause: error });
+      throw new Error(`Could not parse the Prompt API response as JSON (${attempt} attempts): ${raw}`, { cause: error });
     }
 
     return request.schema.parse(parsed);

--- a/src/lib/ai/translate.test.ts
+++ b/src/lib/ai/translate.test.ts
@@ -115,7 +115,7 @@ describe("translateChatMessage", () => {
       const pool = createFakeSessionPool(['{"translation":"へー、なしか。', '{"translation":"へー、']);
 
       await expect(translateChatMessage(pool, "oh no way")).rejects.toThrow(
-        `Prompt APIの応答をJSONとして解釈できませんでした(${STRUCTURED_PROMPT_MAX_ATTEMPTS}回試行): {"translation":"へー、`,
+        `Could not parse the Prompt API response as JSON (${STRUCTURED_PROMPT_MAX_ATTEMPTS} attempts): {"translation":"へー、`,
       );
       expect(pool.enqueue).toHaveBeenCalledTimes(STRUCTURED_PROMPT_MAX_ATTEMPTS);
     });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -20,7 +20,7 @@ export const settingsSchema = z
     explainLang: z.enum(SUPPORTED_LANGUAGES),
   })
   .refine((data) => data.targetLang !== data.explainLang, {
-    message: "学ぶ言語と解説言語には異なる言語を指定してください",
+    message: "The learning language and the explanation language must be different",
     path: ["explainLang"],
   });
 

--- a/src/store/auto-pipeline.ts
+++ b/src/store/auto-pipeline.ts
@@ -223,7 +223,7 @@ export function createAutoPipeline<TDone extends object>(config: AutoPipelineCon
         .catch((error: unknown) => {
           if (controller.signal.aborted) return;
           markPromptApiUnavailable(
-            `Prompt API のセッションを生成できませんでした: ${error instanceof Error ? error.message : String(error)}`,
+            `Could not create a Prompt API session: ${error instanceof Error ? error.message : String(error)}`,
           );
         });
     }

--- a/src/store/prompt-api.test.ts
+++ b/src/store/prompt-api.test.ts
@@ -43,7 +43,7 @@ describe("ensurePromptApiDiagnosed", () => {
 
     expect(status).toEqual({
       status: "unavailable",
-      reason: "環境診断に失敗しました: navigator.storage が使えません",
+      reason: "Environment check failed: navigator.storage が使えません",
     });
   });
 
@@ -78,11 +78,11 @@ describe("markPromptApiUnavailable", () => {
   it("理由付きで unavailable にし、以後の ensurePromptApiDiagnosed もその状態を返す", async () => {
     await ensurePromptApiDiagnosed(async () => createDiagnosis(true));
 
-    markPromptApiUnavailable("Prompt API のセッションを生成できませんでした: user activation is required");
+    markPromptApiUnavailable("Could not create a Prompt API session: user activation is required");
 
     expect(usePromptApiStore.getState().status).toEqual({
       status: "unavailable",
-      reason: "Prompt API のセッションを生成できませんでした: user activation is required",
+      reason: "Could not create a Prompt API session: user activation is required",
     });
     await expect(ensurePromptApiDiagnosed(async () => createDiagnosis(true))).resolves.toEqual(
       usePromptApiStore.getState().status,

--- a/src/store/prompt-api.ts
+++ b/src/store/prompt-api.ts
@@ -36,7 +36,7 @@ let inFlightDiagnosis: Promise<PromptApiStatus> | null = null;
 /** 環境診断結果から、利用者に見せる「Prompt API が使えない理由」を取り出す */
 function describePromptApiUnavailableReason(diagnosis: EnvironmentDiagnosis): string {
   const message = describeDiagnosis(diagnosis).find((item) => item.id === "language-model");
-  return message?.message ?? "Prompt API を利用できません。";
+  return message?.message ?? "The Prompt API is not available.";
 }
 
 /**
@@ -61,7 +61,7 @@ export function ensurePromptApiDiagnosed(
     .catch(
       (error: unknown): PromptApiStatus => ({
         status: "unavailable",
-        reason: `環境診断に失敗しました: ${error instanceof Error ? error.message : String(error)}`,
+        reason: `Environment check failed: ${error instanceof Error ? error.message : String(error)}`,
       }),
     )
     .then((status) => {

--- a/src/store/settings.test.ts
+++ b/src/store/settings.test.ts
@@ -73,7 +73,7 @@ describe("useSettingsStore.setSettings", () => {
     hydrateSettingsStore();
 
     expect(() => useSettingsStore.getState().setSettings({ targetLang: "ja", explainLang: "ja" })).toThrow(
-      /異なる言語/,
+      /must be different/,
     );
 
     expect(useSettingsStore.getState().settings).toEqual(DEFAULT_SETTINGS);


### PR DESCRIPTION
## Summary

chat-sensei は言語学習用ツールのため、画面に表示される文字列を全て英語に統一しました。

- 3カラム画面(`src/app/page.tsx`): 接続フォーム・接続状態・列見出し(Raw IRC / Translation / Pick up)・ぼかしトグル・各行の状態文言を英語化。翻訳列/Pick up 列の状態文言は `noun` 連結(「翻訳中...」等)から列ごとの文言一式 `PipelineCellLabels` に変更
- 設定ダイアログ(`src/components/settings-dialog.tsx`)・bot 除外ダイアログ(`src/components/bot-filter-dialog.tsx`): タイトル・説明・ラベル・ボタン・破損通知を英語化
- 環境診断メッセージ(`src/lib/ai/describeDiagnosis.ts`)と Prompt API 利用不可理由(`src/store/prompt-api.ts`, `src/store/auto-pipeline.ts`)を英語化
- ユーザーに「failed: ...」として表示され得るエラー文言(`src/lib/ai/structured-prompt.ts` の JSON 解釈失敗、`src/lib/ai/pickup.ts` の原文に無い語句)を英語化
- `src/app/layout.tsx`: `html lang="en"`、metadata description を英語化
- Twitch プレイヤーの iframe title を英語化

### 対象外(意図的に据え置き)
- 言語セレクトのネイティブ表記(日本語 / Español 等)
- Gemini Nano へ送るプロンプト(`src/lib/ai/prompts.ts`、解説言語に依存)
- コード内コメント・TSDoc・テストのケース名/テストデータ(CLAUDE.md の方針どおり日本語)

## Test plan

- [x] `npm test` 354 件パス
- [x] `npm run lint` / `npm run type-check` / `npm run build` すべて成功
- [x] CodeRabbit レビュー: 指摘 0 件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH