### PR TITLE
feat: LLM プロバイダに OpenRouter を追加し、モデル一覧から選んだ任意のモデルを使えるようにする

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { resetBotFilterStoreForTests, useBotFilterStore } from "@/store/bot-filter";
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetPickupStoreForTests, usePickupStore } from "@/store/pickups";
@@ -594,7 +595,9 @@ describe("Home(設定ダイアログ)", () => {
     await user.click(screen.getByRole("button", { name: "Settings" }));
 
     const dialog = await screen.findByRole("dialog", { name: "Settings" });
-    expect(within(dialog).queryByRole("combobox")).not.toBeInTheDocument();
+    // 言語設定(学ぶ言語・解説言語)は各列の見出しのダイアログから設定するため、ここには置かない
+    expect(within(dialog).queryByLabelText("Learning languages")).not.toBeInTheDocument();
+    expect(within(dialog).queryByLabelText("Explanation language")).not.toBeInTheDocument();
   });
 
   it("マウント時に LocalStorage から言語設定を復元してから、パイプラインを開始する", () => {
@@ -602,7 +605,7 @@ describe("Home(設定ダイアログ)", () => {
 
     render(<Home />);
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["fr"], explainLang: "ja" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["fr"], explainLang: "ja" });
     expect(mockStartTranslationPipeline).toHaveBeenCalledTimes(1);
     expect(mockStartPickupPipeline).toHaveBeenCalledTimes(1);
   });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -143,9 +143,16 @@ export default function Home() {
 
   const settingsHydrated = useSettingsStore((state) => state.hydrated);
   const settings = useSettingsStore((state) => state.settings);
-  // 言語設定の内容が変わったときだけパイプラインを再起動するため、値を文字列にして依存に使う
-  // (`setSettings` は同じ内容でも新しいオブジェクトを作るため、参照比較では再起動してしまう)
-  const settingsKey = `${settings.learningLangs.join(",")}|${settings.explainLang}`;
+  // 言語設定・LLM プロバイダ設定の内容が変わったときだけパイプラインを再起動するため、値を文字列にして依存に使う
+  // (`setSettings` は同じ内容でも新しいオブジェクトを作るため、参照比較では再起動してしまう)。
+  // LLM 設定はセッションプールの生成(どのプロバイダ・モデル・キーで作るか)に影響するため含める
+  const settingsKey = [
+    settings.learningLangs.join(","),
+    settings.explainLang,
+    settings.llmProvider,
+    settings.openRouterApiKey,
+    settings.openRouterModel,
+  ].join("|");
 
   // 受信した発言を自動で翻訳・抽出ジョブに流す。言語設定の復元後に開始し、言語設定が変わるたびに
   // 停止 → 開始し直す(セッションプールのシステムプロンプトに言語ペアを含むため)。

--- a/src/components/language-dialogs.test.tsx
+++ b/src/components/language-dialogs.test.tsx
@@ -33,7 +33,7 @@ describe("LearningLanguagesDialog", () => {
   it("開くと、対応 5 言語のチェックボックスに現在の学ぶ言語が反映されている", async () => {
     const user = userEvent.setup();
     hydrateSettingsStore();
-    useSettingsStore.getState().setSettings({ learningLangs: ["en", "ja"], explainLang: "ja" });
+    useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: ["en", "ja"], explainLang: "ja" });
     render(<LearningLanguagesDialog />);
 
     await user.click(screen.getByRole("button", { name: "Learning languages" }));
@@ -55,8 +55,9 @@ describe("LearningLanguagesDialog", () => {
     await user.click(within(dialog).getByRole("checkbox", { name: "Español" }));
     await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["en", "es"], explainLang: "ja" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["en", "es"], explainLang: "ja" });
     expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "null")).toEqual({
+      ...DEFAULT_SETTINGS,
       learningLangs: ["en", "es"],
       explainLang: "ja",
     });
@@ -105,7 +106,7 @@ describe("ExplanationLanguageDialog", () => {
   it("開くと、セレクトに現在の解説言語が入っている", async () => {
     const user = userEvent.setup();
     hydrateSettingsStore();
-    useSettingsStore.getState().setSettings({ learningLangs: ["es"], explainLang: "en" });
+    useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: ["es"], explainLang: "en" });
     render(<ExplanationLanguageDialog />);
 
     await user.click(screen.getByRole("button", { name: "Explanation language" }));
@@ -117,7 +118,7 @@ describe("ExplanationLanguageDialog", () => {
   it("言語を変えて保存すると、解説言語だけを更新して LocalStorage にも保存し、ダイアログを閉じる", async () => {
     const user = userEvent.setup();
     hydrateSettingsStore();
-    useSettingsStore.getState().setSettings({ learningLangs: ["en", "fr"], explainLang: "ja" });
+    useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: ["en", "fr"], explainLang: "ja" });
     render(<ExplanationLanguageDialog />);
 
     await user.click(screen.getByRole("button", { name: "Explanation language" }));
@@ -125,8 +126,9 @@ describe("ExplanationLanguageDialog", () => {
     await user.selectOptions(within(dialog).getByRole("combobox", { name: "Explanation language" }), "de");
     await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["en", "fr"], explainLang: "de" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["en", "fr"], explainLang: "de" });
     expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "null")).toEqual({
+      ...DEFAULT_SETTINGS,
       learningLangs: ["en", "fr"],
       explainLang: "de",
     });
@@ -143,6 +145,6 @@ describe("ExplanationLanguageDialog", () => {
     await user.selectOptions(within(dialog).getByRole("combobox", { name: "Explanation language" }), "en");
     await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["en"], explainLang: "en" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["en"], explainLang: "en" });
   });
 });

--- a/src/components/settings-dialog.test.tsx
+++ b/src/components/settings-dialog.test.tsx
@@ -19,6 +19,12 @@ vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
   runBrowserDiagnosis: () => mockRunBrowserDiagnosis(),
 }));
 
+const mockFetchOpenRouterModels = vi.fn<() => Promise<Array<{ id: string; name: string }>>>();
+
+vi.mock("@/lib/ai/openrouter", () => ({
+  fetchOpenRouterModels: () => mockFetchOpenRouterModels(),
+}));
+
 import { SettingsDialog } from "./settings-dialog";
 
 /** Prompt API がすぐに使える環境(Chrome 150)の診断結果 */
@@ -35,6 +41,11 @@ beforeEach(() => {
   resetSettingsStoreForTests();
   mockRunBrowserDiagnosis.mockReset();
   mockRunBrowserDiagnosis.mockResolvedValue(利用可能な診断結果);
+  mockFetchOpenRouterModels.mockReset();
+  mockFetchOpenRouterModels.mockResolvedValue([
+    { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" },
+    { id: "openai/gpt-5", name: "GPT-5" },
+  ]);
 });
 
 afterEach(() => {
@@ -61,8 +72,8 @@ describe("SettingsDialog(設定の初期化・通知)", () => {
 
     const dialog = await openDialog(user);
 
-    expect(within(dialog).queryByRole("combobox")).not.toBeInTheDocument();
-    expect(within(dialog).queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    expect(within(dialog).queryByLabelText("Learning languages")).not.toBeInTheDocument();
+    expect(within(dialog).queryByLabelText("Explanation language")).not.toBeInTheDocument();
   });
 
   it("保存データが壊れていた場合は、デフォルトに戻した旨を表示する", async () => {
@@ -130,5 +141,104 @@ describe("SettingsDialog(環境診断)", () => {
     expect(await within(dialog).findByRole("alert")).toHaveTextContent(
       "Environment check failed: LanguageModel.availability がクラッシュしました",
     );
+  });
+});
+
+describe("SettingsDialog(LLM プロバイダ設定)", () => {
+  it("既定では Gemini Nano が選択されており、OpenRouter の API キー・モデルの入力欄は表示しない", async () => {
+    const user = userEvent.setup();
+    hydrateSettingsStore();
+    render(<SettingsDialog />);
+
+    const dialog = await openDialog(user);
+
+    expect(within(dialog).getByLabelText("LLM provider")).toHaveValue("gemini-nano");
+    expect(within(dialog).queryByLabelText("OpenRouter API key")).not.toBeInTheDocument();
+    expect(within(dialog).queryByLabelText("OpenRouter model")).not.toBeInTheDocument();
+  });
+
+  it("OpenRouter を選ぶと API キー入力欄とモデル一覧のセレクトを表示し、モデル一覧 API から選択肢を取得する", async () => {
+    const user = userEvent.setup();
+    hydrateSettingsStore();
+    render(<SettingsDialog />);
+
+    const dialog = await openDialog(user);
+    await user.selectOptions(within(dialog).getByLabelText("LLM provider"), "openrouter");
+
+    expect(within(dialog).getByLabelText("OpenRouter API key")).toBeInTheDocument();
+    const modelSelect = await within(dialog).findByLabelText("OpenRouter model");
+    expect(mockFetchOpenRouterModels).toHaveBeenCalledTimes(1);
+    expect(await within(modelSelect).findByRole("option", { name: "Claude Sonnet 5" })).toBeInTheDocument();
+    expect(within(modelSelect).getByRole("option", { name: "GPT-5" })).toBeInTheDocument();
+  });
+
+  it("API キーとモデルを入力して保存すると、設定をストアと LocalStorage に反映してダイアログを閉じる", async () => {
+    const user = userEvent.setup();
+    hydrateSettingsStore();
+    render(<SettingsDialog />);
+
+    const dialog = await openDialog(user);
+    await user.selectOptions(within(dialog).getByLabelText("LLM provider"), "openrouter");
+    await user.type(within(dialog).getByLabelText("OpenRouter API key"), "sk-or-v1-test-key-0123");
+    await within(dialog).findByRole("option", { name: "Claude Sonnet 5" });
+    await user.selectOptions(within(dialog).getByLabelText("OpenRouter model"), "anthropic/claude-sonnet-5");
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(useSettingsStore.getState().settings).toEqual({
+      ...DEFAULT_SETTINGS,
+      llmProvider: "openrouter",
+      openRouterApiKey: "sk-or-v1-test-key-0123",
+      openRouterModel: "anthropic/claude-sonnet-5",
+    });
+    expect(screen.queryByRole("dialog", { name: "Settings" })).not.toBeInTheDocument();
+  });
+
+  it("API キーが空のまま保存しようとするとエラーを表示し、設定を保存しない", async () => {
+    const user = userEvent.setup();
+    hydrateSettingsStore();
+    render(<SettingsDialog />);
+
+    const dialog = await openDialog(user);
+    await user.selectOptions(within(dialog).getByLabelText("LLM provider"), "openrouter");
+    await within(dialog).findByRole("option", { name: "Claude Sonnet 5" });
+    await user.selectOptions(within(dialog).getByLabelText("OpenRouter model"), "anthropic/claude-sonnet-5");
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(within(dialog).getByText("Enter your OpenRouter API key")).toBeInTheDocument();
+    expect(useSettingsStore.getState().settings).toEqual(DEFAULT_SETTINGS);
+  });
+
+  it("モデル一覧の取得に失敗した場合は理由を表示する(暗黙に空の選択肢にしない)", async () => {
+    const user = userEvent.setup();
+    hydrateSettingsStore();
+    mockFetchOpenRouterModels.mockRejectedValue(new Error("OpenRouter models API failed with status 500"));
+    render(<SettingsDialog />);
+
+    const dialog = await openDialog(user);
+    await user.selectOptions(within(dialog).getByLabelText("LLM provider"), "openrouter");
+
+    expect(
+      await within(dialog).findByText(/OpenRouter models API failed with status 500/),
+    ).toBeInTheDocument();
+  });
+
+  it("保存済みの OpenRouter 設定があるときは、開いた時点でその値を表示する", async () => {
+    const user = userEvent.setup();
+    hydrateSettingsStore();
+    useSettingsStore.getState().setSettings({
+      ...DEFAULT_SETTINGS,
+      llmProvider: "openrouter",
+      openRouterApiKey: "sk-or-v1-test-key-0123",
+      openRouterModel: "openai/gpt-5",
+    });
+    render(<SettingsDialog />);
+
+    const dialog = await openDialog(user);
+
+    expect(within(dialog).getByLabelText("LLM provider")).toHaveValue("openrouter");
+    expect(within(dialog).getByLabelText("OpenRouter API key")).toHaveValue("sk-or-v1-test-key-0123");
+    const modelSelect = await within(dialog).findByLabelText("OpenRouter model");
+    await within(modelSelect).findByRole("option", { name: "GPT-5" });
+    expect(modelSelect).toHaveValue("openai/gpt-5");
   });
 });

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -7,6 +7,8 @@
  * - 開くたびに環境診断(`runBrowserDiagnosis` → `describeDiagnosis`)を実行し、Prompt API / Language Detector が
  *   使えない環境ではその理由を表示する(chat-sensei は暗黙にクラウド API へ切り替えないため、理由を利用者にそのまま伝える)
  * - 保存されている設定を LocalStorage から削除してデフォルトに戻す
+ * - 翻訳・Pick up に使う LLM プロバイダを切り替える(Gemini Nano / OpenRouter)。OpenRouter を選ぶ場合は
+ *   API キーと、モデル一覧 API から取得した選択肢の中のモデルを保存する(キーはこのブラウザの LocalStorage にのみ保存する)
  *
  * 言語設定(学ぶ言語 / 解説言語)は配信ごとに変わるため、ここではなく各列の見出しのダイアログ
  * (`language-dialogs.tsx`)から設定する。
@@ -28,8 +30,12 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { describeDiagnosis, type DiagnosisMessage } from "@/lib/ai/describeDiagnosis";
+import { fetchOpenRouterModels, type OpenRouterModel } from "@/lib/ai/openrouter";
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
+import { LLM_PROVIDER_DISPLAY_NAMES, LLM_PROVIDERS, settingsSchema, type LlmProvider } from "@/lib/settings";
 import { cn } from "@/lib/utils";
 import { clearSettingsStore, useSettingsStore } from "@/store/settings";
 
@@ -75,6 +81,9 @@ export function SettingsDialog() {
           </p>
         )}
 
+        {/* key で開くたびに作り直し、下書きをストアの現在値から初期化する(前回の未保存の編集を持ち越さない) */}
+        <LlmProviderSection key={open ? "open" : "closed"} open={open} onSaved={() => setOpen(false)} />
+
         <DiagnosisSection open={open} />
 
         <DialogFooter className="sm:justify-between">
@@ -85,6 +94,145 @@ export function SettingsDialog() {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+const PROVIDER_SELECT_ID = "llm-provider-select";
+const OPENROUTER_API_KEY_INPUT_ID = "openrouter-api-key-input";
+const OPENROUTER_MODEL_SELECT_ID = "openrouter-model-select";
+
+/**
+ * OpenRouter のモデル一覧の取得状態。"idle" は未取得(取得中)を表し、画面には Loading と表示する。
+ * 失敗は暗黙に空の選択肢へフォールバックせず理由を表示する
+ */
+type ModelsState =
+  | { status: "idle" }
+  | { status: "loaded"; models: OpenRouterModel[] }
+  | { status: "error"; errorMessage: string };
+
+/**
+ * 翻訳・Pick up に使う LLM プロバイダの設定。
+ * ダイアログを開くたびにストアの現在値から下書きを作り直し、保存時に `settingsSchema` で検証してから
+ * ストア(→ LocalStorage)へ反映する。OpenRouter を選んでいる間だけ API キーとモデルの入力欄を表示し、
+ * モデルの選択肢はモデル一覧 API から取得する。
+ */
+function LlmProviderSection({ open, onSaved }: { open: boolean; onSaved: () => void }) {
+  const settings = useSettingsStore((state) => state.settings);
+  const setSettings = useSettingsStore((state) => state.setSettings);
+
+  const [draftProvider, setDraftProvider] = useState<LlmProvider>(settings.llmProvider);
+  const [draftApiKey, setDraftApiKey] = useState(settings.openRouterApiKey);
+  const [draftModel, setDraftModel] = useState(settings.openRouterModel);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [models, setModels] = useState<ModelsState>({ status: "idle" });
+
+  // OpenRouter を選んでいる間だけモデル一覧を取得する(取得済み・失敗確定後は再取得しない)
+  useEffect(() => {
+    if (!open || draftProvider !== "openrouter" || models.status !== "idle") return;
+    let cancelled = false;
+    fetchOpenRouterModels()
+      .then((fetched) => {
+        if (!cancelled) setModels({ status: "loaded", models: fetched });
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setModels({ status: "error", errorMessage: error instanceof Error ? error.message : String(error) });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, draftProvider, models.status]);
+
+  const handleSave = () => {
+    const validation = settingsSchema.safeParse({
+      ...settings,
+      llmProvider: draftProvider,
+      openRouterApiKey: draftApiKey,
+      openRouterModel: draftModel,
+    });
+    if (!validation.success) {
+      setSaveError(validation.error.issues[0]?.message ?? "Invalid settings");
+      return;
+    }
+    setSettings(validation.data);
+    onSaved();
+  };
+
+  return (
+    <section aria-label="LLM provider settings" className="flex flex-col gap-3 rounded-lg border p-3">
+      <h3 className="text-sm font-semibold">LLM provider</h3>
+
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor={PROVIDER_SELECT_ID}>LLM provider</Label>
+        <select
+          id={PROVIDER_SELECT_ID}
+          className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+          value={draftProvider}
+          onChange={(e) => setDraftProvider(e.target.value as LlmProvider)}
+        >
+          {LLM_PROVIDERS.map((provider) => (
+            <option key={provider} value={provider}>
+              {LLM_PROVIDER_DISPLAY_NAMES[provider]}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {draftProvider === "openrouter" && (
+        <>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={OPENROUTER_API_KEY_INPUT_ID}>OpenRouter API key</Label>
+            <Input
+              id={OPENROUTER_API_KEY_INPUT_ID}
+              type="password"
+              autoComplete="off"
+              placeholder="sk-or-v1-..."
+              value={draftApiKey}
+              onChange={(e) => setDraftApiKey(e.target.value)}
+            />
+            <p className="text-xs text-muted-foreground">
+              Stored only in this browser (LocalStorage) and sent directly to OpenRouter.
+            </p>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor={OPENROUTER_MODEL_SELECT_ID}>OpenRouter model</Label>
+            <select
+              id={OPENROUTER_MODEL_SELECT_ID}
+              className="h-8 w-full rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30"
+              value={draftModel}
+              onChange={(e) => setDraftModel(e.target.value)}
+            >
+              <option value="">{models.status === "idle" ? "Loading models..." : "Select a model"}</option>
+              {/* 一覧の取得が終わるまでは、保存済みのモデルを選択状態のまま保てるよう単独の選択肢として出す */}
+              {models.status !== "loaded" && draftModel !== "" && <option value={draftModel}>{draftModel}</option>}
+              {models.status === "loaded" &&
+                models.models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.name}
+                  </option>
+                ))}
+            </select>
+            {models.status === "error" && (
+              <p className="text-xs text-destructive" role="alert">
+                Could not load the model list: {models.errorMessage}
+              </p>
+            )}
+          </div>
+        </>
+      )}
+
+      {saveError && (
+        <p className="text-xs text-destructive" role="alert">
+          {saveError}
+        </p>
+      )}
+
+      <div>
+        <Button onClick={handleSave}>Save</Button>
+      </div>
+    </section>
   );
 }
 

--- a/src/lib/ai/availability.ts
+++ b/src/lib/ai/availability.ts
@@ -89,8 +89,11 @@ export function isChromeVersionSupported(version: number | null): boolean {
   return version >= MINIMUM_CHROME_VERSION;
 }
 
-/** `availability` の結果を「すぐ使える、または利用者操作でDL開始できる」かどうかに変換する */
-function isUsableAvailability(availability: ApiAvailability | null): boolean {
+/**
+ * `availability` の結果を「すぐ使える、または利用者操作でDL開始できる」かどうかに変換する。
+ * OpenRouter プロバイダ選択時に Language Detector 単体の可否を判定する用途(`store/prompt-api.ts`)でも使う
+ */
+export function isUsableApiAvailability(availability: ApiAvailability | null): boolean {
   return availability === "available" || availability === "downloadable";
 }
 
@@ -136,6 +139,6 @@ export async function diagnoseEnvironment(deps: DiagnosisDeps): Promise<Environm
     languageDetector,
     storageEstimate,
     overallReady:
-      isUsableAvailability(languageModel.availability) && isUsableAvailability(languageDetector.availability),
+      isUsableApiAvailability(languageModel.availability) && isUsableApiAvailability(languageDetector.availability),
   };
 }

--- a/src/lib/ai/detect-language.test.ts
+++ b/src/lib/ai/detect-language.test.ts
@@ -12,11 +12,12 @@
  * 「先頭の学ぶ言語で扱う」ような判定器の結果に基づかないフォールバックは行わない。
  */
 import { describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import type { Settings } from "@/lib/settings";
 import { classifyDetectedLanguage, MIN_FALLBACK_CONFIDENCE, SHORT_LATIN_TEXT_MAX_LENGTH } from "./detect-language";
 
-const 英語を学ぶ日本語話者の設定: Settings = { learningLangs: ["en"], explainLang: "ja" };
-const 日英混在チャットの設定: Settings = { learningLangs: ["en", "ja"], explainLang: "ja" };
+const 英語を学ぶ日本語話者の設定: Settings = { ...DEFAULT_SETTINGS, learningLangs: ["en"], explainLang: "ja" };
+const 日英混在チャットの設定: Settings = { ...DEFAULT_SETTINGS, learningLangs: ["en", "ja"], explainLang: "ja" };
 
 describe("classifyDetectedLanguage(かな規則)", () => {
   // Language Detector は「龍が如く感」を zh-Hant 0.939 / ja 0.058、「ｱｲﾑﾚﾃﾞｨ」を zh-Hans 0.871 / ja 0.052 と判定する(実測)。
@@ -25,7 +26,7 @@ describe("classifyDetectedLanguage(かな規則)", () => {
     const result = classifyDetectedLanguage(
       "龍が如く感",
       [{ detectedLanguage: "zh-Hant", confidence: 0.939 }, { detectedLanguage: "ja", confidence: 0.058 }],
-      { learningLangs: ["ja"], explainLang: "en" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["ja"], explainLang: "en" },
     );
 
     expect(result).toEqual({ kind: "learning", lang: "ja" });
@@ -55,7 +56,7 @@ describe("classifyDetectedLanguage(かな規則)", () => {
     const result = classifyDetectedLanguage(
       "それな",
       [{ detectedLanguage: "ja", confidence: 0.999 }],
-      { learningLangs: ["en"], explainLang: "es" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["en"], explainLang: "es" },
     );
 
     expect(result).toEqual({ kind: "other", detectedLanguage: "ja" });
@@ -79,7 +80,7 @@ describe("classifyDetectedLanguage(漢字規則)", () => {
     const result = classifyDetectedLanguage(
       "太陽神",
       [{ detectedLanguage: "zh-Hans", confidence: 0.9 }, { detectedLanguage: "ja", confidence: 0.03 }],
-      { learningLangs: ["ja"], explainLang: "en" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["ja"], explainLang: "en" },
     );
 
     expect(result).toEqual({ kind: "learning", lang: "ja" });
@@ -99,7 +100,7 @@ describe("classifyDetectedLanguage(漢字規則)", () => {
     const result = classifyDetectedLanguage(
       "太陽神",
       [{ detectedLanguage: "zh-Hans", confidence: 0.9 }],
-      { learningLangs: ["en"], explainLang: "es" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["en"], explainLang: "es" },
     );
 
     expect(result).toEqual({ kind: "other", detectedLanguage: "zh" });
@@ -136,7 +137,7 @@ describe("classifyDetectedLanguage(短い Latin 文字列の規則)", () => {
     const result = classifyDetectedLanguage(
       "sheesh",
       [{ detectedLanguage: "so", confidence: 0.6 }],
-      { learningLangs: ["ja", "es", "en"], explainLang: "de" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["ja", "es", "en"], explainLang: "de" },
     );
 
     expect(result).toEqual({ kind: "learning", lang: "es" });
@@ -146,7 +147,7 @@ describe("classifyDetectedLanguage(短い Latin 文字列の規則)", () => {
     const result = classifyDetectedLanguage(
       "KEKW",
       [{ detectedLanguage: "ku", confidence: 0.136 }],
-      { learningLangs: ["ja"], explainLang: "en" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["ja"], explainLang: "en" },
     );
 
     expect(result).toEqual({ kind: "same-as-explanation" });
@@ -179,7 +180,7 @@ describe("classifyDetectedLanguage(短い Latin 文字列の規則)", () => {
     const result = classifyDetectedLanguage(
       "W",
       [{ detectedLanguage: "ar-Latn", confidence: 0.553 }, { detectedLanguage: "en", confidence: 0.259 }],
-      { learningLangs: ["es", "en"], explainLang: "ja" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["es", "en"], explainLang: "ja" },
     );
 
     expect(result).toEqual({ kind: "learning", lang: "en" });
@@ -250,7 +251,7 @@ describe("classifyDetectedLanguage", () => {
         { detectedLanguage: "es", confidence: 0.3 },
         { detectedLanguage: "en", confidence: 0.15 },
       ],
-      { learningLangs: ["en", "es"], explainLang: "ja" },
+      { ...DEFAULT_SETTINGS, learningLangs: ["en", "es"], explainLang: "ja" },
     );
 
     expect(result).toEqual({ kind: "learning", lang: "es" });

--- a/src/lib/ai/llm-provider.test.ts
+++ b/src/lib/ai/llm-provider.test.ts
@@ -1,0 +1,63 @@
+/**
+ * src/lib/ai/llm-provider.ts(LLM プロバイダ切替層)のテスト。
+ *
+ * 設定 `llmProvider` に応じて、Gemini Nano(Prompt API)用と OpenRouter 用のどちらの
+ * ベースセッション生成関数が組み立てられるかを検証する。実ブラウザ API・ネットワークには触れず、
+ * `LanguageModel` と `fetch` はグローバルのスタブを注入する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { createLlmBaseSessionFactory } from "./llm-provider";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** 翻訳用を模したシステムプロンプトの組み立て関数(言語ペアが渡ることを検証できる形にする) */
+function buildSystemPrompt(targetLang: string, explainLang: string): string {
+  return `${targetLang} のチャットを ${explainLang} に翻訳してください`;
+}
+
+describe("createLlmBaseSessionFactory", () => {
+  it("Gemini Nano プロバイダでは LanguageModel.create でベースセッションを生成する", async () => {
+    const fakeSession = { prompt: vi.fn(), clone: vi.fn(), destroy: vi.fn() };
+    const create = vi.fn(async () => fakeSession);
+    vi.stubGlobal("LanguageModel", { create });
+
+    const factory = createLlmBaseSessionFactory(DEFAULT_SETTINGS, buildSystemPrompt, "en", "ja");
+    const session = await factory();
+
+    expect(session).toBe(fakeSession);
+    expect(create).toHaveBeenCalledWith({
+      initialPrompts: [{ role: "system", content: "en のチャットを ja に翻訳してください" }],
+      expectedInputs: [{ type: "text", languages: ["en", "ja"] }],
+      expectedOutputs: [{ type: "text", languages: ["ja"] }],
+    });
+  });
+
+  it("OpenRouter プロバイダでは設定のキー・モデルとシステムプロンプトで chat/completions を呼ぶセッションを生成する", async () => {
+    const fetchFake = vi.fn(
+      async (): Promise<Response> =>
+        new Response(JSON.stringify({ choices: [{ message: { content: "ナイスプレー" } }] }), { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchFake);
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      llmProvider: "openrouter" as const,
+      openRouterApiKey: "sk-or-v1-test-key-0123",
+      openRouterModel: "anthropic/claude-sonnet-5",
+    };
+
+    const factory = createLlmBaseSessionFactory(settings, buildSystemPrompt, "en", "ja");
+    const session = await factory();
+    const result = await session.prompt("nice play");
+
+    expect(result).toBe("ナイスプレー");
+    const [url, init] = fetchFake.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe("https://openrouter.ai/api/v1/chat/completions");
+    expect(new Headers(init.headers).get("Authorization")).toBe("Bearer sk-or-v1-test-key-0123");
+    const body = JSON.parse(String(init.body)) as { model: string; messages: Array<{ role: string; content: string }> };
+    expect(body.model).toBe("anthropic/claude-sonnet-5");
+    expect(body.messages[0]).toEqual({ role: "system", content: "en のチャットを ja に翻訳してください" });
+  });
+});

--- a/src/lib/ai/llm-provider.ts
+++ b/src/lib/ai/llm-provider.ts
@@ -1,0 +1,38 @@
+/**
+ * LLM プロバイダ切替層。設定(`lib/settings.ts` の `llmProvider`)に応じて、
+ * 翻訳・Pick up のセッションプールに渡すベースセッション生成関数を組み立てる。
+ *
+ * - "gemini-nano": Chrome 内蔵の Prompt API(`structured-prompt.ts` の `createBaseSessionFactory`)
+ * - "openrouter": 利用者の API キーで OpenRouter を呼ぶ互換セッション(`openrouter.ts`)
+ *
+ * どちらも `PromptSessionLike` を返すため、セッションプール・構造化プロンプト・パイプラインは
+ * プロバイダを意識せずそのまま動く。発言ごとの言語判定(Language Detector)は
+ * プロバイダに関わらずブラウザ内蔵 API を使い続ける。
+ */
+import type { Settings } from "@/lib/settings";
+import { createOpenRouterSessionFactory } from "./openrouter";
+import type { SupportedLanguage } from "./prompts";
+import type { PromptSessionLike } from "./session-pool";
+import { createBaseSessionFactory } from "./structured-prompt";
+
+/**
+ * 設定・用途ごとのシステムプロンプト組み立て関数・言語ペアから、
+ * 現在のプロバイダに対応するベースセッション生成関数を組み立てる。
+ */
+export function createLlmBaseSessionFactory(
+  settings: Settings,
+  buildSystemPrompt: (targetLang: SupportedLanguage, explainLang: SupportedLanguage) => string,
+  targetLang: SupportedLanguage,
+  explainLang: SupportedLanguage,
+): () => Promise<PromptSessionLike> {
+  switch (settings.llmProvider) {
+    case "gemini-nano":
+      return createBaseSessionFactory(buildSystemPrompt, targetLang, explainLang);
+    case "openrouter":
+      return createOpenRouterSessionFactory({
+        apiKey: settings.openRouterApiKey,
+        model: settings.openRouterModel,
+        systemPrompt: buildSystemPrompt(targetLang, explainLang),
+      });
+  }
+}

--- a/src/lib/ai/openrouter.test.ts
+++ b/src/lib/ai/openrouter.test.ts
@@ -1,0 +1,139 @@
+/**
+ * src/lib/ai/openrouter.ts(OpenRouter API クライアント)のテスト。
+ *
+ * ネットワークには触れず、fetch のフェイクを注入して以下を検証する。
+ * - モデル一覧 API(GET /models)の取得・整形・失敗時の例外(Fail-Fast)
+ * - `PromptSessionLike` 互換セッションが chat/completions へ正しいリクエストを送ること
+ * - 応答の取り出しと、HTTP エラー時に理由付きの例外を投げること
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createOpenRouterSessionFactory, fetchOpenRouterModels, OPENROUTER_API_BASE_URL } from "./openrouter";
+
+/** fetch のフェイクを組み立てる。返す JSON とステータスを指定できる */
+function createFetchFake(body: unknown, init: { status?: number } = {}) {
+  return vi.fn(async (): Promise<Response> => {
+    return new Response(JSON.stringify(body), { status: init.status ?? 200 });
+  });
+}
+
+describe("fetchOpenRouterModels", () => {
+  it("モデル一覧を id 昇順で返し、name が無いモデルは id を表示名にする", async () => {
+    const fetchFake = createFetchFake({
+      data: [
+        { id: "openai/gpt-5", name: "GPT-5" },
+        { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" },
+        { id: "meta-llama/llama-4" },
+      ],
+    });
+
+    const models = await fetchOpenRouterModels(fetchFake);
+
+    expect(fetchFake).toHaveBeenCalledWith(`${OPENROUTER_API_BASE_URL}/models`);
+    expect(models).toEqual([
+      { id: "anthropic/claude-sonnet-5", name: "Claude Sonnet 5" },
+      { id: "meta-llama/llama-4", name: "meta-llama/llama-4" },
+      { id: "openai/gpt-5", name: "GPT-5" },
+    ]);
+  });
+
+  it("HTTP エラーの場合はステータスコードを含む例外を投げる(暗黙に空一覧へフォールバックしない)", async () => {
+    const fetchFake = createFetchFake({ error: { message: "Internal Server Error" } }, { status: 500 });
+
+    await expect(fetchOpenRouterModels(fetchFake)).rejects.toThrow(/500/);
+  });
+
+  it("応答がスキーマに合わない場合は例外を投げる", async () => {
+    const fetchFake = createFetchFake({ models: "これは想定した形ではない" });
+
+    await expect(fetchOpenRouterModels(fetchFake)).rejects.toThrow();
+  });
+});
+
+describe("createOpenRouterSessionFactory", () => {
+  const config = {
+    apiKey: "sk-or-v1-test-key-0123",
+    model: "anthropic/claude-sonnet-5",
+    systemPrompt: "あなたはTwitchチャットの翻訳者です",
+  };
+
+  /** chat/completions の正常応答を返す fetch フェイク */
+  function createCompletionFetchFake(content: string) {
+    return createFetchFake({ choices: [{ message: { content } }] });
+  }
+
+  it("システムプロンプト・ユーザープロンプト・responseConstraint を chat/completions のリクエストに組み立てる", async () => {
+    const fetchFake = createCompletionFetchFake('{"translation":"ナイスプレー"}');
+    const session = await createOpenRouterSessionFactory(config, fetchFake)();
+
+    const constraint = { type: "object", properties: { translation: { type: "string" } } };
+    const result = await session.prompt("nice play", { responseConstraint: constraint });
+
+    expect(result).toBe('{"translation":"ナイスプレー"}');
+    expect(fetchFake).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFake.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe(`${OPENROUTER_API_BASE_URL}/chat/completions`);
+    expect(init.method).toBe("POST");
+    expect(new Headers(init.headers).get("Authorization")).toBe(`Bearer ${config.apiKey}`);
+    expect(new Headers(init.headers).get("Content-Type")).toBe("application/json");
+    expect(JSON.parse(String(init.body))).toEqual({
+      model: config.model,
+      messages: [
+        { role: "system", content: config.systemPrompt },
+        { role: "user", content: "nice play" },
+      ],
+      response_format: {
+        type: "json_schema",
+        json_schema: { name: "response", strict: true, schema: constraint },
+      },
+    });
+  });
+
+  it("responseConstraint を渡さない場合は response_format を付けない", async () => {
+    const fetchFake = createCompletionFetchFake("こんにちは");
+    const session = await createOpenRouterSessionFactory(config, fetchFake)();
+
+    await session.prompt("hello");
+
+    const [, init] = fetchFake.mock.calls[0] as unknown as [string, RequestInit];
+    expect(JSON.parse(String(init.body))).not.toHaveProperty("response_format");
+  });
+
+  it("HTTP エラーの場合はステータスコードと本文の理由を含む例外を投げる", async () => {
+    const fetchFake = createFetchFake({ error: { message: "Invalid API key" } }, { status: 401 });
+    const session = await createOpenRouterSessionFactory(config, fetchFake)();
+
+    await expect(session.prompt("hello")).rejects.toThrow(/401.*Invalid API key/);
+  });
+
+  it("応答に choices が無い場合は例外を投げる(暗黙に空文字へフォールバックしない)", async () => {
+    const fetchFake = createFetchFake({ choices: [] });
+    const session = await createOpenRouterSessionFactory(config, fetchFake)();
+
+    await expect(session.prompt("hello")).rejects.toThrow();
+  });
+
+  it("clone したセッションも同じ設定でリクエストでき、destroy は例外を投げない", async () => {
+    const fetchFake = createCompletionFetchFake("よい試合でした");
+    const session = await createOpenRouterSessionFactory(config, fetchFake)();
+
+    const cloned = await session.clone();
+    const result = await cloned.prompt("gg");
+
+    expect(result).toBe("よい試合でした");
+    expect(() => {
+      cloned.destroy();
+      session.destroy();
+    }).not.toThrow();
+  });
+
+  it("prompt の signal を fetch に引き渡す(パイプライン停止時に実行中のリクエストを中断できるようにする)", async () => {
+    const fetchFake = createCompletionFetchFake("ok");
+    const session = await createOpenRouterSessionFactory(config, fetchFake)();
+    const controller = new AbortController();
+
+    await session.prompt("hello", { signal: controller.signal });
+
+    const [, init] = fetchFake.mock.calls[0] as unknown as [string, RequestInit];
+    expect(init.signal).toBe(controller.signal);
+  });
+});

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -1,0 +1,143 @@
+/**
+ * OpenRouter API のクライアント。Gemini Nano(Prompt API)の代わりに、利用者自身の
+ * OpenRouter API キーで任意のクラウド LLM を使えるようにする(設定 `llmProvider: "openrouter"`)。
+ *
+ * - `fetchOpenRouterModels`: モデル一覧 API(GET /models)から選択肢を取得する(設定ダイアログで使用)
+ * - `createOpenRouterSessionFactory`: 既存パイプラインがそのまま使えるよう、Prompt API の
+ *   セッションと互換の `PromptSessionLike` を返す生成関数を組み立てる。`responseConstraint`
+ *   (JSON Schema)は OpenRouter の Structured Outputs(`response_format: json_schema`)に対応させる
+ *
+ * chat-sensei はサーバーを持たないため、リクエストはブラウザから直接 OpenRouter へ送る。
+ * HTTP エラーや想定外の応答は暗黙にフォールバックせず、理由付きの例外を投げる(Fail-Fast)。
+ */
+import { z } from "zod";
+import type { PromptSessionLike } from "./session-pool";
+
+export const OPENROUTER_API_BASE_URL = "https://openrouter.ai/api/v1";
+
+/** モデル一覧 API の応答のうち、この画面で使う項目だけを検証する(他の項目は無視する) */
+const modelsResponseSchema = z.object({
+  data: z.array(
+    z.looseObject({
+      id: z.string().min(1),
+      name: z.string().optional(),
+    }),
+  ),
+});
+
+/** エラー応答の本文(`{"error": {"message": "..."}}`)。理由の取り出しに失敗しても例外は投げる */
+const errorResponseSchema = z.looseObject({
+  error: z.looseObject({ message: z.string() }).optional(),
+});
+
+/** chat/completions の応答のうち、この画面で使う項目だけを検証する */
+const completionResponseSchema = z.object({
+  choices: z
+    .array(
+      z.looseObject({
+        message: z.looseObject({ content: z.string() }),
+      }),
+    )
+    .min(1, "OpenRouter returned no choices"),
+});
+
+/** 設定ダイアログのモデル選択に表示する 1 モデルぶんの情報 */
+export interface OpenRouterModel {
+  id: string;
+  /** 表示名。API が name を返さないモデルは id をそのまま使う */
+  name: string;
+}
+
+/**
+ * OpenRouter のモデル一覧を取得し、id 昇順で返す。
+ * モデル一覧 API は API キー無しで呼び出せるため、認証ヘッダは付けない。
+ * HTTP エラー・スキーマ不一致は例外を投げる(暗黙に空一覧へフォールバックしない)。
+ */
+export async function fetchOpenRouterModels(fetchFn: typeof fetch = fetch): Promise<OpenRouterModel[]> {
+  const response = await fetchFn(`${OPENROUTER_API_BASE_URL}/models`);
+  if (!response.ok) {
+    throw new Error(`OpenRouter models API failed with status ${response.status}`);
+  }
+  const parsed = modelsResponseSchema.parse(await response.json());
+  return parsed.data
+    .map((model) => ({ id: model.id, name: model.name ?? model.id }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** OpenRouter セッションの設定。API キー・モデルは利用者の設定(`lib/settings.ts`)から渡す */
+export interface OpenRouterSessionConfig {
+  apiKey: string;
+  /** モデル ID(例: "anthropic/claude-sonnet-5") */
+  model: string;
+  /** 用途(翻訳・Pick up)ごとのシステムプロンプト */
+  systemPrompt: string;
+}
+
+/** エラー応答の本文から理由を取り出す。取り出せない場合は null */
+function extractErrorMessage(body: unknown): string | null {
+  const parsed = errorResponseSchema.safeParse(body);
+  return parsed.success ? (parsed.data.error?.message ?? null) : null;
+}
+
+/**
+ * `SessionPool` にそのまま渡せる、OpenRouter 向けベースセッションの生成関数を組み立てる。
+ *
+ * Prompt API と違いセッションはサーバー側の状態を持たないため、`clone()` は同じ設定の
+ * セッションを返すだけ、`destroy()` は何もしない。1 回の `prompt()` が
+ * 「システムプロンプト + ユーザープロンプト」の独立した chat/completions リクエストになる
+ * (既存パイプラインもクローンセッションに 1 回だけ prompt する使い方のため、意味は変わらない)。
+ */
+export function createOpenRouterSessionFactory(
+  config: OpenRouterSessionConfig,
+  fetchFn: typeof fetch = fetch,
+): () => Promise<PromptSessionLike> {
+  async function prompt(
+    input: string,
+    options?: { responseConstraint?: Record<string, unknown>; signal?: AbortSignal },
+  ): Promise<string> {
+    const body: Record<string, unknown> = {
+      model: config.model,
+      messages: [
+        { role: "system", content: config.systemPrompt },
+        { role: "user", content: input },
+      ],
+    };
+    if (options?.responseConstraint) {
+      // Prompt API の responseConstraint(JSON Schema)を OpenRouter の Structured Outputs に対応させる
+      body.response_format = {
+        type: "json_schema",
+        json_schema: { name: "response", strict: true, schema: options.responseConstraint },
+      };
+    }
+
+    const response = await fetchFn(`${OPENROUTER_API_BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${config.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+      signal: options?.signal,
+    });
+
+    if (!response.ok) {
+      const reason = extractErrorMessage(await response.json().catch(() => null));
+      throw new Error(
+        `OpenRouter chat completion failed with status ${response.status}${reason ? `: ${reason}` : ""}`,
+      );
+    }
+
+    const parsed = completionResponseSchema.parse(await response.json());
+    return parsed.choices[0].message.content;
+  }
+
+  function createSession(): PromptSessionLike {
+    return {
+      prompt,
+      clone: async () => createSession(),
+      destroy: () => {},
+    };
+  }
+
+  return async () => createSession();
+}

--- a/src/lib/ai/pickup.test.ts
+++ b/src/lib/ai/pickup.test.ts
@@ -9,6 +9,7 @@
  * (`LanguageModel` はブラウザ組み込みAPIのため `vi.stubGlobal` でモックする)。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { createPickupBaseSessionFactory, pickUpExpressions } from "./pickup";
 import { buildExplainSystemPrompt, buildTranslateSystemPrompt } from "./prompts";
 import type { SessionPool } from "./session-pool";
@@ -236,7 +237,7 @@ describe("createPickupBaseSessionFactory", () => {
     const create = vi.fn<(options: CapturedCreateOptions) => Promise<typeof created>>(async () => created);
     vi.stubGlobal("LanguageModel", { create, availability: vi.fn() });
 
-    const factory = createPickupBaseSessionFactory("en", "ja");
+    const factory = createPickupBaseSessionFactory(DEFAULT_SETTINGS, "en", "ja");
     const session = await factory();
 
     expect(session).toBe(created);

--- a/src/lib/ai/pickup.ts
+++ b/src/lib/ai/pickup.ts
@@ -13,12 +13,14 @@
  * - `createPickupBaseSessionFactory`: Pick up 専用のシステムプロンプトを持つベースセッションの生成関数を組み立てる。
  *   翻訳用とはプール(ベースセッション)を分ける前提(issue #15 の方針 (a))。直列キューは共有する(issue #23)
  */
+import type { Settings } from "@/lib/settings";
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
+import { createLlmBaseSessionFactory } from "./llm-provider";
 import { filterPickupTerms, preparePickupInput } from "./pickup-filter";
 import { buildPickupSystemPrompt, buildPickupUserPrompt, type SupportedLanguage } from "./prompts";
 import { pickupSchema, type PickupResult } from "./schemas";
 import type { JobPriority, PromptSessionLike, SessionPool } from "./session-pool";
-import { createBaseSessionFactory, runStructuredPrompt } from "./structured-prompt";
+import { runStructuredPrompt } from "./structured-prompt";
 
 export interface PickupOptions {
   /** 抽出は受信した全発言を自動で処理するバックグラウンド生成のため、既定は low */
@@ -62,10 +64,14 @@ export async function pickUpExpressions(
   return { terms };
 }
 
-/** 学ぶ言語・意味を書く言語のペアから、Pick up 専用の `SessionPool` に渡すベースセッション生成関数を組み立てる */
+/**
+ * 設定(LLM プロバイダ)と学ぶ言語・意味を書く言語のペアから、
+ * Pick up 専用の `SessionPool` に渡すベースセッション生成関数を組み立てる
+ */
 export function createPickupBaseSessionFactory(
+  settings: Settings,
   targetLang: SupportedLanguage,
   explainLang: SupportedLanguage,
 ): () => Promise<PromptSessionLike> {
-  return createBaseSessionFactory(buildPickupSystemPrompt, targetLang, explainLang);
+  return createLlmBaseSessionFactory(settings, buildPickupSystemPrompt, targetLang, explainLang);
 }

--- a/src/lib/ai/translate.test.ts
+++ b/src/lib/ai/translate.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildExplainSystemPrompt } from "./prompts";
 import type { SessionPool } from "./session-pool";
 import { STRUCTURED_PROMPT_MAX_ATTEMPTS } from "./structured-prompt";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { createTranslateBaseSessionFactory, translateChatMessage } from "./translate";
 
 /**
@@ -149,7 +150,7 @@ describe("createTranslateBaseSessionFactory", () => {
     const create = vi.fn<(options: CapturedCreateOptions) => Promise<typeof created>>(async () => created);
     vi.stubGlobal("LanguageModel", { create, availability: vi.fn() });
 
-    const factory = createTranslateBaseSessionFactory("en", "ja");
+    const factory = createTranslateBaseSessionFactory(DEFAULT_SETTINGS, "en", "ja");
     const session = await factory();
 
     expect(session).toBe(created);

--- a/src/lib/ai/translate.ts
+++ b/src/lib/ai/translate.ts
@@ -8,10 +8,12 @@
  * - `createTranslateBaseSessionFactory`: 翻訳専用のシステムプロンプトを持つベースセッションの生成関数を組み立てる。
  *   Pick up 用とはプール(ベースセッション)を分ける前提(issue #15 の方針 (a))。直列キューは共有する(issue #23)
  */
+import type { Settings } from "@/lib/settings";
+import { createLlmBaseSessionFactory } from "./llm-provider";
 import { buildTranslateSystemPrompt, buildTranslateUserPrompt, type SupportedLanguage } from "./prompts";
 import { translationSchema, type TranslationResult } from "./schemas";
 import type { JobPriority, PromptSessionLike, SessionPool } from "./session-pool";
-import { createBaseSessionFactory, runStructuredPrompt } from "./structured-prompt";
+import { runStructuredPrompt } from "./structured-prompt";
 
 export interface TranslateOptions {
   /** 翻訳は受信した全発言を自動で処理するバックグラウンド生成のため、既定は low */
@@ -35,10 +37,14 @@ export async function translateChatMessage(
   });
 }
 
-/** 学ぶ言語・訳文の言語のペアから、翻訳専用の `SessionPool` に渡すベースセッション生成関数を組み立てる */
+/**
+ * 設定(LLM プロバイダ)と学ぶ言語・訳文の言語のペアから、
+ * 翻訳専用の `SessionPool` に渡すベースセッション生成関数を組み立てる
+ */
 export function createTranslateBaseSessionFactory(
+  settings: Settings,
   targetLang: SupportedLanguage,
   explainLang: SupportedLanguage,
 ): () => Promise<PromptSessionLike> {
-  return createBaseSessionFactory(buildTranslateSystemPrompt, targetLang, explainLang);
+  return createLlmBaseSessionFactory(settings, buildTranslateSystemPrompt, targetLang, explainLang);
 }

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -21,22 +21,31 @@ describe("loadSettings", () => {
     const result = loadSettings();
 
     expect(result).toEqual({ settings: DEFAULT_SETTINGS, wasCorrupted: false });
-    expect(DEFAULT_SETTINGS).toEqual({ learningLangs: ["en"], explainLang: "ja" });
+    expect(DEFAULT_SETTINGS).toEqual({
+      learningLangs: ["en"],
+      explainLang: "ja",
+      llmProvider: "gemini-nano",
+      openRouterApiKey: "",
+      openRouterModel: "",
+    });
   });
 
   it("保存された正常な設定(学ぶ言語が複数)を復元する", () => {
-    saveSettings({ learningLangs: ["es", "en"], explainLang: "ja" });
+    saveSettings({ ...DEFAULT_SETTINGS, learningLangs: ["es", "en"] });
 
     const result = loadSettings();
 
-    expect(result).toEqual({ settings: { learningLangs: ["es", "en"], explainLang: "ja" }, wasCorrupted: false });
+    expect(result).toEqual({
+      settings: { ...DEFAULT_SETTINGS, learningLangs: ["es", "en"] },
+      wasCorrupted: false,
+    });
   });
 
   it("学ぶ言語に解説言語と同じ言語が含まれていても、そのまま復元する(同じ言語の発言はパイプライン側でスキップする)", () => {
-    saveSettings({ learningLangs: ["en", "ja"], explainLang: "ja" });
+    saveSettings({ ...DEFAULT_SETTINGS, learningLangs: ["en", "ja"], explainLang: "ja" });
 
     expect(loadSettings()).toEqual({
-      settings: { learningLangs: ["en", "ja"], explainLang: "ja" },
+      settings: { ...DEFAULT_SETTINGS, learningLangs: ["en", "ja"], explainLang: "ja" },
       wasCorrupted: false,
     });
   });
@@ -78,14 +87,72 @@ describe("loadSettings", () => {
 
 describe("saveSettings", () => {
   it("学ぶ言語が空の設定は例外を投げて保存しない", () => {
-    expect(() => saveSettings({ learningLangs: [], explainLang: "ja" })).toThrow();
+    expect(() => saveSettings({ ...DEFAULT_SETTINGS, learningLangs: [] })).toThrow();
     expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("LLMプロバイダ設定", () => {
+  it("旧形式(llmProvider 無し)の保存データは Gemini Nano・空の OpenRouter 設定として復元する(壊れた扱いにしない)", () => {
+    window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ learningLangs: ["en"], explainLang: "ja" }));
+
+    expect(loadSettings()).toEqual({
+      settings: {
+        learningLangs: ["en"],
+        explainLang: "ja",
+        llmProvider: "gemini-nano",
+        openRouterApiKey: "",
+        openRouterModel: "",
+      },
+      wasCorrupted: false,
+    });
+  });
+
+  it("OpenRouter プロバイダの設定(APIキー・モデル)を保存・復元できる", () => {
+    const settings = {
+      ...DEFAULT_SETTINGS,
+      llmProvider: "openrouter" as const,
+      openRouterApiKey: "sk-or-v1-テスト用キー",
+      openRouterModel: "anthropic/claude-sonnet-5",
+    };
+    saveSettings(settings);
+
+    expect(loadSettings()).toEqual({ settings, wasCorrupted: false });
+  });
+
+  it("OpenRouter プロバイダなのに API キーが空の設定は例外を投げて保存しない", () => {
+    expect(() =>
+      saveSettings({ ...DEFAULT_SETTINGS, llmProvider: "openrouter", openRouterModel: "anthropic/claude-sonnet-5" }),
+    ).toThrow();
+    expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
+  });
+
+  it("OpenRouter プロバイダなのにモデルが空の設定は例外を投げて保存しない", () => {
+    expect(() =>
+      saveSettings({ ...DEFAULT_SETTINGS, llmProvider: "openrouter", openRouterApiKey: "sk-or-v1-テスト用キー" }),
+    ).toThrow();
+    expect(window.localStorage.getItem(SETTINGS_STORAGE_KEY)).toBeNull();
+  });
+
+  it("Gemini Nano プロバイダでは API キー・モデルが空でも保存できる", () => {
+    saveSettings({ ...DEFAULT_SETTINGS, llmProvider: "gemini-nano" });
+
+    expect(loadSettings().wasCorrupted).toBe(false);
+  });
+
+  it("未知のプロバイダ名が保存されている場合はデフォルトに戻す", () => {
+    window.localStorage.setItem(
+      SETTINGS_STORAGE_KEY,
+      JSON.stringify({ learningLangs: ["en"], explainLang: "ja", llmProvider: "unknown-provider" }),
+    );
+
+    expect(loadSettings()).toEqual({ settings: DEFAULT_SETTINGS, wasCorrupted: true });
   });
 });
 
 describe("clearSettings", () => {
   it("保存されていた設定をLocalStorageから削除し、以後はデフォルト設定が読み込まれる", () => {
-    saveSettings({ learningLangs: ["es"], explainLang: "ja" });
+    saveSettings({ ...DEFAULT_SETTINGS, learningLangs: ["es"] });
 
     clearSettings();
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,5 +1,6 @@
 /**
- * 学ぶ言語(learningLangs: 1つ以上)・解説言語(explainLang)の設定を LocalStorage に保存・復元するモジュール。
+ * 学ぶ言語(learningLangs: 1つ以上)・解説言語(explainLang)・LLM プロバイダ
+ * (llmProvider / openRouterApiKey / openRouterModel)の設定を LocalStorage に保存・復元するモジュール。
  *
  * 学ぶ言語は配信ごとに複数の言語が混ざるチャット(英語と日本語など)に対応するため複数選べる。
  * 学ぶ言語と解説言語が同じ組み合わせは禁止しない。解説言語と同じ言語の発言は翻訳・Pick up をしない、
@@ -16,6 +17,11 @@ import { SUPPORTED_LANGUAGES, type SupportedLanguage } from "./ai/prompts";
 
 export const SETTINGS_STORAGE_KEY = "chat-sensei:settings";
 
+/** 翻訳・Pick up の生成に使う LLM プロバイダの選択肢 */
+export const LLM_PROVIDERS = ["gemini-nano", "openrouter"] as const;
+
+export type LlmProvider = (typeof LLM_PROVIDERS)[number];
+
 export const settingsSchema = z.object({
   /** 学ぶ言語(Twitchチャットの原文として翻訳・Pick up の対象にする言語)。1つ以上、重複なし */
   learningLangs: z
@@ -24,6 +30,21 @@ export const settingsSchema = z.object({
     .refine((langs) => new Set(langs).size === langs.length, { message: "Learning languages must not repeat" }),
   /** 解説言語(訳文・Pick up の意味の言語) */
   explainLang: z.enum(SUPPORTED_LANGUAGES),
+  /** 翻訳・Pick up の生成に使う LLM プロバイダ。旧形式(項目なし)の保存データは Gemini Nano として復元する */
+  llmProvider: z.enum(LLM_PROVIDERS).default("gemini-nano"),
+  /** OpenRouter の API キー。プロバイダが openrouter のときのみ必須 */
+  openRouterApiKey: z.string().default(""),
+  /** OpenRouter のモデル ID(例: "anthropic/claude-sonnet-5")。プロバイダが openrouter のときのみ必須 */
+  openRouterModel: z.string().default(""),
+}).superRefine((settings, ctx) => {
+  // OpenRouter を選んだのにキー・モデルが無い設定は動作しないため、保存時点で拒否する(Fail-Fast)
+  if (settings.llmProvider !== "openrouter") return;
+  if (settings.openRouterApiKey.trim() === "") {
+    ctx.addIssue({ code: "custom", message: "Enter your OpenRouter API key", path: ["openRouterApiKey"] });
+  }
+  if (settings.openRouterModel.trim() === "") {
+    ctx.addIssue({ code: "custom", message: "Select an OpenRouter model", path: ["openRouterModel"] });
+  }
 });
 
 export type Settings = z.infer<typeof settingsSchema>;
@@ -31,6 +52,15 @@ export type Settings = z.infer<typeof settingsSchema>;
 export const DEFAULT_SETTINGS: Settings = {
   learningLangs: ["en"],
   explainLang: "ja",
+  llmProvider: "gemini-nano",
+  openRouterApiKey: "",
+  openRouterModel: "",
+};
+
+/** 設定画面のセレクトボックスに表示する、各 LLM プロバイダの表示名 */
+export const LLM_PROVIDER_DISPLAY_NAMES: Record<LlmProvider, string> = {
+  "gemini-nano": "Gemini Nano (on-device)",
+  openrouter: "OpenRouter",
 };
 
 /** 設定画面のセレクトボックスに表示する、各言語のネイティブ表記 */

--- a/src/store/auto-pipeline.test.ts
+++ b/src/store/auto-pipeline.test.ts
@@ -8,6 +8,7 @@
  * をここで検証する。翻訳・Pick up 固有の振る舞いは `translations.test.ts` / `pickups.test.ts` が担当する。
  */
 import { afterEach, describe, expect, it } from "vitest";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
 import { LowPriorityQueueOverflowError } from "@/lib/ai/session-pool";
 import { createAutoPipeline, MAX_WAITING_FOR_DIAGNOSIS } from "./auto-pipeline";
@@ -237,7 +238,7 @@ describe("createAutoPipeline().start", () => {
   it("学ぶ言語が複数のとき、判定した言語ごとに別のセッションプールを使う", async () => {
     const { deps, emit, detect } = createDeps({
       promptResults: [Promise.resolve("英語の結果"), Promise.resolve("スペイン語の結果")],
-      settings: { learningLangs: ["en", "es"], explainLang: "ja" },
+      settings: { ...DEFAULT_SETTINGS, learningLangs: ["en", "es"], explainLang: "ja" },
     });
     detect
       .mockResolvedValueOnce([{ detectedLanguage: "en", confidence: 0.9 }])
@@ -273,7 +274,7 @@ describe("createAutoPipeline().start", () => {
   it("解説言語と同じ言語と判定した発言は、モデルを呼ばず same-language として保持する", async () => {
     const { deps, emit, enqueue } = createDeps({
       detectedLanguage: "ja",
-      settings: { learningLangs: ["en", "ja"], explainLang: "ja" },
+      settings: { ...DEFAULT_SETTINGS, learningLangs: ["en", "ja"], explainLang: "ja" },
     });
 
     const stop = start(deps);
@@ -434,7 +435,7 @@ describe("createAutoPipeline().warmUp", () => {
   it("診断が ready のとき、ユーザー操作の延長で Language Detector と学ぶ言語ごとのセッションプールを生成しウォームアップする", async () => {
     const { deps, warmUp, createDetector } = createDeps({
       ready: true,
-      settings: { learningLangs: ["en", "es"], explainLang: "ja" },
+      settings: { ...DEFAULT_SETTINGS, learningLangs: ["en", "es"], explainLang: "ja" },
     });
 
     const stop = start(deps);
@@ -453,7 +454,7 @@ describe("createAutoPipeline().warmUp", () => {
   it("学ぶ言語に解説言語が含まれていても、解説言語のセッションプールはウォームアップしない(その言語の発言は処理しないため)", async () => {
     const { deps, warmUp } = createDeps({
       ready: true,
-      settings: { learningLangs: ["en", "ja"], explainLang: "ja" },
+      settings: { ...DEFAULT_SETTINGS, learningLangs: ["en", "ja"], explainLang: "ja" },
     });
 
     const stop = start(deps);

--- a/src/store/auto-pipeline.ts
+++ b/src/store/auto-pipeline.ts
@@ -322,7 +322,7 @@ export function createAutoPipeline<TDone extends object>(config: AutoPipelineCon
     deps.getMessages().forEach(handleMessage);
     const unsubscribe = deps.subscribeToChatMessages(handleMessage);
 
-    void ensurePromptApiDiagnosed(deps.diagnose).then((promptApi) => {
+    void ensurePromptApiDiagnosed(deps.diagnose, settings.llmProvider).then((promptApi) => {
       if (controller.signal.aborted) return;
       settleDiagnosis(promptApi);
     });

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -21,6 +21,7 @@ import type { PickupTerm } from "@/lib/ai/schemas";
 import { isChatCommandMessage } from "@/lib/twitch/chat-command";
 import { isTextlessMessage } from "@/lib/twitch/emotes";
 import { createAutoPipeline, type AutoPipelineDeps, type PipelineEntry } from "./auto-pipeline";
+import { useSettingsStore } from "./settings";
 
 /** 抽出の完了時に保持する結果。該当する表現が無い場合は `terms` が空配列 */
 export interface PickupDone {
@@ -34,7 +35,10 @@ export type PickupEntry = PipelineEntry<PickupDone>;
 export type PickupPipelineDeps = AutoPipelineDeps;
 
 const pipeline = createAutoPipeline<PickupDone>({
-  createBaseSession: (targetLang, explainLang) => createPickupBaseSessionFactory(targetLang, explainLang),
+  // ベースセッションは設定(LLM プロバイダ)に依存する。設定変更時はホーム画面がパイプラインを再起動し、
+  // プールも作り直されるため、生成時点のストアの設定を読めばよい
+  createBaseSession: (targetLang, explainLang) =>
+    createPickupBaseSessionFactory(useSettingsStore.getState().settings, targetLang, explainLang),
   resolveWithoutModel: (message) =>
     isTextlessMessage(message.text, message.emotes) || isChatCommandMessage(message.text) ? { terms: [] } : null,
   runJob: (pool, message, { signal, getMessages }) =>

--- a/src/store/pipeline-test-fixtures.ts
+++ b/src/store/pipeline-test-fixtures.ts
@@ -8,7 +8,7 @@ import { vi } from "vitest";
 import type { ApiDiagnosis, EnvironmentDiagnosis } from "@/lib/ai/availability";
 import type { DetectedLanguageCandidate, LanguageDetectorLike } from "@/lib/ai/detect-language";
 import type { SessionPool } from "@/lib/ai/session-pool";
-import type { Settings } from "@/lib/settings";
+import { DEFAULT_SETTINGS, type Settings } from "@/lib/settings";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import type { AutoPipelineDeps } from "./auto-pipeline";
 
@@ -75,7 +75,7 @@ export function createDeps(
   const listeners = new Set<(message: TwitchChatMessage) => void>();
   let messages: TwitchChatMessage[] = [];
   const promptResults = [...(options.promptResults ?? [])];
-  const settings: Settings = options.settings ?? { learningLangs: ["en"], explainLang: "ja" };
+  const settings: Settings = options.settings ?? { ...DEFAULT_SETTINGS, learningLangs: ["en"], explainLang: "ja" };
 
   /** フェイクセッションの prompt。LLM に渡された本文(ユーザープロンプト)を検証するために公開する */
   const prompt = vi.fn((): Promise<string> => {

--- a/src/store/prompt-api.test.ts
+++ b/src/store/prompt-api.test.ts
@@ -10,6 +10,7 @@ import { createDeferred, createDiagnosis, flush } from "./pipeline-test-fixtures
 import {
   ensurePromptApiDiagnosed,
   markPromptApiUnavailable,
+  resetPromptApiDiagnosis,
   resetPromptApiStoreForTests,
   usePromptApiStore,
 } from "./prompt-api";
@@ -81,6 +82,49 @@ describe("ensurePromptApiDiagnosed", () => {
     const status = await ensurePromptApiDiagnosed(diagnose);
 
     expect(diagnose).toHaveBeenCalledTimes(1);
+    expect(status).toEqual({ status: "ready" });
+  });
+});
+
+describe("ensurePromptApiDiagnosed(OpenRouter プロバイダ)", () => {
+  it("Prompt API(LanguageModel)が無い環境でも、Language Detector が使えれば ready になる", async () => {
+    const status = await ensurePromptApiDiagnosed(
+      async () => ({
+        ...createDiagnosis(false),
+        languageDetector: { supported: true, availability: "available" },
+      }),
+      "openrouter",
+    );
+
+    expect(status).toEqual({ status: "ready" });
+    expect(usePromptApiStore.getState().status).toEqual({ status: "ready" });
+  });
+
+  it("Language Detector が使えない場合は、Language Detector を理由にした unavailable になる", async () => {
+    const status = await ensurePromptApiDiagnosed(
+      async () => ({
+        ...createDiagnosis(true),
+        languageDetector: { supported: false, availability: null },
+        overallReady: false,
+      }),
+      "openrouter",
+    );
+
+    expect(status.status).toBe("unavailable");
+    expect(status.status === "unavailable" && status.reason).toMatch(/Language Detector/);
+  });
+});
+
+describe("resetPromptApiDiagnosis", () => {
+  it("確定済みの状態を checking に戻し、次の ensurePromptApiDiagnosed が診断をやり直す(プロバイダ変更時に使う)", async () => {
+    const diagnose = vi.fn(async () => createDiagnosis(false));
+    await ensurePromptApiDiagnosed(diagnose);
+    expect(usePromptApiStore.getState().status.status).toBe("unavailable");
+
+    resetPromptApiDiagnosis();
+
+    expect(usePromptApiStore.getState().status).toEqual({ status: "checking" });
+    const status = await ensurePromptApiDiagnosed(async () => createDiagnosis(true));
     expect(status).toEqual({ status: "ready" });
   });
 });

--- a/src/store/prompt-api.test.ts
+++ b/src/store/prompt-api.test.ts
@@ -127,6 +127,25 @@ describe("resetPromptApiDiagnosis", () => {
     const status = await ensurePromptApiDiagnosed(async () => createDiagnosis(true));
     expect(status).toEqual({ status: "ready" });
   });
+
+  it("診断の実行中にリセットされた場合、古い診断の結果は捨てて checking のままにする(プロバイダ変更直後の巻き戻り防止)", async () => {
+    const oldDiagnosis = createDeferred<EnvironmentDiagnosis>();
+    const pending = ensurePromptApiDiagnosed(() => oldDiagnosis.promise);
+
+    // 診断の完了前にプロバイダ変更などでリセットされる
+    resetPromptApiDiagnosis();
+
+    // その後に古い診断が確定しても、新しい checking 状態を上書きしない
+    oldDiagnosis.resolve(createDiagnosis(false));
+    await pending;
+    await flush();
+    expect(usePromptApiStore.getState().status).toEqual({ status: "checking" });
+
+    // 次の診断は新しく実行され、正常に確定する
+    const status = await ensurePromptApiDiagnosed(async () => createDiagnosis(true));
+    expect(status).toEqual({ status: "ready" });
+    expect(usePromptApiStore.getState().status).toEqual({ status: "ready" });
+  });
 });
 
 describe("markPromptApiUnavailable", () => {

--- a/src/store/prompt-api.ts
+++ b/src/store/prompt-api.ts
@@ -37,6 +37,12 @@ export const usePromptApiStore = create<PromptApiState>(() => ({
 let inFlightDiagnosis: Promise<PromptApiStatus> | null = null;
 
 /**
+ * 診断の世代番号。`resetPromptApiDiagnosis` のたびに進め、実行中だった古い診断の完了ハンドラが
+ * リセット後の checking 状態を古い結果で上書きしないようにする(プロバイダ変更直後の巻き戻り防止)。
+ */
+let diagnosisGeneration = 0;
+
+/**
  * 環境診断結果から、利用者に見せる「使えない理由」を取り出す。
  * Prompt API と Language Detector API のうち error になっているものを優先し、
  * どちらも error でなければ(診断の判定と食い違う場合)Prompt API のメッセージを返す。
@@ -73,6 +79,7 @@ export function ensurePromptApiDiagnosed(
   if (current.status !== "checking") return Promise.resolve(current);
   if (inFlightDiagnosis) return inFlightDiagnosis;
 
+  const generation = diagnosisGeneration;
   inFlightDiagnosis = diagnose()
     .then(
       (diagnosis): PromptApiStatus =>
@@ -87,6 +94,8 @@ export function ensurePromptApiDiagnosed(
       }),
     )
     .then((status) => {
+      // 診断中にリセットされていた(世代が進んでいた)場合、この結果は古い設定に基づくため捨てる
+      if (generation !== diagnosisGeneration) return usePromptApiStore.getState().status;
       inFlightDiagnosis = null;
       // 診断中にウォームアップ失敗などで unavailable が確定していた場合はそちらを優先する
       const settled = usePromptApiStore.getState().status;
@@ -107,6 +116,7 @@ export function markPromptApiUnavailable(reason: string): void {
  * LLM プロバイダの設定変更時(`store/settings.ts`)に、新しいプロバイダの条件で判定し直すために使う。
  */
 export function resetPromptApiDiagnosis(): void {
+  diagnosisGeneration += 1;
   inFlightDiagnosis = null;
   usePromptApiStore.setState({ status: { status: "checking" } });
 }

--- a/src/store/prompt-api.ts
+++ b/src/store/prompt-api.ts
@@ -1,5 +1,6 @@
 /**
  * Prompt API(Gemini Nano)と Language Detector API の利用可否を 1 か所で保持する共有ストア。
+ * LLM プロバイダが OpenRouter の場合は Prompt API を使わないため、Language Detector の可否だけで判定する。
  * 翻訳・Pick up は発言ごとの言語判定(Language Detector)を前提にするため、両方が使えて初めて `ready` とする。
  *
  * 翻訳列(`translations.ts`)と Pick up 列(`pickups.ts`)は同じ環境で動くため、環境診断は 1 回だけ実行し、
@@ -13,9 +14,10 @@
  *   Prompt API が使えない環境で暗黙にフォールバックせず、理由を保持して行ごとに「〜不可」を表示できるようにする
  */
 import { create } from "zustand";
-import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
+import { isUsableApiAvailability, type EnvironmentDiagnosis } from "@/lib/ai/availability";
 import { describeDiagnosis } from "@/lib/ai/describeDiagnosis";
 import { runBrowserDiagnosis } from "@/lib/ai/runBrowserDiagnosis";
+import type { LlmProvider } from "@/lib/settings";
 
 /** Prompt API の利用可否(環境診断の結果と、その後のウォームアップ失敗を反映したもの) */
 export type PromptApiStatus =
@@ -37,14 +39,25 @@ let inFlightDiagnosis: Promise<PromptApiStatus> | null = null;
 /**
  * 環境診断結果から、利用者に見せる「使えない理由」を取り出す。
  * Prompt API と Language Detector API のうち error になっているものを優先し、
- * どちらも error でなければ(診断の判定と食い違う場合)Prompt API のメッセージを返す
+ * どちらも error でなければ(診断の判定と食い違う場合)Prompt API のメッセージを返す。
+ * OpenRouter プロバイダでは Prompt API(LanguageModel)を使わないため、Language Detector の理由だけを対象にする
  */
-function describePromptApiUnavailableReason(diagnosis: EnvironmentDiagnosis): string {
-  const messages = describeDiagnosis(diagnosis).filter(
-    (item) => item.id === "language-model" || item.id === "language-detector",
-  );
+function describePromptApiUnavailableReason(diagnosis: EnvironmentDiagnosis, llmProvider: LlmProvider): string {
+  const relevantIds: string[] =
+    llmProvider === "openrouter" ? ["language-detector"] : ["language-model", "language-detector"];
+  const messages = describeDiagnosis(diagnosis).filter((item) => relevantIds.includes(item.id));
   const failed = messages.find((item) => item.level === "error");
   return failed?.message ?? messages[0]?.message ?? "The Prompt API is not available.";
+}
+
+/**
+ * 診断結果と LLM プロバイダから利用可否を判定する。
+ * Gemini Nano では Prompt API と Language Detector の両方、OpenRouter では
+ * (モデルはクラウド側にあるため)発言ごとの言語判定に使う Language Detector だけを必要とする
+ */
+function isDiagnosisReady(diagnosis: EnvironmentDiagnosis, llmProvider: LlmProvider): boolean {
+  if (llmProvider === "openrouter") return isUsableApiAvailability(diagnosis.languageDetector.availability);
+  return diagnosis.overallReady;
 }
 
 /**
@@ -54,6 +67,7 @@ function describePromptApiUnavailableReason(diagnosis: EnvironmentDiagnosis): st
  */
 export function ensurePromptApiDiagnosed(
   diagnose: () => Promise<EnvironmentDiagnosis> = runBrowserDiagnosis,
+  llmProvider: LlmProvider = "gemini-nano",
 ): Promise<PromptApiStatus> {
   const current = usePromptApiStore.getState().status;
   if (current.status !== "checking") return Promise.resolve(current);
@@ -62,9 +76,9 @@ export function ensurePromptApiDiagnosed(
   inFlightDiagnosis = diagnose()
     .then(
       (diagnosis): PromptApiStatus =>
-        diagnosis.overallReady
+        isDiagnosisReady(diagnosis, llmProvider)
           ? { status: "ready" }
-          : { status: "unavailable", reason: describePromptApiUnavailableReason(diagnosis) },
+          : { status: "unavailable", reason: describePromptApiUnavailableReason(diagnosis, llmProvider) },
     )
     .catch(
       (error: unknown): PromptApiStatus => ({
@@ -89,9 +103,17 @@ export function markPromptApiUnavailable(reason: string): void {
 }
 
 /**
+ * 確定済みの診断状態を破棄して checking に戻す。次の `ensurePromptApiDiagnosed` が診断をやり直す。
+ * LLM プロバイダの設定変更時(`store/settings.ts`)に、新しいプロバイダの条件で判定し直すために使う。
+ */
+export function resetPromptApiDiagnosis(): void {
+  inFlightDiagnosis = null;
+  usePromptApiStore.setState({ status: { status: "checking" } });
+}
+
+/**
  * テスト専用: ストアと実行中の診断を初期状態に戻す。各テストの afterEach で呼び出すこと。
  */
 export function resetPromptApiStoreForTests(): void {
-  inFlightDiagnosis = null;
-  usePromptApiStore.setState({ status: { status: "checking" } });
+  resetPromptApiDiagnosis();
 }

--- a/src/store/settings.test.ts
+++ b/src/store/settings.test.ts
@@ -8,6 +8,7 @@
  */
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { DEFAULT_SETTINGS, SETTINGS_STORAGE_KEY } from "@/lib/settings";
+import { ensurePromptApiDiagnosed, resetPromptApiStoreForTests, usePromptApiStore } from "./prompt-api";
 import { clearSettingsStore, hydrateSettingsStore, resetSettingsStoreForTests, useSettingsStore } from "./settings";
 
 beforeEach(() => {
@@ -16,6 +17,40 @@ beforeEach(() => {
 
 afterEach(() => {
   window.localStorage.clear();
+  resetPromptApiStoreForTests();
+});
+
+/** 環境診断済み(unavailable)の状態を作る。プロバイダ変更で再診断が要ることの検証に使う */
+async function settleDiagnosisAsUnavailable() {
+  await ensurePromptApiDiagnosed(async () => {
+    throw new Error("Prompt API が無い環境");
+  });
+  expect(usePromptApiStore.getState().status.status).toBe("unavailable");
+}
+
+describe("setSettings と LLM 診断状態", () => {
+  it("LLM プロバイダの設定が変わったら、確定済みの診断状態を checking に戻す(新しいプロバイダで診断し直すため)", async () => {
+    hydrateSettingsStore();
+    await settleDiagnosisAsUnavailable();
+
+    useSettingsStore.getState().setSettings({
+      ...useSettingsStore.getState().settings,
+      llmProvider: "openrouter",
+      openRouterApiKey: "sk-or-v1-test-key-0123",
+      openRouterModel: "anthropic/claude-sonnet-5",
+    });
+
+    expect(usePromptApiStore.getState().status).toEqual({ status: "checking" });
+  });
+
+  it("言語設定だけが変わった場合は、確定済みの診断状態を維持する(環境は変わらないため)", async () => {
+    hydrateSettingsStore();
+    await settleDiagnosisAsUnavailable();
+
+    useSettingsStore.getState().setSettings({ ...useSettingsStore.getState().settings, learningLangs: ["es"] });
+
+    expect(usePromptApiStore.getState().status.status).toBe("unavailable");
+  });
 });
 
 describe("hydrateSettingsStore", () => {
@@ -24,7 +59,7 @@ describe("hydrateSettingsStore", () => {
 
     hydrateSettingsStore();
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["es"], explainLang: "en" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["es"], explainLang: "en" });
     expect(useSettingsStore.getState().hydrated).toBe(true);
     expect(useSettingsStore.getState().wasCorrupted).toBe(false);
   });
@@ -47,12 +82,12 @@ describe("hydrateSettingsStore", () => {
 
   it("2回目以降の呼び出しでは、ストア上の変更を LocalStorage の値で上書きしない", () => {
     hydrateSettingsStore();
-    useSettingsStore.getState().setSettings({ learningLangs: ["de"], explainLang: "ja" });
+    useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: ["de"], explainLang: "ja" });
     window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify({ learningLangs: ["fr"], explainLang: "ja" }));
 
     hydrateSettingsStore();
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["de"], explainLang: "ja" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["de"], explainLang: "ja" });
   });
 });
 
@@ -60,10 +95,11 @@ describe("useSettingsStore.setSettings", () => {
   it("設定をストアに反映し、LocalStorage にも保存する", () => {
     hydrateSettingsStore();
 
-    useSettingsStore.getState().setSettings({ learningLangs: ["fr", "ja"], explainLang: "en" });
+    useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: ["fr", "ja"], explainLang: "en" });
 
-    expect(useSettingsStore.getState().settings).toEqual({ learningLangs: ["fr", "ja"], explainLang: "en" });
+    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLangs: ["fr", "ja"], explainLang: "en" });
     expect(JSON.parse(window.localStorage.getItem(SETTINGS_STORAGE_KEY) ?? "null")).toEqual({
+      ...DEFAULT_SETTINGS,
       learningLangs: ["fr", "ja"],
       explainLang: "en",
     });
@@ -72,7 +108,7 @@ describe("useSettingsStore.setSettings", () => {
   it("学ぶ言語が空の場合は例外を投げ、ストアも LocalStorage も変更しない", () => {
     hydrateSettingsStore();
 
-    expect(() => useSettingsStore.getState().setSettings({ learningLangs: [], explainLang: "ja" })).toThrow(
+    expect(() => useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: [], explainLang: "ja" })).toThrow(
       /at least one/,
     );
 
@@ -84,7 +120,7 @@ describe("useSettingsStore.setSettings", () => {
     window.localStorage.setItem(SETTINGS_STORAGE_KEY, "壊れたデータ");
     hydrateSettingsStore();
 
-    useSettingsStore.getState().setSettings({ learningLangs: ["en"], explainLang: "es" });
+    useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLangs: ["en"], explainLang: "es" });
 
     expect(useSettingsStore.getState().wasCorrupted).toBe(false);
   });

--- a/src/store/settings.ts
+++ b/src/store/settings.ts
@@ -13,6 +13,16 @@
  */
 import { create } from "zustand";
 import { clearSettings, DEFAULT_SETTINGS, loadSettings, saveSettings, type Settings } from "@/lib/settings";
+import { resetPromptApiDiagnosis } from "./prompt-api";
+
+/** LLM プロバイダに関わる設定が変わったか(変わったら環境診断をやり直す必要がある) */
+function isLlmConfigChanged(prev: Settings, next: Settings): boolean {
+  return (
+    prev.llmProvider !== next.llmProvider ||
+    prev.openRouterApiKey !== next.openRouterApiKey ||
+    prev.openRouterModel !== next.openRouterModel
+  );
+}
 
 interface SettingsState {
   settings: Settings;
@@ -32,10 +42,13 @@ export const useSettingsStore = create<SettingsState>((set) => ({
   hydrated: false,
   wasCorrupted: false,
   setSettings: (settings) => {
+    const prev = useSettingsStore.getState().settings;
     saveSettings(settings);
     // 保存に成功した時点で LocalStorage は正常な値になっているため、壊れていた印は下ろす。
     // ストアが正本の値を持った状態になるので、復元済み扱いにする
     set({ settings, wasCorrupted: false, hydrated: true });
+    // LLM プロバイダの設定が変わったら、確定済みの診断状態を破棄して新しいプロバイダの条件で診断し直す
+    if (isLlmConfigChanged(prev, settings)) resetPromptApiDiagnosis();
   },
 }));
 

--- a/src/store/translations.ts
+++ b/src/store/translations.ts
@@ -24,6 +24,7 @@ import {
   type MessageSegment,
 } from "@/lib/twitch/emotes";
 import { createAutoPipeline, type AutoPipelineDeps, type PipelineEntry } from "./auto-pipeline";
+import { useSettingsStore } from "./settings";
 
 /** 翻訳の完了時に保持する結果。訳文はページがそのまま描画できるテキスト/emote セグメント列で持つ */
 export interface TranslationDone {
@@ -37,7 +38,10 @@ export type TranslationEntry = PipelineEntry<TranslationDone>;
 export type TranslationPipelineDeps = AutoPipelineDeps;
 
 const pipeline = createAutoPipeline<TranslationDone>({
-  createBaseSession: (targetLang, explainLang) => createTranslateBaseSessionFactory(targetLang, explainLang),
+  // ベースセッションは設定(LLM プロバイダ)に依存する。設定変更時はホーム画面がパイプラインを再起動し、
+  // プールも作り直されるため、生成時点のストアの設定を読めばよい
+  createBaseSession: (targetLang, explainLang) =>
+    createTranslateBaseSessionFactory(useSettingsStore.getState().settings, targetLang, explainLang),
   resolveWithoutModel: (message) =>
     isTextlessMessage(message.text, message.emotes) || isChatCommandMessage(message.text)
       ? { segments: splitMessageIntoSegments(message.text, message.emotes) }


### PR DESCRIPTION
## Summary

Gemini Nano(Prompt API)に加えて、利用者自身の OpenRouter API キーで任意のクラウド LLM を翻訳・Pick up に使えるようにします。モデルは OpenRouter のモデル一覧 API から取得した選択肢の中から選べます。

## 変更内容

- **設定**(`src/lib/settings.ts`): `llmProvider`(`gemini-nano` / `openrouter`)・`openRouterApiKey`・`openRouterModel` を追加。旧形式の保存データは Gemini Nano として復元(壊れた扱いにしない)。OpenRouter 選択時にキー・モデルが空の設定は保存時に拒否(Fail-Fast)
- **OpenRouter クライアント**(`src/lib/ai/openrouter.ts`): モデル一覧 API(`GET /api/v1/models`)の取得と、既存の `PromptSessionLike` 互換セッション。`responseConstraint`(JSON Schema)は Structured Outputs(`response_format: json_schema`)に対応させたため、直列キュー・再試行・zod 検証のパイプラインは無変更で動く
- **プロバイダ切替層**(`src/lib/ai/llm-provider.ts`): 設定に応じて翻訳・Pick up のベースセッション生成を Gemini Nano / OpenRouter に振り分け
- **環境診断**(`src/store/prompt-api.ts`): OpenRouter 選択時は `window.LanguageModel` を要求せず、発言ごとの言語判定に使う Language Detector のみで判定。LLM 設定の変更時は診断をやり直す(実行中の古い診断結果は世代番号で破棄)
- **設定ダイアログ**(`src/components/settings-dialog.tsx`): プロバイダ選択・API キー入力(password)・モデル一覧から取得したモデルのセレクトと保存を追加

## 補足

- API キーはこのブラウザの LocalStorage にのみ保存し、リクエストはブラウザから OpenRouter へ直接送られます(本アプリはサーバーレス構成)
- 発言ごとの言語判定はプロバイダに関わらずブラウザ内蔵の Language Detector を使い続けます

## テスト

- テスト 480 件パス / Lint 警告ゼロ / 型チェック・ビルド成功
- CodeRabbit レビュー実施済み(指摘 1 件: 診断実行中のリセット競合 → 世代トークンで修正済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH