### PR TITLE
feat: Cheering Emote(Cheer100 / showLove1000 など)を画像表示に対応する

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -60,6 +60,7 @@ const サンプル発言: TwitchChatMessage = {
   isAction: false,
   emotes: [],
   badges: [],
+  bits: null,
   timestampMs: 1_700_000_000_000,
 };
 

--- a/src/lib/twitch/cheermotes.test.ts
+++ b/src/lib/twitch/cheermotes.test.ts
@@ -1,0 +1,87 @@
+/**
+ * src/lib/twitch/cheermotes.ts のテスト。
+ *
+ * bits 付き発言の本文に含まれる Cheering Emote(`Cheer100` / `showLove1000` など)を
+ * 位置情報(EmotePosition)として既存の emote 処理に合成する純関数を検証する。
+ */
+import { describe, expect, it } from "vitest";
+import { mergeCheermotePositions, resolveCheermoteTier } from "./cheermotes";
+import type { EmotePosition } from "./irc-parser";
+
+describe("resolveCheermoteTier", () => {
+  it("bits 数に応じて表示ティア(1 / 100 / 1000 / 5000 / 10000)を返す", () => {
+    expect(resolveCheermoteTier(1)).toBe(1);
+    expect(resolveCheermoteTier(99)).toBe(1);
+    expect(resolveCheermoteTier(100)).toBe(100);
+    expect(resolveCheermoteTier(999)).toBe(100);
+    expect(resolveCheermoteTier(1000)).toBe(1000);
+    expect(resolveCheermoteTier(4999)).toBe(1000);
+    expect(resolveCheermoteTier(5000)).toBe(5000);
+    expect(resolveCheermoteTier(9999)).toBe(5000);
+    expect(resolveCheermoteTier(10000)).toBe(10000);
+    expect(resolveCheermoteTier(123456)).toBe(10000);
+  });
+});
+
+describe("mergeCheermotePositions", () => {
+  it("bits が null(Cheer していない発言)の場合は、公式 emote の位置情報をそのまま返す", () => {
+    const twitchEmotes: EmotePosition[] = [{ id: "25", start: 0, end: 4 }];
+    expect(mergeCheermotePositions("Kappa Cheer100", twitchEmotes, null)).toEqual(twitchEmotes);
+  });
+
+  it("Cheer100 のプレフィックス部分だけを emote 位置として合成する(数値はテキストのまま残す)", () => {
+    const result = mergeCheermotePositions("Cheer100 nice", [], 100);
+    expect(result).toEqual([{ id: "cheer:cheer/100", start: 0, end: 4 }]);
+  });
+
+  it("showLove1000 は小文字化したプレフィックスと bits 数のティアで ID を組み立てる", () => {
+    const result = mergeCheermotePositions("showLove1000", [], 1000);
+    expect(result).toEqual([{ id: "cheer:showlove/1000", start: 0, end: 7 }]);
+  });
+
+  it("プレフィックスは大文字小文字を区別せずに照合する(Twitch の仕様)", () => {
+    expect(mergeCheermotePositions("cheer100", [], 100)).toEqual([{ id: "cheer:cheer/100", start: 0, end: 4 }]);
+    expect(mergeCheermotePositions("CHEER100", [], 100)).toEqual([{ id: "cheer:cheer/100", start: 0, end: 4 }]);
+  });
+
+  it("ティアは各トークンの bits 数から決める(発言全体の bits 合計ではない)", () => {
+    const result = mergeCheermotePositions("Cheer1 Cheer5000", [], 5001);
+    expect(result).toEqual([
+      { id: "cheer:cheer/1", start: 0, end: 4 },
+      { id: "cheer:cheer/5000", start: 7, end: 11 },
+    ]);
+  });
+
+  it("既知のプレフィックスでない単語(hello100 など)は emote にしない", () => {
+    expect(mergeCheermotePositions("hello100", [], 100)).toEqual([]);
+  });
+
+  it("数値が続かない単語(Cheer のみ)や 0 bits(Cheer0)は emote にしない", () => {
+    expect(mergeCheermotePositions("Cheer", [], 100)).toEqual([]);
+    expect(mergeCheermotePositions("Cheer0", [], 100)).toEqual([]);
+  });
+
+  it("単語の一部だけの一致(Cheer100! など)は emote にしない", () => {
+    expect(mergeCheermotePositions("Cheer100!", [], 100)).toEqual([]);
+  });
+
+  it("公式 emote の範囲と重なる単語は公式 emote を優先して emote にしない", () => {
+    const twitchEmotes: EmotePosition[] = [{ id: "999", start: 0, end: 7 }];
+    expect(mergeCheermotePositions("Cheer100", twitchEmotes, 100)).toEqual(twitchEmotes);
+  });
+
+  it("サロゲートペアの絵文字が前にあっても、コードポイント単位で位置を数える", () => {
+    // "🌿 Cheer100" — 🌿 はコードポイント1つ(UTF-16では2ユニット)
+    const result = mergeCheermotePositions("🌿 Cheer100", [], 100);
+    expect(result).toEqual([{ id: "cheer:cheer/100", start: 2, end: 6 }]);
+  });
+
+  it("公式 emote と合成した結果は開始位置の昇順で返す", () => {
+    const twitchEmotes: EmotePosition[] = [{ id: "25", start: 9, end: 13 }];
+    const result = mergeCheermotePositions("Cheer100 Kappa", twitchEmotes, 100);
+    expect(result).toEqual([
+      { id: "cheer:cheer/100", start: 0, end: 4 },
+      { id: "25", start: 9, end: 13 },
+    ]);
+  });
+});

--- a/src/lib/twitch/cheermotes.ts
+++ b/src/lib/twitch/cheermotes.ts
@@ -1,0 +1,127 @@
+/**
+ * Twitch の Cheering Emote(Cheermote: `Cheer100` / `showLove1000` など)への対応。
+ *
+ * bits 付きの PRIVMSG(`bits` タグあり)の本文には、Cheermote が
+ * 「プレフィックス + bits 数」のトークン(例: `Cheer100`)としてそのまま含まれる。
+ * `mergeCheermotePositions` はこのトークンを検出し、Twitch 公式 emote と同じ
+ * `EmotePosition` として合成する。これにより下流(描画・翻訳のプレースホルダ化・
+ * textless 判定)はサードパーティ emote(`third-party-emotes.ts`)と同様に
+ * 既存の emote 処理をそのまま使える。
+ *
+ * - このアプリは Helix API を使わない匿名 IRC 接続のため、チャンネル独自の Cheermote は
+ *   取得できない。Twitch 公式ドキュメントに載っているグローバル Cheermote の
+ *   プレフィックスを静的な一覧として持つ(BibleThump / EleGiggle は CDN 上に
+ *   画像が存在しなくなっているため一覧から除外した。2026-09 に確認)
+ * - emote 位置はプレフィックス部分だけを覆い、bits 数はテキストとして残す
+ *   (Twitch 本家のチャット UI と同じく「画像 + 数値」で表示するため)
+ * - ID は `cheer:{プレフィックス小文字}/{ティア}` 形式とし、`emotes.ts` の
+ *   `buildEmoteImageUrl` が静的 CDN の URL に組み立てる
+ * - 位置は Twitch の `emotes` タグと同じくコードポイント単位・end は inclusive
+ */
+import type { EmotePosition } from "./irc-parser";
+
+/**
+ * グローバル Cheermote のプレフィックス一覧(小文字)。
+ * 出典: https://dev.twitch.tv/docs/irc/emotes/(Cheermotes の節)
+ */
+const GLOBAL_CHEERMOTE_PREFIXES: ReadonlySet<string> = new Set([
+  "cheer",
+  "doodlecheer",
+  "cheerwhal",
+  "corgo",
+  "uni",
+  "showlove",
+  "party",
+  "seemsgood",
+  "pride",
+  "kappa",
+  "frankerz",
+  "heyguys",
+  "dansgame",
+  "trihard",
+  "kreygasm",
+  "4head",
+  "swiftrage",
+  "notlikethis",
+  "failfish",
+  "vohiyo",
+  "pjsalt",
+  "mrdestructoid",
+  "bday",
+  "ripcheer",
+  "shamrock",
+]);
+
+/** Cheermote の画像が用意されている bits 数の閾値(降順) */
+const CHEERMOTE_TIERS = [10000, 5000, 1000, 100, 1] as const;
+
+/**
+ * bits 数から Cheermote の表示ティア(画像・色の段階)を返す。
+ * 1〜99 → 1、100〜999 → 100、1000〜4999 → 1000、5000〜9999 → 5000、10000〜 → 10000。
+ */
+export function resolveCheermoteTier(bits: number): number {
+  for (const tier of CHEERMOTE_TIERS) {
+    if (bits >= tier) return tier;
+  }
+  return 1;
+}
+
+/** 「英字プレフィックス + bits 数」のトークン(例: `Cheer100`)にマッチするパターン */
+const CHEERMOTE_TOKEN_PATTERN = /^([a-zA-Z]+)(\d+)$/;
+
+/** 既存の emote の位置範囲とトークンの範囲(いずれもコードポイント単位・inclusive)が重なるか */
+function overlapsAnyEmote(start: number, end: number, emotes: EmotePosition[]): boolean {
+  return emotes.some((emote) => start <= emote.end && end >= emote.start);
+}
+
+/**
+ * bits 付き発言の本文から Cheermote トークンを検出し、Twitch 公式 emote の
+ * 位置情報に合成して返す(開始位置の昇順)。bits が無い発言(null または 0 以下)では
+ * Cheermote は成立しないため、公式 emote の位置情報をそのまま返す。
+ *
+ * - プレフィックスは Twitch の仕様どおり大文字小文字を区別せずに照合する
+ * - 単語全体が「プレフィックス + 1 以上の数値」の場合のみ Cheermote とする
+ * - emote 位置はプレフィックス部分だけを覆い、bits 数はテキストとして残す
+ * - 公式 emote の範囲と重なる単語は公式 emote を優先して対象外とする
+ */
+export function mergeCheermotePositions(
+  text: string,
+  twitchEmotes: EmotePosition[],
+  bits: number | null,
+): EmotePosition[] {
+  if (bits === null || bits <= 0) return twitchEmotes;
+
+  // Twitch の emotes タグと同じコードポイント単位で位置を数えるため、コードポイント配列で走査する
+  const codePoints = [...text];
+  const merged = [...twitchEmotes];
+  let tokenStart = -1;
+
+  for (let i = 0; i <= codePoints.length; i += 1) {
+    const isBoundary = i === codePoints.length || /\s/u.test(codePoints[i]);
+    if (!isBoundary) {
+      if (tokenStart === -1) tokenStart = i;
+      continue;
+    }
+    if (tokenStart === -1) continue;
+
+    const token = codePoints.slice(tokenStart, i).join("");
+    const match = CHEERMOTE_TOKEN_PATTERN.exec(token);
+    if (match !== null) {
+      const prefix = match[1].toLowerCase();
+      const amount = Number.parseInt(match[2], 10);
+      if (
+        GLOBAL_CHEERMOTE_PREFIXES.has(prefix) &&
+        amount >= 1 &&
+        !overlapsAnyEmote(tokenStart, i - 1, twitchEmotes)
+      ) {
+        // 画像が覆うのはプレフィックス部分だけ。bits 数は後続のテキストセグメントとして残る
+        const prefixEnd = tokenStart + match[1].length - 1;
+        merged.push({ id: `cheer:${prefix}/${resolveCheermoteTier(amount)}`, start: tokenStart, end: prefixEnd });
+      }
+    }
+    tokenStart = -1;
+  }
+
+  merged.sort((a, b) => a.start - b.start);
+  return merged;
+}

--- a/src/lib/twitch/emotes.test.ts
+++ b/src/lib/twitch/emotes.test.ts
@@ -269,3 +269,14 @@ describe("isTextlessMessage", () => {
     expect(isTextlessMessage("gg Kappa", [{ id: "25", start: 3, end: 7 }])).toBe(false);
   });
 });
+
+describe("buildEmoteImageUrl(Cheering Emote)", () => {
+  it("cheer: プレフィックス付き ID は Cheermote の静的 CDN URL(ダーク・アニメ・2倍)を組み立てる", () => {
+    expect(buildEmoteImageUrl("cheer:cheer/100")).toBe(
+      "https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/100/2.gif",
+    );
+    expect(buildEmoteImageUrl("cheer:showlove/1000")).toBe(
+      "https://d3aqoihi2n8ty8.cloudfront.net/actions/showlove/dark/animated/1000/2.gif",
+    );
+  });
+});

--- a/src/lib/twitch/emotes.ts
+++ b/src/lib/twitch/emotes.ts
@@ -39,26 +39,32 @@ export interface EmoteSegment {
 export type MessageSegment = TextSegment | EmoteSegment;
 
 /**
- * サードパーティ emote(`third-party-emotes.ts`)のプレフィックス付き ID から、
- * 各サービスの CDN URL を組み立てる関数の表。theme / scale の指定には対応していないため、
- * ライブチャット表示に適した2倍サイズ相当の URL を固定で返す。
+ * プレフィックス付き ID(サードパーティ emote: `third-party-emotes.ts`、
+ * Cheering Emote: `cheermotes.ts`)から各サービスの CDN URL を組み立てる関数の表。
+ * theme / scale の指定には対応していないため、ライブチャット表示に適した
+ * 2倍サイズ相当の URL を固定で返す。
  */
-const THIRD_PARTY_EMOTE_URL_BUILDERS: Record<string, (id: string) => string> = {
+const PREFIXED_EMOTE_URL_BUILDERS: Record<string, (id: string) => string> = {
   bttv: (id) => `https://cdn.betterttv.net/emote/${id}/2x`,
   ffz: (id) => `https://cdn.frankerfacez.com/emote/${id}/2`,
   "7tv": (id) => `https://cdn.7tv.app/emote/${id}/2x.webp`,
+  // Cheering Emote(cheermotes.ts): `cheer:{プレフィックス}/{ティア}` 形式の ID から静的 CDN URL を組み立てる
+  cheer: (id) => {
+    const [name, tier] = id.split("/");
+    return `https://d3aqoihi2n8ty8.cloudfront.net/actions/${name}/dark/animated/${tier}/2.gif`;
+  },
 };
 
 /**
  * emote ID から emote 画像CDN URLを組み立てる。
- * `bttv:` / `ffz:` / `7tv:` プレフィックス付き ID は各サードパーティの CDN URL、
+ * `bttv:` / `ffz:` / `7tv:` / `cheer:` プレフィックス付き ID は各サービスの CDN URL、
  * それ以外は Twitch の CDN URL(デフォルトはダークテーマ・2倍サイズ)を返す。
  */
 export function buildEmoteImageUrl(emoteId: string, options: EmoteImageOptions = {}): string {
   const colonIndex = emoteId.indexOf(":");
   if (colonIndex !== -1) {
-    const buildThirdPartyUrl = THIRD_PARTY_EMOTE_URL_BUILDERS[emoteId.slice(0, colonIndex)];
-    if (buildThirdPartyUrl) return buildThirdPartyUrl(emoteId.slice(colonIndex + 1));
+    const buildPrefixedUrl = PREFIXED_EMOTE_URL_BUILDERS[emoteId.slice(0, colonIndex)];
+    if (buildPrefixedUrl) return buildPrefixedUrl(emoteId.slice(colonIndex + 1));
   }
   const theme = options.theme ?? "dark";
   const scale = options.scale ?? "2.0";

--- a/src/lib/twitch/irc-parser.test.ts
+++ b/src/lib/twitch/irc-parser.test.ts
@@ -123,6 +123,7 @@ describe("parseTwitchIrcMessage", () => {
           { name: "broadcaster", version: "1" },
           { name: "subscriber", version: "12" },
         ],
+        bits: null,
         timestampMs: 1690000000123,
       },
     });
@@ -238,5 +239,28 @@ describe("parseTwitchIrcMessage", () => {
     const event = parseTwitchIrcMessage(":tmi.twitch.tv 001 justinfan39818 :Welcome, GLHF!");
 
     expect(event).toEqual({ type: "unknown", command: "001" });
+  });
+});
+
+describe("bits タグ(Cheering)", () => {
+  it("bits タグ付きの PRIVMSG は bits を数値として保持する", () => {
+    const line =
+      "@badge-info=;badges=;bits=100;display-name=CheerFan;id=msg-cheer-1;user-id=222 :cheerfan!cheerfan@cheerfan.tmi.twitch.tv PRIVMSG #zackrawrr :Cheer100 great play!";
+
+    const event = parseTwitchIrcMessage(line);
+
+    expect(event.type).toBe("privmsg");
+    if (event.type !== "privmsg") throw new Error("unreachable");
+    expect(event.message.bits).toBe(100);
+  });
+
+  it("bits タグの無い PRIVMSG は bits が null になる", () => {
+    const line = "@badge-info=;badges=;id=msg-3;user-id=111 :lurker42!lurker42@lurker42.tmi.twitch.tv PRIVMSG #zackrawrr :hi";
+
+    const event = parseTwitchIrcMessage(line);
+
+    expect(event.type).toBe("privmsg");
+    if (event.type !== "privmsg") throw new Error("unreachable");
+    expect(event.message.bits).toBeNull();
   });
 });

--- a/src/lib/twitch/irc-parser.ts
+++ b/src/lib/twitch/irc-parser.ts
@@ -55,6 +55,8 @@ export interface TwitchChatMessage {
   isAction: boolean;
   emotes: EmotePosition[];
   badges: Badge[];
+  /** `bits` タグ(Cheer した bits の合計)。Cheer していない発言は null */
+  bits: number | null;
   /** `tmi-sent-ts` をミリ秒のUNIXタイムスタンプとして解釈した値。無ければ null */
   timestampMs: number | null;
 }
@@ -248,6 +250,7 @@ function parsePrivmsg(parsed: ParsedIrcMessage): TwitchChatEvent {
       isAction,
       emotes: parseEmotesTag(parsed.tags.emotes ?? ""),
       badges: parseBadgesTag(parsed.tags.badges ?? ""),
+      bits: parsed.tags.bits ? Number.parseInt(parsed.tags.bits, 10) : null,
       timestampMs: parsed.tags["tmi-sent-ts"] ? Number.parseInt(parsed.tags["tmi-sent-ts"], 10) : null,
     },
   };

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -60,6 +60,7 @@ function createSampleMessage(overrides: Partial<TwitchChatMessage> = {}): Twitch
     isAction: false,
     emotes: [],
     badges: [],
+    bits: null,
     timestampMs: 1690000000000,
     ...overrides,
   };
@@ -283,5 +284,20 @@ describe("bot除外", () => {
     useBotFilterStore.getState().setPatterns(["streamelements"]);
 
     expect(useChatConnectionStore.getState().messages).toEqual([humanMessage]);
+  });
+});
+
+describe("Cheering Emote(Cheermote)", () => {
+  it("bits 付きの privmsg 受信時に、本文中の Cheermote を emotes に合成してから保持・通知する", () => {
+    const received: TwitchChatMessage[] = [];
+    subscribeToChatMessages((message) => received.push(message));
+    useChatConnectionStore.getState().connect("somechannel");
+    const message = createSampleMessage({ text: "Cheer100 nice play", bits: 100 });
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message });
+
+    const expected = [{ id: "cheer:cheer/100", start: 0, end: 4 }];
+    expect(useChatConnectionStore.getState().messages[0].emotes).toEqual(expected);
+    expect(received[0].emotes).toEqual(expected);
   });
 });

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -25,6 +25,7 @@ import {
   type TwitchIrcClient,
 } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
+import { mergeCheermotePositions } from "@/lib/twitch/cheermotes";
 import { mergeThirdPartyEmotePositions } from "@/lib/twitch/third-party-emotes";
 import { matchesBotFilter } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
@@ -64,11 +65,17 @@ function getClient(): TwitchIrcClient {
         }
         if (event.type !== "privmsg") return;
         if (isExcludedByBotFilter(event.message.username)) return;
-        // 本文中のサードパーティ emote 名(BTTV / FFZ / 7TV)を位置情報として合成してから
-        // 保持・通知する。下流(描画・翻訳・Pick up)は Twitch 公式 emote と同じ扱いで処理できる
+        // 本文中の Cheermote(bits 付き発言)とサードパーティ emote 名(BTTV / FFZ / 7TV)を
+        // 位置情報として合成してから保持・通知する。下流(描画・翻訳・Pick up)は
+        // Twitch 公式 emote と同じ扱いで処理できる
+        const emotesWithCheermotes = mergeCheermotePositions(
+          event.message.text,
+          event.message.emotes,
+          event.message.bits,
+        );
         const message: TwitchChatMessage = {
           ...event.message,
-          emotes: mergeThirdPartyEmotePositions(event.message.text, event.message.emotes, getThirdPartyEmoteMap()),
+          emotes: mergeThirdPartyEmotePositions(event.message.text, emotesWithCheermotes, getThirdPartyEmoteMap()),
         };
         useChatConnectionStore.setState((prev) => {
           const next = [...prev.messages, message];

--- a/src/store/pipeline-test-fixtures.ts
+++ b/src/store/pipeline-test-fixtures.ts
@@ -25,6 +25,7 @@ export function createMessage(overrides: Partial<TwitchChatMessage> = {}): Twitc
     isAction: false,
     emotes: [],
     badges: [],
+    bits: null,
     timestampMs: 1_700_000_000_000,
     ...overrides,
   };


### PR DESCRIPTION
## Summary

bits タグ付き発言の本文に含まれる Twitch の Cheering Emote(Cheermote: `Cheer100` / `showLove1000` など)を検出し、既存の emote 処理に合成して画像で表示します。

## 実装内容

- `src/lib/twitch/cheermotes.ts`(新規): `bits` タグ付き発言の本文から「プレフィックス + bits 数」のトークンを検出し、`EmotePosition` として公式 emote に合成する `mergeCheermotePositions` を実装しました
  - Helix API を使わない匿名 IRC 構成のため、Twitch 公式ドキュメントのグローバル Cheermote プレフィックス一覧を静的に保持します(チャンネル独自の Cheermote は対象外)
  - BibleThump / EleGiggle は静的 CDN 上に画像が存在しないことを確認したため一覧から除外しました
  - emote 画像はプレフィックス部分だけを覆い、bits 数は Twitch 本家 UI と同様にテキストとして残します
  - ティア(1 / 100 / 1000 / 5000 / 10000)は各トークンの bits 数から決定します
- `src/lib/twitch/irc-parser.ts`: `TwitchChatMessage` に `bits`(`bits` タグ由来、無ければ null)を追加しました
- `src/lib/twitch/emotes.ts`: `cheer:{プレフィックス}/{ティア}` 形式の ID から静的 CDN(`d3aqoihi2n8ty8.cloudfront.net`)の URL を組み立てるビルダーを追加し、表の名前を `PREFIXED_EMOTE_URL_BUILDERS` に改名しました
- `src/store/chat-connection.ts`: privmsg 受信時に Cheermote → サードパーティ emote の順で位置情報を合成するようにしました

下流(描画・翻訳のプレースホルダ化・textless 判定・Pick up)はサードパーティ emote(#49)と同じ仕組みをそのまま使うため変更していません。

## テスト

- `npm run lint` / `npm run type-check` / `npm test`(496件)/ `npm run build` すべて成功
- 全 Cheermote プレフィックスの CDN 画像 URL が有効(HTTP 200)であることを curl で確認済み
- CodeRabbit レビュー実施済み(指摘 0 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH