### PR TITLE
feat: BTTV/FFZ/7TV のサードパーティエモートに対応する

### DIFF
--- a/src/lib/twitch/emotes.test.ts
+++ b/src/lib/twitch/emotes.test.ts
@@ -29,6 +29,22 @@ describe("buildEmoteImageUrl", () => {
       "https://static-cdn.jtvnw.net/emoticons/v2/25/default/light/1.0",
     );
   });
+
+  it("bttv: プレフィックス付き ID は BTTV の CDN URL を組み立てる", () => {
+    expect(buildEmoteImageUrl("bttv:60ae958e229664e8667aea38")).toBe(
+      "https://cdn.betterttv.net/emote/60ae958e229664e8667aea38/2x",
+    );
+  });
+
+  it("ffz: プレフィックス付き ID は FrankerFaceZ の CDN URL を組み立てる", () => {
+    expect(buildEmoteImageUrl("ffz:128054")).toBe("https://cdn.frankerfacez.com/emote/128054/2");
+  });
+
+  it("7tv: プレフィックス付き ID は 7TV の CDN URL を組み立てる", () => {
+    expect(buildEmoteImageUrl("7tv:01F6MZGCNG000255K4X1K7NTHR")).toBe(
+      "https://cdn.7tv.app/emote/01F6MZGCNG000255K4X1K7NTHR/2x.webp",
+    );
+  });
 });
 
 describe("splitMessageIntoSegments", () => {

--- a/src/lib/twitch/emotes.ts
+++ b/src/lib/twitch/emotes.ts
@@ -39,10 +39,27 @@ export interface EmoteSegment {
 export type MessageSegment = TextSegment | EmoteSegment;
 
 /**
- * emote ID から Twitch の emote 画像CDN URLを組み立てる。
- * デフォルトはダークテーマ・2倍サイズ(ライブチャット表示に適したサイズ)。
+ * サードパーティ emote(`third-party-emotes.ts`)のプレフィックス付き ID から、
+ * 各サービスの CDN URL を組み立てる関数の表。theme / scale の指定には対応していないため、
+ * ライブチャット表示に適した2倍サイズ相当の URL を固定で返す。
+ */
+const THIRD_PARTY_EMOTE_URL_BUILDERS: Record<string, (id: string) => string> = {
+  bttv: (id) => `https://cdn.betterttv.net/emote/${id}/2x`,
+  ffz: (id) => `https://cdn.frankerfacez.com/emote/${id}/2`,
+  "7tv": (id) => `https://cdn.7tv.app/emote/${id}/2x.webp`,
+};
+
+/**
+ * emote ID から emote 画像CDN URLを組み立てる。
+ * `bttv:` / `ffz:` / `7tv:` プレフィックス付き ID は各サードパーティの CDN URL、
+ * それ以外は Twitch の CDN URL(デフォルトはダークテーマ・2倍サイズ)を返す。
  */
 export function buildEmoteImageUrl(emoteId: string, options: EmoteImageOptions = {}): string {
+  const colonIndex = emoteId.indexOf(":");
+  if (colonIndex !== -1) {
+    const buildThirdPartyUrl = THIRD_PARTY_EMOTE_URL_BUILDERS[emoteId.slice(0, colonIndex)];
+    if (buildThirdPartyUrl) return buildThirdPartyUrl(emoteId.slice(colonIndex + 1));
+  }
   const theme = options.theme ?? "dark";
   const scale = options.scale ?? "2.0";
   return `https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/default/${theme}/${scale}`;

--- a/src/lib/twitch/irc-parser.test.ts
+++ b/src/lib/twitch/irc-parser.test.ts
@@ -184,6 +184,7 @@ describe("parseTwitchIrcMessage", () => {
         r9k: false,
         slowSeconds: 0,
         subsOnly: false,
+        roomId: "552120296",
       },
     });
   });

--- a/src/lib/twitch/irc-parser.ts
+++ b/src/lib/twitch/irc-parser.ts
@@ -70,6 +70,8 @@ export interface RoomState {
   r9k: boolean;
   slowSeconds: number;
   subsOnly: boolean;
+  /** `room-id` タグ(配信者の Twitch ユーザー ID)。サードパーティ emote の取得に使う。無ければ null */
+  roomId: string | null;
 }
 
 /** parseTwitchIrcMessage が返す、UI層がそのまま扱える構造化イベント */
@@ -263,6 +265,7 @@ function parseRoomState(parsed: ParsedIrcMessage): TwitchChatEvent {
       r9k: parsed.tags.r9k === "1",
       slowSeconds: slowRaw !== undefined ? Number.parseInt(slowRaw, 10) : 0,
       subsOnly: parsed.tags["subs-only"] === "1",
+      roomId: parsed.tags["room-id"] ?? null,
     },
   };
 }

--- a/src/lib/twitch/third-party-emotes.test.ts
+++ b/src/lib/twitch/third-party-emotes.test.ts
@@ -1,0 +1,186 @@
+/**
+ * src/lib/twitch/third-party-emotes.ts のテスト。
+ *
+ * BTTV / FFZ / 7TV の各 API レスポンスから「emote 名 → プレフィックス付き ID」の対応表を組み立てる処理と、
+ * 発言本文の単語を対応表と照合してサードパーティ emote の位置情報(EmotePosition[])を合成する処理を検証する。
+ * API 呼び出しはすべてフェイクの fetch を注入して行い、実際のネットワーク通信は行わない。
+ */
+import { describe, expect, it, vi } from "vitest";
+import type { EmotePosition } from "./irc-parser";
+import {
+  buildThirdPartyEmoteMap,
+  fetchThirdPartyEmoteMap,
+  mergeThirdPartyEmotePositions,
+  type ThirdPartyEmote,
+} from "./third-party-emotes";
+
+describe("buildThirdPartyEmoteMap", () => {
+  it("emote 名をキー、プレフィックス付き ID を値とする対応表を作る", () => {
+    const emotes: ThirdPartyEmote[] = [
+      { code: "catJAM", id: "bttv:60ae958e229664e8667aea38" },
+      { code: "AlienPls", id: "7tv:01F6MZGCNG000255K4X1K7NTHR" },
+    ];
+
+    const map = buildThirdPartyEmoteMap(emotes);
+
+    expect(map.get("catJAM")).toBe("bttv:60ae958e229664e8667aea38");
+    expect(map.get("AlienPls")).toBe("7tv:01F6MZGCNG000255K4X1K7NTHR");
+  });
+
+  it("同じ emote 名が複数ある場合は後勝ちにする(チャンネル emote がグローバル emote を上書きする)", () => {
+    const emotes: ThirdPartyEmote[] = [
+      { code: "catJAM", id: "bttv:global-id" },
+      { code: "catJAM", id: "7tv:channel-id" },
+    ];
+
+    const map = buildThirdPartyEmoteMap(emotes);
+
+    expect(map.get("catJAM")).toBe("7tv:channel-id");
+  });
+});
+
+describe("mergeThirdPartyEmotePositions", () => {
+  const emoteMap = new Map([
+    ["catJAM", "bttv:60ae958e229664e8667aea38"],
+    ["AlienPls", "7tv:01F6MZGCNG000255K4X1K7NTHR"],
+  ]);
+
+  it("本文中の emote 名に一致する単語を EmotePosition として合成する", () => {
+    const result = mergeThirdPartyEmotePositions("catJAM nice", [], emoteMap);
+
+    expect(result).toEqual([{ id: "bttv:60ae958e229664e8667aea38", start: 0, end: 5 }]);
+  });
+
+  it("Twitch 公式 emote の位置情報と結合し、開始位置の昇順で返す", () => {
+    // "Kappa catJAM" — Kappa(id:25)は Twitch の emotes タグ由来
+    const twitchEmotes: EmotePosition[] = [{ id: "25", start: 0, end: 4 }];
+
+    const result = mergeThirdPartyEmotePositions("Kappa catJAM", twitchEmotes, emoteMap);
+
+    expect(result).toEqual([
+      { id: "25", start: 0, end: 4 },
+      { id: "bttv:60ae958e229664e8667aea38", start: 6, end: 11 },
+    ]);
+  });
+
+  it("単語の一部として含まれるだけの emote 名(部分一致)は emote にしない", () => {
+    const result = mergeThirdPartyEmotePositions("catJAMmer says catJAM!", [], emoteMap);
+
+    // "catJAMmer" も "catJAM!" も空白区切りの単語全体が emote 名と一致しないため対象外
+    expect(result).toEqual([]);
+  });
+
+  it("emote 名の大文字小文字は区別する", () => {
+    const result = mergeThirdPartyEmotePositions("catjam", [], emoteMap);
+
+    expect(result).toEqual([]);
+  });
+
+  it("サロゲートペアの絵文字が前にあってもコードポイント単位の位置を返す(Twitch の emotes タグと同じ基準)", () => {
+    // 🌿 は UTF-16 では2コードユニットだが、位置はコードポイント単位で数える
+    const result = mergeThirdPartyEmotePositions("🌿 catJAM", [], emoteMap);
+
+    expect(result).toEqual([{ id: "bttv:60ae958e229664e8667aea38", start: 2, end: 7 }]);
+  });
+
+  it("同じ emote 名が複数回現れたら出現ごとに位置を返す", () => {
+    const result = mergeThirdPartyEmotePositions("catJAM catJAM", [], emoteMap);
+
+    expect(result).toEqual([
+      { id: "bttv:60ae958e229664e8667aea38", start: 0, end: 5 },
+      { id: "bttv:60ae958e229664e8667aea38", start: 7, end: 12 },
+    ]);
+  });
+
+  it("対応表が空なら Twitch 公式 emote の位置情報をそのまま返す", () => {
+    const twitchEmotes: EmotePosition[] = [{ id: "25", start: 0, end: 4 }];
+
+    const result = mergeThirdPartyEmotePositions("Kappa", twitchEmotes, new Map());
+
+    expect(result).toEqual(twitchEmotes);
+  });
+});
+
+/** フェイク fetch: URL の部分一致で JSON レスポンスを返す。未定義の URL は 404 を返す */
+function createFakeFetch(responses: Record<string, unknown>): typeof fetch {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = String(input);
+    for (const [pattern, body] of Object.entries(responses)) {
+      if (url.includes(pattern)) {
+        return new Response(JSON.stringify(body), { status: 200 });
+      }
+    }
+    return new Response("Not Found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+describe("fetchThirdPartyEmoteMap", () => {
+  const bttvGlobal = [{ id: "bttv-g1", code: "catJAM", imageType: "webp", animated: true }];
+  const bttvUser = {
+    channelEmotes: [{ id: "bttv-c1", code: "chDance", imageType: "webp", animated: true }],
+    sharedEmotes: [{ id: "bttv-s1", code: "chShared", imageType: "webp", animated: false }],
+  };
+  const ffzGlobal = [{ id: 111, code: "ffzGlobalEmote", images: { "1x": "u1", "2x": "u2", "4x": null } }];
+  const ffzChannel = [{ id: 222, code: "ffzChannelEmote", images: { "1x": "u1", "2x": null, "4x": null } }];
+  const sevenTvGlobal = { emotes: [{ id: "7tv-g1", name: "AlienPls" }] };
+  const sevenTvUser = { emote_set: { emotes: [{ id: "7tv-c1", name: "chAlien" }] } };
+
+  it("BTTV / FFZ / 7TV のグローバル・チャンネル emote をすべて集めた対応表を返す", async () => {
+    const fetchFn = createFakeFetch({
+      "api.betterttv.net/3/cached/emotes/global": bttvGlobal,
+      "api.betterttv.net/3/cached/users/twitch/12345": bttvUser,
+      "api.betterttv.net/3/cached/frankerfacez/emotes/global": ffzGlobal,
+      "api.betterttv.net/3/cached/frankerfacez/users/twitch/12345": ffzChannel,
+      "7tv.io/v3/emote-sets/global": sevenTvGlobal,
+      "7tv.io/v3/users/twitch/12345": sevenTvUser,
+    });
+
+    const map = await fetchThirdPartyEmoteMap("12345", fetchFn);
+
+    expect(map.get("catJAM")).toBe("bttv:bttv-g1");
+    expect(map.get("chDance")).toBe("bttv:bttv-c1");
+    expect(map.get("chShared")).toBe("bttv:bttv-s1");
+    expect(map.get("ffzGlobalEmote")).toBe("ffz:111");
+    expect(map.get("ffzChannelEmote")).toBe("ffz:222");
+    expect(map.get("AlienPls")).toBe("7tv:7tv-g1");
+    expect(map.get("chAlien")).toBe("7tv:7tv-c1");
+  });
+
+  it("チャンネル emote は同名のグローバル emote を上書きする", async () => {
+    const fetchFn = createFakeFetch({
+      "api.betterttv.net/3/cached/emotes/global": [{ id: "bttv-g1", code: "sameName" }],
+      "7tv.io/v3/users/twitch/12345": { emote_set: { emotes: [{ id: "7tv-c1", name: "sameName" }] } },
+    });
+
+    const map = await fetchThirdPartyEmoteMap("12345", fetchFn);
+
+    expect(map.get("sameName")).toBe("7tv:7tv-c1");
+  });
+
+  it("未登録チャンネル(404)や一部プロバイダの障害があっても、他のプロバイダの emote は返す", async () => {
+    // BTTV グローバルだけ成功し、他はすべて 404(未登録チャンネル相当)
+    const fetchFn = createFakeFetch({
+      "api.betterttv.net/3/cached/emotes/global": bttvGlobal,
+    });
+
+    const map = await fetchThirdPartyEmoteMap("12345", fetchFn);
+
+    expect(map.get("catJAM")).toBe("bttv:bttv-g1");
+    expect(map.size).toBe(1);
+  });
+
+  it("fetch 自体が例外を投げるプロバイダがあっても、他のプロバイダの emote は返す", async () => {
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("api.betterttv.net/3/cached/emotes/global")) {
+        return new Response(JSON.stringify(bttvGlobal), { status: 200 });
+      }
+      throw new TypeError("network error");
+    }) as unknown as typeof fetch;
+
+    const map = await fetchThirdPartyEmoteMap("12345", fetchFn);
+
+    expect(map.get("catJAM")).toBe("bttv:bttv-g1");
+    expect(map.size).toBe(1);
+  });
+});

--- a/src/lib/twitch/third-party-emotes.ts
+++ b/src/lib/twitch/third-party-emotes.ts
@@ -1,0 +1,198 @@
+/**
+ * サードパーティ emote(BTTV / FrankerFaceZ / 7TV)への対応。
+ *
+ * Twitch 公式 emote は IRC の `emotes` タグで位置が届くが、サードパーティ emote は
+ * 本文に emote 名がそのまま含まれるだけで、位置情報は届かない。そこで:
+ *
+ * 1. `fetchThirdPartyEmoteMap` — 各サービスの公開 API からグローバル emote と
+ *    チャンネル emote(配信者の Twitch ID で引く)を集め、「emote 名 → プレフィックス付き ID」の
+ *    対応表を作る。プレフィックス(`bttv:` / `ffz:` / `7tv:`)は `emotes.ts` の
+ *    `buildEmoteImageUrl` が CDN URL の組み立てに使う
+ * 2. `mergeThirdPartyEmotePositions` — 発言本文を空白区切りの単語に分け、対応表と
+ *    完全一致した単語を `EmotePosition` として Twitch 公式 emote の位置情報に合成する。
+ *    これにより下流(描画・翻訳のプレースホルダ化・Pick up の除外・textless 判定)は
+ *    既存の emote 処理をそのまま使える
+ *
+ * 位置はTwitch の `emotes` タグと同じくコードポイント単位・end は inclusive で表す
+ * (`emotes.ts` の `splitMessageIntoSegments` が UTF-16 位置へ変換する)。
+ * emote 名の照合は各サービスの仕様どおり大文字小文字を区別する。
+ */
+import type { EmotePosition } from "./irc-parser";
+
+/** サードパーティ emote 1 件。`id` は `bttv:` / `ffz:` / `7tv:` プレフィックス付き */
+export interface ThirdPartyEmote {
+  /** チャット本文中に現れる emote 名(例: `catJAM`) */
+  code: string;
+  /** プロバイダのプレフィックスを付けた emote ID(例: `bttv:60ae958e229664e8667aea38`) */
+  id: string;
+}
+
+/**
+ * emote 一覧から「emote 名 → プレフィックス付き ID」の対応表を作る。
+ * 同名の emote は後勝ちとする(呼び出し側がグローバル → チャンネルの順で渡すことで、
+ * チャンネル emote がグローバル emote を上書きする)。
+ */
+export function buildThirdPartyEmoteMap(emotes: ThirdPartyEmote[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const emote of emotes) {
+    map.set(emote.code, emote.id);
+  }
+  return map;
+}
+
+/** Twitch 公式 emote の位置範囲と単語の範囲(いずれもコードポイント単位・inclusive)が重なるか */
+function overlapsAnyTwitchEmote(start: number, end: number, twitchEmotes: EmotePosition[]): boolean {
+  return twitchEmotes.some((emote) => start <= emote.end && end >= emote.start);
+}
+
+/**
+ * 発言本文の空白区切りの単語を対応表と照合し、一致した単語をサードパーティ emote の
+ * `EmotePosition` として Twitch 公式 emote の位置情報に合成して返す(開始位置の昇順)。
+ *
+ * - 単語全体が emote 名と完全一致した場合のみ emote とする(`catJAM!` のような部分一致は対象外)
+ * - Twitch 公式 emote の範囲と重なる単語は公式 emote を優先して対象外とする
+ */
+export function mergeThirdPartyEmotePositions(
+  text: string,
+  twitchEmotes: EmotePosition[],
+  emoteMap: ReadonlyMap<string, string>,
+): EmotePosition[] {
+  if (emoteMap.size === 0) return twitchEmotes;
+
+  // Twitch の emotes タグと同じコードポイント単位で位置を数えるため、コードポイント配列で走査する
+  const codePoints = [...text];
+  const merged = [...twitchEmotes];
+  let tokenStart = -1;
+
+  for (let i = 0; i <= codePoints.length; i += 1) {
+    const isBoundary = i === codePoints.length || /\s/u.test(codePoints[i]);
+    if (!isBoundary) {
+      if (tokenStart === -1) tokenStart = i;
+      continue;
+    }
+    if (tokenStart === -1) continue;
+
+    const token = codePoints.slice(tokenStart, i).join("");
+    const end = i - 1;
+    const id = emoteMap.get(token);
+    if (id !== undefined && !overlapsAnyTwitchEmote(tokenStart, end, twitchEmotes)) {
+      merged.push({ id, start: tokenStart, end });
+    }
+    tokenStart = -1;
+  }
+
+  merged.sort((a, b) => a.start - b.start);
+  return merged;
+}
+
+/** BTTV API の emote 1 件(`/3/cached/emotes/global` と `/3/cached/users/twitch/:id` で共通の形) */
+interface BttvEmoteJson {
+  id: string;
+  code: string;
+}
+
+/** 値が BTTV emote の形かを確かめる型ガード。API 側の仕様変更で形が変わった項目は読み飛ばす */
+function isBttvEmoteJson(value: unknown): value is BttvEmoteJson {
+  if (typeof value !== "object" || value === null) return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.id === "string" && typeof record.code === "string";
+}
+
+/** BTTV のグローバル emote(emote の配列)を解析する */
+function parseBttvEmoteList(json: unknown): ThirdPartyEmote[] {
+  if (!Array.isArray(json)) return [];
+  return json.filter(isBttvEmoteJson).map((emote) => ({ code: emote.code, id: `bttv:${emote.id}` }));
+}
+
+/** BTTV のチャンネル emote(`channelEmotes` + `sharedEmotes`)を解析する */
+function parseBttvUser(json: unknown): ThirdPartyEmote[] {
+  if (typeof json !== "object" || json === null) return [];
+  const record = json as Record<string, unknown>;
+  return [...parseBttvEmoteList(record.channelEmotes), ...parseBttvEmoteList(record.sharedEmotes)];
+}
+
+/**
+ * FFZ の emote 一覧を解析する。BTTV が提供する FFZ のキャッシュ API
+ * (`/3/cached/frankerfacez/...`)を使うため、`id` は数値・emote 名は `code` で届く
+ */
+function parseFfzEmoteList(json: unknown): ThirdPartyEmote[] {
+  if (!Array.isArray(json)) return [];
+  return json.flatMap((value) => {
+    if (typeof value !== "object" || value === null) return [];
+    const record = value as Record<string, unknown>;
+    if (typeof record.id !== "number" || typeof record.code !== "string") return [];
+    return [{ code: record.code, id: `ffz:${record.id}` }];
+  });
+}
+
+/** 7TV の emote 一覧(`{id, name}` の配列)を解析する */
+function parseSevenTvEmoteList(json: unknown): ThirdPartyEmote[] {
+  if (!Array.isArray(json)) return [];
+  return json.flatMap((value) => {
+    if (typeof value !== "object" || value === null) return [];
+    const record = value as Record<string, unknown>;
+    if (typeof record.id !== "string" || typeof record.name !== "string") return [];
+    return [{ code: record.name, id: `7tv:${record.id}` }];
+  });
+}
+
+/** 7TV のグローバル emote セット(`{emotes: [...]}`)を解析する */
+function parseSevenTvEmoteSet(json: unknown): ThirdPartyEmote[] {
+  if (typeof json !== "object" || json === null) return [];
+  return parseSevenTvEmoteList((json as Record<string, unknown>).emotes);
+}
+
+/** 7TV のユーザー情報(`{emote_set: {emotes: [...]}}`)を解析する */
+function parseSevenTvUser(json: unknown): ThirdPartyEmote[] {
+  if (typeof json !== "object" || json === null) return [];
+  return parseSevenTvEmoteSet((json as Record<string, unknown>).emote_set);
+}
+
+/** 読み込む API エンドポイントと、そのレスポンスの解析関数の組 */
+interface EmoteSource {
+  url: string;
+  parse: (json: unknown) => ThirdPartyEmote[];
+}
+
+/**
+ * 優先度の昇順(後勝ち)に並べた emote の取得元一覧。
+ * グローバル → チャンネルの順、各スコープ内は FFZ → BTTV → 7TV の順とし、
+ * 同名の emote はチャンネル emote(その中では 7TV)が最優先になる。
+ */
+function buildEmoteSources(twitchUserId: string): EmoteSource[] {
+  return [
+    { url: "https://api.betterttv.net/3/cached/frankerfacez/emotes/global", parse: parseFfzEmoteList },
+    { url: "https://api.betterttv.net/3/cached/emotes/global", parse: parseBttvEmoteList },
+    { url: "https://7tv.io/v3/emote-sets/global", parse: parseSevenTvEmoteSet },
+    { url: `https://api.betterttv.net/3/cached/frankerfacez/users/twitch/${twitchUserId}`, parse: parseFfzEmoteList },
+    { url: `https://api.betterttv.net/3/cached/users/twitch/${twitchUserId}`, parse: parseBttvUser },
+    { url: `https://7tv.io/v3/users/twitch/${twitchUserId}`, parse: parseSevenTvUser },
+  ];
+}
+
+/**
+ * BTTV / FFZ / 7TV のグローバル・チャンネル emote をすべて取得し、
+ * 「emote 名 → プレフィックス付き ID」の対応表を返す。
+ *
+ * 取得元ごとの失敗は当該取得元を空として続行する(暗黙のフォールバックではなく意図した仕様):
+ * - そのサービスに登録していないチャンネルでは API が 404 を返す(正常系)
+ * - 一部の外部サービスの障害で、他のサービスの emote 表示まで失われるべきではない
+ */
+export async function fetchThirdPartyEmoteMap(
+  twitchUserId: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<Map<string, string>> {
+  const results = await Promise.all(
+    buildEmoteSources(twitchUserId).map(async (source): Promise<ThirdPartyEmote[]> => {
+      try {
+        const response = await fetchFn(source.url);
+        if (!response.ok) return [];
+        return source.parse(await response.json());
+      } catch (error) {
+        console.warn(`サードパーティ emote の取得に失敗しました: ${source.url}`, error);
+        return [];
+      }
+    }),
+  );
+  return buildThirdPartyEmoteMap(results.flat());
+}

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -33,6 +33,17 @@ vi.mock("@/lib/twitch/irc-client", () => ({
   normalizeChannelName: (channel: string) => channel.replace(/^#/, "").toLowerCase(),
 }));
 
+// サードパーティ emote の読み込みは実 API を呼ぶため、ストア連携だけをモックで検証する
+const mockLoadThirdPartyEmotes = vi.fn();
+const mockClearThirdPartyEmotes = vi.fn();
+let fakeThirdPartyEmoteMap = new Map<string, string>();
+
+vi.mock("./third-party-emotes", () => ({
+  loadThirdPartyEmotes: (roomId: string) => mockLoadThirdPartyEmotes(roomId),
+  clearThirdPartyEmotes: () => mockClearThirdPartyEmotes(),
+  getThirdPartyEmoteMap: () => fakeThirdPartyEmoteMap,
+}));
+
 import { resetBotFilterStoreForTests, useBotFilterStore } from "./bot-filter";
 import { resetChatConnectionStoreForTests, subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
 
@@ -63,6 +74,9 @@ beforeEach(() => {
 afterEach(() => {
   mockConnect.mockClear();
   mockDisconnect.mockClear();
+  mockLoadThirdPartyEmotes.mockClear();
+  mockClearThirdPartyEmotes.mockClear();
+  fakeThirdPartyEmoteMap = new Map();
   window.localStorage.clear();
 });
 
@@ -169,6 +183,69 @@ describe("subscribeToChatMessages", () => {
     capturedCallbacks?.onEvent({ type: "ping", payload: "PING :tmi.twitch.tv" });
 
     expect(listener).not.toHaveBeenCalled();
+  });
+});
+
+describe("サードパーティ emote(BTTV / FFZ / 7TV)", () => {
+  it("roomstate イベントを受信すると、room-id を使ってサードパーティ emote の読み込みを開始する", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onEvent({
+      type: "roomstate",
+      channel: "zackrawrr",
+      state: {
+        emoteOnly: false,
+        followersOnlyMinutes: null,
+        r9k: false,
+        slowSeconds: 0,
+        subsOnly: false,
+        roomId: "552120296",
+      },
+    });
+
+    expect(mockLoadThirdPartyEmotes).toHaveBeenCalledWith("552120296");
+  });
+
+  it("room-id が無い roomstate では読み込みを開始しない", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onEvent({
+      type: "roomstate",
+      channel: "zackrawrr",
+      state: {
+        emoteOnly: false,
+        followersOnlyMinutes: null,
+        r9k: false,
+        slowSeconds: 0,
+        subsOnly: false,
+        roomId: null,
+      },
+    });
+
+    expect(mockLoadThirdPartyEmotes).not.toHaveBeenCalled();
+  });
+
+  it("connect() を呼ぶと、前のチャンネルのサードパーティ emote 対応表をクリアする", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(mockClearThirdPartyEmotes).toHaveBeenCalled();
+  });
+
+  it("privmsg 受信時に、本文中のサードパーティ emote 名を emotes に合成してから保持・通知する", () => {
+    fakeThirdPartyEmoteMap = new Map([["catJAM", "bttv:60ae958e229664e8667aea38"]]);
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const listener = vi.fn();
+    subscribeToChatMessages(listener);
+    const message = createSampleMessage({ text: "catJAM nice" });
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message });
+
+    const expected = {
+      ...message,
+      emotes: [{ id: "bttv:60ae958e229664e8667aea38", start: 0, end: 5 }],
+    };
+    expect(useChatConnectionStore.getState().messages).toEqual([expected]);
+    expect(listener).toHaveBeenCalledWith(expected);
   });
 });
 

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -25,8 +25,10 @@ import {
   type TwitchIrcClient,
 } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+import { mergeThirdPartyEmotePositions } from "@/lib/twitch/third-party-emotes";
 import { matchesBotFilter } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
+import { clearThirdPartyEmotes, getThirdPartyEmoteMap, loadThirdPartyEmotes } from "./third-party-emotes";
 
 /** チャットに表示する発言の最大保持件数(古いものから捨てるリングバッファ) */
 const MAX_DISPLAYED_MESSAGES = 300;
@@ -55,16 +57,27 @@ function getClient(): TwitchIrcClient {
     client = createTwitchIrcClient({
       onStateChange: (state) => useChatConnectionStore.setState({ connectionState: state }),
       onEvent: (event) => {
+        if (event.type === "roomstate") {
+          // room-id(配信者の Twitch ユーザー ID)が判明した時点でサードパーティ emote を読み込む
+          if (event.state.roomId !== null) void loadThirdPartyEmotes(event.state.roomId);
+          return;
+        }
         if (event.type !== "privmsg") return;
         if (isExcludedByBotFilter(event.message.username)) return;
+        // 本文中のサードパーティ emote 名(BTTV / FFZ / 7TV)を位置情報として合成してから
+        // 保持・通知する。下流(描画・翻訳・Pick up)は Twitch 公式 emote と同じ扱いで処理できる
+        const message: TwitchChatMessage = {
+          ...event.message,
+          emotes: mergeThirdPartyEmotePositions(event.message.text, event.message.emotes, getThirdPartyEmoteMap()),
+        };
         useChatConnectionStore.setState((prev) => {
-          const next = [...prev.messages, event.message];
+          const next = [...prev.messages, message];
           return {
             messages:
               next.length > MAX_DISPLAYED_MESSAGES ? next.slice(next.length - MAX_DISPLAYED_MESSAGES) : next,
           };
         });
-        messageListeners.forEach((listener) => listener(event.message));
+        messageListeners.forEach((listener) => listener(message));
       },
     });
   }
@@ -76,6 +89,8 @@ export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
   messages: [],
   channel: null,
   connect: (channel) => {
+    // 前のチャンネルのサードパーティ emote 対応表を持ち越さない(ROOMSTATE 受信後に再読み込みされる)
+    clearThirdPartyEmotes();
     set({ messages: [], channel: normalizeChannelName(channel) });
     getClient().connect(channel);
   },

--- a/src/store/third-party-emotes.test.ts
+++ b/src/store/third-party-emotes.test.ts
@@ -1,0 +1,66 @@
+/**
+ * src/store/third-party-emotes.ts(サードパーティ emote 対応表のモジュールスコープ保持)のテスト。
+ *
+ * ROOMSTATE で判明した配信者の Twitch ID から BTTV / FFZ / 7TV の emote を読み込み、
+ * `chat-connection.ts` が発言受信時に同期的に参照できる対応表として保持する流れを検証する。
+ * 実際の API 呼び出しは行わず、フェイクの読み込み関数を注入する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearThirdPartyEmotes,
+  getThirdPartyEmoteMap,
+  loadThirdPartyEmotes,
+  resetThirdPartyEmotesForTests,
+} from "./third-party-emotes";
+
+afterEach(() => {
+  resetThirdPartyEmotesForTests();
+});
+
+describe("loadThirdPartyEmotes", () => {
+  it("読み込んだ対応表を getThirdPartyEmoteMap で参照できる", async () => {
+    const fetchEmoteMap = vi.fn(async () => new Map([["catJAM", "bttv:g1"]]));
+
+    await loadThirdPartyEmotes("12345", fetchEmoteMap);
+
+    expect(fetchEmoteMap).toHaveBeenCalledWith("12345");
+    expect(getThirdPartyEmoteMap().get("catJAM")).toBe("bttv:g1");
+  });
+
+  it("同じ Twitch ID の2回目の読み込みは行わない(ROOMSTATE は再接続などで複数回届く)", async () => {
+    const fetchEmoteMap = vi.fn(async () => new Map([["catJAM", "bttv:g1"]]));
+
+    await loadThirdPartyEmotes("12345", fetchEmoteMap);
+    await loadThirdPartyEmotes("12345", fetchEmoteMap);
+
+    expect(fetchEmoteMap).toHaveBeenCalledTimes(1);
+  });
+
+  it("読み込み完了前に clearThirdPartyEmotes された場合は結果を破棄する(チャンネル切り替え)", async () => {
+    let resolveFetch: (map: Map<string, string>) => void = () => {};
+    const fetchEmoteMap = vi.fn(
+      () => new Promise<Map<string, string>>((resolve) => (resolveFetch = resolve)),
+    );
+
+    const loading = loadThirdPartyEmotes("12345", fetchEmoteMap);
+    clearThirdPartyEmotes();
+    resolveFetch(new Map([["catJAM", "bttv:g1"]]));
+    await loading;
+
+    expect(getThirdPartyEmoteMap().size).toBe(0);
+  });
+
+  it("clearThirdPartyEmotes すると対応表が空になり、同じ ID でも再読み込みできる", async () => {
+    const fetchEmoteMap = vi.fn(async () => new Map([["catJAM", "bttv:g1"]]));
+
+    await loadThirdPartyEmotes("12345", fetchEmoteMap);
+    clearThirdPartyEmotes();
+
+    expect(getThirdPartyEmoteMap().size).toBe(0);
+
+    await loadThirdPartyEmotes("12345", fetchEmoteMap);
+
+    expect(fetchEmoteMap).toHaveBeenCalledTimes(2);
+    expect(getThirdPartyEmoteMap().get("catJAM")).toBe("bttv:g1");
+  });
+});

--- a/src/store/third-party-emotes.ts
+++ b/src/store/third-party-emotes.ts
@@ -1,0 +1,56 @@
+/**
+ * サードパーティ emote(BTTV / FFZ / 7TV)の対応表を保持するモジュールスコープのストア。
+ *
+ * `chat-connection.ts` が ROOMSTATE の `room-id`(配信者の Twitch ユーザー ID)を受け取った時点で
+ * `loadThirdPartyEmotes` を呼び、以降の発言受信時に `getThirdPartyEmoteMap` で同期的に参照する。
+ * 発言の受信は高頻度なため、対応表は React の state ではなくモジュールスコープに置き、
+ * 受信ハンドラから直接読めるようにする(`chat-connection.ts` のクライアント保持と同じ方針)。
+ *
+ * - 同じ Twitch ID への読み込みは 1 回だけ行う(ROOMSTATE は再接続などで複数回届く)
+ * - チャンネル切り替え(`connect()`)時は `clearThirdPartyEmotes` で対応表を破棄し、
+ *   読み込み途中だった前チャンネルの結果は世代番号の比較で捨てる
+ */
+import { fetchThirdPartyEmoteMap } from "@/lib/twitch/third-party-emotes";
+
+/** emote 名 → プレフィックス付き ID(`bttv:xxx` など)の対応表 */
+let emoteMap: ReadonlyMap<string, string> = new Map();
+/** 読み込み済み(または読み込み中)の Twitch ユーザー ID。未読み込みなら null */
+let loadedRoomId: string | null = null;
+/** クリアのたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
+let generation = 0;
+
+/** 現在の対応表を返す。未読み込み・クリア直後は空の Map */
+export function getThirdPartyEmoteMap(): ReadonlyMap<string, string> {
+  return emoteMap;
+}
+
+/**
+ * 指定した配信者の Twitch ユーザー ID でサードパーティ emote を読み込む。
+ * 同じ ID で読み込み済み(読み込み中を含む)の場合は何もしない。
+ */
+export async function loadThirdPartyEmotes(
+  roomId: string,
+  fetchEmoteMap: (twitchUserId: string) => Promise<Map<string, string>> = fetchThirdPartyEmoteMap,
+): Promise<void> {
+  if (loadedRoomId === roomId) return;
+  loadedRoomId = roomId;
+  const requestGeneration = generation;
+
+  const map = await fetchEmoteMap(roomId);
+
+  // 読み込み中にチャンネルが切り替わっていたら(クリア済みなら)、前チャンネルの結果は捨てる
+  if (generation !== requestGeneration) return;
+  emoteMap = map;
+}
+
+/** 対応表を破棄して未読み込み状態に戻す。チャンネル切り替え時に呼ぶ */
+export function clearThirdPartyEmotes(): void {
+  generation += 1;
+  emoteMap = new Map();
+  loadedRoomId = null;
+}
+
+/** テスト専用: モジュールスコープの状態を初期状態に戻す。各テストの afterEach で呼び出すこと */
+export function resetThirdPartyEmotesForTests(): void {
+  clearThirdPartyEmotes();
+}


### PR DESCRIPTION
## Summary

Twitch 公式エモートに加えて、BTTV / FrankerFaceZ / 7TV のサードパーティエモートを画像として表示できるようにします。

## 実装内容

- **`src/lib/twitch/third-party-emotes.ts`(新規)**: BTTV / FFZ / 7TV の公開 API からグローバル・チャンネルエモートを取得し、「emote 名 → プレフィックス付き ID(`bttv:` / `ffz:` / `7tv:`)」の対応表を組み立てる。発言本文を空白区切りの単語で完全一致照合し、`EmotePosition`(コードポイント単位・Twitch の emotes タグと同じ基準)として合成する
- **`src/store/third-party-emotes.ts`(新規)**: 対応表のモジュールスコープ保持。同一 room-id の再読み込み抑止と、チャンネル切り替え時の世代番号による古い結果の破棄
- **`src/lib/twitch/irc-parser.ts`**: ROOMSTATE の `room-id` タグ(配信者の Twitch ユーザー ID)を `RoomState.roomId` として保持
- **`src/store/chat-connection.ts`**: ROOMSTATE 受信時にエモート読み込みを開始し、privmsg 受信時に本文中のサードパーティエモートを `message.emotes` に合成してから保持・通知
- **`src/lib/twitch/emotes.ts`**: `buildEmoteImageUrl` がプレフィックス付き ID を各サービスの CDN URL にディスパッチ

## 設計のポイント

受信時点で `EmotePosition` に合成するため、下流(生 IRC 列の描画・翻訳のプレースホルダ化 #44・Pick up の除外 #26・textless 判定 #28)は既存のエモート処理がそのまま機能します。

- 同名エモートはチャンネル > グローバル、同スコープ内は 7TV > BTTV > FFZ の優先順
- 未登録チャンネルの 404 や一部プロバイダの障害は当該プロバイダのみ空として続行(理由をコードコメントに明記)

## テスト

- 対応表の組み立て・優先順、単語照合(部分一致除外・大文字小文字区別・サロゲートペア位置)、フェイク fetch による取得処理
- ストアの読み込み抑止・クリア・競合破棄、chat-connection の統合(roomstate → 読み込み開始、privmsg → 合成)
- lint / type-check / test(451 件)/ build / CodeRabbit(指摘 0 件)すべてグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH