### PR TITLE
feat: Helix API の基盤を導入する(App Access Token + Next.js プロキシ)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ npm test            # Vitest
 npm run lint
 npm run type-check
 ```
+
+### Twitch Helix API(任意)
+
+Twitch Helix API の公開データ(チャンネル独自 Cheermote・配信情報など)を利用する場合は、[Twitch Developer Console](https://dev.twitch.tv/console/apps) でアプリケーションを登録し、以下の環境変数を設定してください(ローカルは `.env.local`、本番は Vercel の環境変数)。
+
+```bash
+TWITCH_CLIENT_ID=<Client ID>
+TWITCH_CLIENT_SECRET=<Client Secret>
+```
+
+サーバーサイド(`/api/twitch/*` の Route Handler)が App Access Token を取得・キャッシュして Helix API を中継するため、視聴者のログインは不要で、Client Secret がブラウザに露出することもありません。未設定の場合、Helix 依存の機能は無効になりますが、既存機能(IRC 接続・翻訳・Pick up)はそのまま動作します。

--- a/src/app/api/twitch/[...path]/route.test.ts
+++ b/src/app/api/twitch/[...path]/route.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Helix API プロキシ Route Handler のテスト。
+ *
+ * - 許可リスト内のエンドポイントへ App Access Token 付きで中継すること
+ * - Client Secret / トークンをブラウザに露出させないこと(レスポンスは Helix の JSON のみ)
+ * - 401(トークン失効)でトークンを破棄して1回だけ再試行すること
+ * - 429(レート制限)を Retry-After 付きでそのまま返すこと
+ * - 環境変数未設定時は 503 を返し、クライアント側でフォールバックできること
+ * を検証する。外部依存(fetch・トークンモジュール)はモックする。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { GET } from "./route";
+import { HelixTokenError } from "@/lib/twitch/helix-token";
+
+const getAppAccessTokenMock = vi.fn();
+const invalidateAppAccessTokenMock = vi.fn();
+
+vi.mock("@/lib/twitch/helix-token", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/twitch/helix-token")>();
+  return {
+    ...original,
+    getAppAccessToken: (...args: unknown[]) => getAppAccessTokenMock(...args),
+    invalidateAppAccessToken: (...args: unknown[]) =>
+      invalidateAppAccessTokenMock(...args),
+  };
+});
+
+/** Route Handler を呼び出すヘルパー */
+function callGet(pathSegments: string[], query = "") {
+  const url = `https://example.com/api/twitch/${pathSegments.join("/")}${query}`;
+  return GET(new Request(url), {
+    params: Promise.resolve({ path: pathSegments }),
+  });
+}
+
+/** Helix API のレスポンスを組み立てるヘルパー */
+function helixResponse(body: unknown, status = 200, headers?: HeadersInit) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json", ...(headers ?? {}) },
+  });
+}
+
+describe("GET /api/twitch/[...path]", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("TWITCH_CLIENT_ID", "test-client-id");
+    fetchMock.mockReset();
+    getAppAccessTokenMock.mockReset();
+    invalidateAppAccessTokenMock.mockReset();
+    getAppAccessTokenMock.mockResolvedValue("test-app-token");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it("許可リスト内のエンドポイントへクエリ付きで中継し、Helix の JSON を返す", async () => {
+    const helixBody = { data: [{ id: "12345", login: "example_user" }] };
+    fetchMock.mockResolvedValueOnce(helixResponse(helixBody));
+
+    const response = await callGet(["users"], "?login=example_user");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(helixBody);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.twitch.tv/helix/users?login=example_user");
+    const headers = new Headers(init.headers);
+    expect(headers.get("Authorization")).toBe("Bearer test-app-token");
+    expect(headers.get("Client-Id")).toBe("test-client-id");
+  });
+
+  it("複数セグメントのエンドポイント(bits/cheermotes)も中継できる", async () => {
+    fetchMock.mockResolvedValueOnce(helixResponse({ data: [] }));
+
+    const response = await callGet(
+      ["bits", "cheermotes"],
+      "?broadcaster_id=12345",
+    );
+
+    expect(response.status).toBe(200);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe(
+      "https://api.twitch.tv/helix/bits/cheermotes?broadcaster_id=12345",
+    );
+  });
+
+  it("許可リストにないエンドポイントは 404 を返し、Helix へ中継しない", async () => {
+    const response = await callGet(["moderation", "banned"]);
+
+    expect(response.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("Helix が 401 を返したらトークンを破棄して1回だけ再試行する", async () => {
+    const helixBody = { data: [{ id: "12345" }] };
+    fetchMock
+      .mockResolvedValueOnce(helixResponse({ message: "expired" }, 401))
+      .mockResolvedValueOnce(helixResponse(helixBody));
+
+    const response = await callGet(["users"], "?login=example_user");
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(helixBody);
+    expect(invalidateAppAccessTokenMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("再試行後も 401 の場合はそれ以上再試行せず 502 を返す", async () => {
+    fetchMock.mockResolvedValue(helixResponse({ message: "expired" }, 401));
+
+    const response = await callGet(["users"]);
+
+    expect(response.status).toBe(502);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("Helix が 429 を返したら Retry-After 付きで 429 を返す", async () => {
+    fetchMock.mockResolvedValueOnce(
+      helixResponse({ message: "Too Many Requests" }, 429, {
+        "Retry-After": "30",
+      }),
+    );
+
+    const response = await callGet(["streams"]);
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("Retry-After")).toBe("30");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("環境変数未設定(not_configured)の場合は 503 を返す", async () => {
+    getAppAccessTokenMock.mockRejectedValue(
+      new HelixTokenError("not_configured", "未設定"),
+    );
+
+    const response = await callGet(["users"]);
+
+    expect(response.status).toBe(503);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("トークン取得リクエストの失敗(request_failed)の場合は 502 を返す", async () => {
+    getAppAccessTokenMock.mockRejectedValue(
+      new HelixTokenError("request_failed", "取得失敗"),
+    );
+
+    const response = await callGet(["users"]);
+
+    expect(response.status).toBe(502);
+  });
+
+  it("Helix への fetch 自体が失敗した場合は 502 を返す", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("ネットワークエラー"));
+
+    const response = await callGet(["users"]);
+
+    expect(response.status).toBe(502);
+  });
+
+  it("Helix の 4xx エラー(400 など)はステータスとボディをそのまま返す", async () => {
+    const errorBody = { error: "Bad Request", status: 400, message: "invalid" };
+    fetchMock.mockResolvedValueOnce(helixResponse(errorBody, 400));
+
+    const response = await callGet(["users"], "?id=invalid");
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual(errorBody);
+  });
+});

--- a/src/app/api/twitch/[...path]/route.ts
+++ b/src/app/api/twitch/[...path]/route.ts
@@ -1,0 +1,105 @@
+/**
+ * Twitch Helix API を中継する Next.js Route Handler(プロキシ)。
+ *
+ * 視聴者にログインを求めず公開データ系の Helix API を使うため、
+ * サーバーサイドで App Access Token(`helix-token.ts`)を付与して中継する。
+ * Client ID / Client Secret / トークンはブラウザに一切露出しない。
+ *
+ * - GET のみ対応(公開データの取得のみが目的のため)
+ * - Helix のレート制限(App Access Token で 800 req/min)を第三者に浪費されないよう、
+ *   中継先エンドポイントは許可リスト(`ALLOWED_ENDPOINTS`)で制限する。
+ *   新しいエンドポイントが必要になったら許可リストに追加する
+ * - 429(レート制限)は Retry-After ヘッダー付きでそのまま返し、
+ *   クライアント側で待機・再試行できるようにする
+ * - 401(トークン失効)はトークンキャッシュを破棄して1回だけ再試行する
+ * - 環境変数未設定時は 503 を返す。クライアント側はこれを「Helix 利用不可」として
+ *   扱い、既存機能(IRC 接続・翻訳・Pick up)はそのまま動作させること
+ */
+import {
+  getAppAccessToken,
+  invalidateAppAccessToken,
+  HelixTokenError,
+} from "@/lib/twitch/helix-token";
+
+/** Helix API のベース URL */
+const HELIX_BASE_URL = "https://api.twitch.tv/helix";
+
+/**
+ * 中継を許可する Helix エンドポイント(先頭パス)の一覧。
+ * すべて App Access Token で取得できる公開データ系のみを載せること。
+ */
+const ALLOWED_ENDPOINTS: ReadonlySet<string> = new Set([
+  "users",
+  "streams",
+  "channels",
+  "bits/cheermotes",
+  "chat/emotes",
+]);
+
+/** エラーレスポンス(JSON)を組み立てる */
+function errorResponse(status: number, message: string): Response {
+  return Response.json({ error: message }, { status });
+}
+
+export async function GET(
+  request: Request,
+  ctx: { params: Promise<{ path: string[] }> },
+): Promise<Response> {
+  const { path } = await ctx.params;
+  const endpoint = path.join("/");
+  if (!ALLOWED_ENDPOINTS.has(endpoint)) {
+    return errorResponse(404, `未対応のエンドポイントです: ${endpoint}`);
+  }
+
+  const clientId = process.env.TWITCH_CLIENT_ID;
+  if (!clientId) {
+    return errorResponse(503, "Helix API が設定されていません");
+  }
+
+  const { search } = new URL(request.url);
+  const helixUrl = `${HELIX_BASE_URL}/${endpoint}${search}`;
+
+  try {
+    let helixResponse = await fetchHelix(helixUrl, clientId);
+    if (helixResponse.status === 401) {
+      // トークン失効とみなしてキャッシュを破棄し、1回だけ再試行する
+      invalidateAppAccessToken();
+      helixResponse = await fetchHelix(helixUrl, clientId);
+      if (helixResponse.status === 401) {
+        return errorResponse(502, "Helix API の認証に失敗しました");
+      }
+    }
+    if (helixResponse.status === 429) {
+      const headers = new Headers({ "Content-Type": "application/json" });
+      const retryAfter = helixResponse.headers.get("Retry-After");
+      if (retryAfter !== null) {
+        headers.set("Retry-After", retryAfter);
+      }
+      return new Response(
+        JSON.stringify({ error: "Helix API のレート制限に達しました" }),
+        { status: 429, headers },
+      );
+    }
+    // 成功・その他の 4xx はステータスとボディをそのまま返す
+    return new Response(helixResponse.body, {
+      status: helixResponse.status,
+      headers: { "Content-Type": "application/json" },
+    });
+  } catch (error) {
+    if (error instanceof HelixTokenError && error.kind === "not_configured") {
+      return errorResponse(503, "Helix API が設定されていません");
+    }
+    return errorResponse(502, "Helix API への中継に失敗しました");
+  }
+}
+
+/** App Access Token を付与して Helix API へ GET リクエストを送る */
+async function fetchHelix(url: string, clientId: string): Promise<Response> {
+  const token = await getAppAccessToken();
+  return fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Client-Id": clientId,
+    },
+  });
+}

--- a/src/lib/twitch/helix-token.test.ts
+++ b/src/lib/twitch/helix-token.test.ts
@@ -1,0 +1,147 @@
+/**
+ * helix-token.ts のテスト。
+ *
+ * Twitch App Access Token(Client Credentials フロー)の取得・キャッシュを検証する。
+ * 外部依存(fetch・環境変数)はモックする。
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  getAppAccessToken,
+  invalidateAppAccessToken,
+  HelixTokenError,
+} from "./helix-token";
+
+/** fetch モックが返すトークンレスポンスを組み立てるヘルパー */
+function tokenResponse(accessToken: string, expiresIn = 5_000_000) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      access_token: accessToken,
+      expires_in: expiresIn,
+      token_type: "bearer",
+    }),
+  } as Response;
+}
+
+describe("getAppAccessToken", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock);
+    vi.stubEnv("TWITCH_CLIENT_ID", "テスト用クライアントID");
+    vi.stubEnv("TWITCH_CLIENT_SECRET", "テスト用シークレット");
+    // モジュール内キャッシュをテストごとにリセットする
+    invalidateAppAccessToken();
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+    vi.useRealTimers();
+  });
+
+  it("Twitch のトークンエンドポイントに client_credentials で POST してトークンを返す", async () => {
+    fetchMock.mockResolvedValueOnce(tokenResponse("取得したトークン"));
+
+    const token = await getAppAccessToken();
+
+    expect(token).toBe("取得したトークン");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://id.twitch.tv/oauth2/token");
+    expect(init.method).toBe("POST");
+    const body = init.body as URLSearchParams;
+    expect(body.get("client_id")).toBe("テスト用クライアントID");
+    expect(body.get("client_secret")).toBe("テスト用シークレット");
+    expect(body.get("grant_type")).toBe("client_credentials");
+  });
+
+  it("2回目の呼び出しではキャッシュを使い、fetch を再実行しない", async () => {
+    fetchMock.mockResolvedValueOnce(tokenResponse("キャッシュされるトークン"));
+
+    const first = await getAppAccessToken();
+    const second = await getAppAccessToken();
+
+    expect(first).toBe("キャッシュされるトークン");
+    expect(second).toBe("キャッシュされるトークン");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("同時に複数回呼ばれても fetch は1回だけ実行する(in-flight 共有)", async () => {
+    fetchMock.mockResolvedValueOnce(tokenResponse("共有トークン"));
+
+    const [a, b] = await Promise.all([
+      getAppAccessToken(),
+      getAppAccessToken(),
+    ]);
+
+    expect(a).toBe("共有トークン");
+    expect(b).toBe("共有トークン");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("有効期限が近づいたトークンは再取得する", async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse("古いトークン", 3600))
+      .mockResolvedValueOnce(tokenResponse("新しいトークン"));
+
+    await getAppAccessToken();
+    // 有効期限(3600秒)を超えて時間を進める
+    vi.advanceTimersByTime(3600 * 1000 + 1);
+    const token = await getAppAccessToken();
+
+    expect(token).toBe("新しいトークン");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateAppAccessToken でキャッシュを破棄すると再取得する", async () => {
+    fetchMock
+      .mockResolvedValueOnce(tokenResponse("破棄されるトークン"))
+      .mockResolvedValueOnce(tokenResponse("再取得したトークン"));
+
+    await getAppAccessToken();
+    invalidateAppAccessToken();
+    const token = await getAppAccessToken();
+
+    expect(token).toBe("再取得したトークン");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("環境変数が未設定の場合は設定エラーとして HelixTokenError を投げる", async () => {
+    vi.stubEnv("TWITCH_CLIENT_ID", "");
+    vi.stubEnv("TWITCH_CLIENT_SECRET", "");
+
+    await expect(getAppAccessToken()).rejects.toThrow(HelixTokenError);
+    await expect(getAppAccessToken()).rejects.toMatchObject({
+      kind: "not_configured",
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("トークンエンドポイントがエラーを返した場合は HelixTokenError を投げる", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: false,
+      status: 403,
+      json: async () => ({ message: "invalid client secret" }),
+    } as Response);
+
+    await expect(getAppAccessToken()).rejects.toMatchObject({
+      kind: "request_failed",
+    });
+  });
+
+  it("取得失敗後の再呼び出しでは fetch を再実行する(失敗した Promise をキャッシュしない)", async () => {
+    fetchMock
+      .mockRejectedValueOnce(new Error("ネットワークエラー"))
+      .mockResolvedValueOnce(tokenResponse("復帰後のトークン"));
+
+    await expect(getAppAccessToken()).rejects.toThrow();
+    const token = await getAppAccessToken();
+
+    expect(token).toBe("復帰後のトークン");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/lib/twitch/helix-token.ts
+++ b/src/lib/twitch/helix-token.ts
@@ -1,0 +1,115 @@
+/**
+ * Twitch App Access Token(Client Credentials フロー)の取得・キャッシュを行う
+ * サーバーサイド専用モジュール。
+ *
+ * - `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` は Client Secret を含むため、
+ *   Route Handler などサーバーサイドからのみ import すること
+ *   (`NEXT_PUBLIC_` を付けず、ブラウザへは絶対に露出させない)
+ * - App Access Token は約60日有効なため、モジュールスコープでキャッシュして使い回す。
+ *   Vercel の Fluid Compute ではインスタンスがリクエスト間で再利用されるため、
+ *   モジュールスコープのキャッシュが有効に機能する(インスタンスが破棄された場合は
+ *   再取得されるだけで正しく動く)
+ * - 同時リクエストで取得が重ならないよう、進行中の取得 Promise を共有する
+ * - Helix 側で 401 が返った場合(トークン失効)は `invalidateAppAccessToken` で
+ *   キャッシュを破棄して再取得させる
+ */
+
+/** トークン取得エンドポイント */
+const TOKEN_URL = "https://id.twitch.tv/oauth2/token";
+
+/**
+ * 有効期限手前でトークンを再取得するためのマージン(秒)。
+ * 期限ぎりぎりのトークンで Helix を呼んで 401 になるのを避ける。
+ */
+const EXPIRY_MARGIN_SECONDS = 300;
+
+/** トークン取得に失敗した理由の分類 */
+export type HelixTokenErrorKind = "not_configured" | "request_failed";
+
+/**
+ * トークン取得の失敗を表すエラー。
+ * `kind` により「環境変数未設定(設定不備)」と「取得リクエスト失敗」を区別できる。
+ */
+export class HelixTokenError extends Error {
+  readonly kind: HelixTokenErrorKind;
+
+  constructor(kind: HelixTokenErrorKind, message: string) {
+    super(message);
+    this.name = "HelixTokenError";
+    this.kind = kind;
+  }
+}
+
+/** キャッシュ中のトークンと有効期限(エポックミリ秒) */
+interface CachedToken {
+  accessToken: string;
+  expiresAtMs: number;
+}
+
+let cachedToken: CachedToken | null = null;
+let inFlight: Promise<string> | null = null;
+
+/**
+ * App Access Token を取得する。
+ * キャッシュが有効ならそれを返し、なければ Twitch から新規取得する。
+ *
+ * @throws HelixTokenError 環境変数未設定、または取得リクエスト失敗時
+ */
+export async function getAppAccessToken(): Promise<string> {
+  if (cachedToken !== null && Date.now() < cachedToken.expiresAtMs) {
+    return cachedToken.accessToken;
+  }
+  if (inFlight !== null) {
+    return inFlight;
+  }
+  inFlight = fetchNewToken().finally(() => {
+    inFlight = null;
+  });
+  return inFlight;
+}
+
+/**
+ * キャッシュ中のトークンを破棄する。
+ * Helix API が 401 を返した場合(トークン失効)に呼び、次回取得時に再発行させる。
+ */
+export function invalidateAppAccessToken(): void {
+  cachedToken = null;
+}
+
+/** Twitch のトークンエンドポイントから新しいトークンを取得してキャッシュする */
+async function fetchNewToken(): Promise<string> {
+  const clientId = process.env.TWITCH_CLIENT_ID;
+  const clientSecret = process.env.TWITCH_CLIENT_SECRET;
+  if (!clientId || !clientSecret) {
+    throw new HelixTokenError(
+      "not_configured",
+      "TWITCH_CLIENT_ID / TWITCH_CLIENT_SECRET が設定されていません",
+    );
+  }
+
+  const response = await fetch(TOKEN_URL, {
+    method: "POST",
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: "client_credentials",
+    }),
+  });
+  if (!response.ok) {
+    throw new HelixTokenError(
+      "request_failed",
+      `App Access Token の取得に失敗しました(status: ${response.status})`,
+    );
+  }
+
+  const data = (await response.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+  cachedToken = {
+    accessToken: data.access_token,
+    expiresAtMs:
+      Date.now() + Math.max(0, data.expires_in - EXPIRY_MARGIN_SECONDS) * 1000,
+  };
+  return data.access_token;
+}


### PR DESCRIPTION
## Summary

視聴者にログインを求めないまま公開データ系の Twitch Helix API を利用するための基盤を導入します。完全クライアントサイドだった構成に初めてサーバー依存(Route Handler)が入りますが、Helix が使えない場合でも既存機能(IRC 接続・翻訳・Pick up)には影響しません。

## 変更内容

- **`src/lib/twitch/helix-token.ts`**: App Access Token(Client Credentials フロー)の取得・キャッシュを行うサーバーサイドモジュール
  - トークン(約60日有効)をモジュールスコープでキャッシュし、有効期限の 5 分前に再取得
  - 同時リクエスト時は進行中の取得 Promise を共有(fetch は1回のみ)
  - `HelixTokenError` の `kind` で「環境変数未設定」と「取得失敗」を区別
- **`src/app/api/twitch/[...path]/route.ts`**: Helix API を中継する Route Handler(プロキシ)
  - Client ID / Client Secret / トークンはブラウザに一切露出しない
  - GET のみ対応。レート制限(App Access Token で 800 req/min)を第三者に浪費されないよう、中継先エンドポイントを許可リスト(`users` / `streams` / `channels` / `bits/cheermotes` / `chat/emotes`)で制限
  - 401(トークン失効)はキャッシュ破棄後に1回だけ再試行、それでも 401 なら 502
  - 429 は Retry-After ヘッダー付きでそのまま返却(クライアント側で待機・再試行可能)
  - 環境変数未設定時は 503(クライアント側は「Helix 利用不可」としてフォールバック)
- **README.md**: `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` の設定手順を追記

## テスト

- `helix-token.test.ts`: 8件(取得・キャッシュ・in-flight 共有・期限切れ再取得・破棄・エラー分類・失敗後の復帰)
- `route.test.ts`: 10件(中継・許可リスト・401 再試行・429・503/502 フォールバック・4xx パススルー)
- Lint / 型チェック / テスト514件 / ビルド すべて通過。CodeRabbit レビュー指摘 0 件

## 残作業(コード外)

- Twitch Developer Console でのアプリケーション登録と、Vercel への `TWITCH_CLIENT_ID` / `TWITCH_CLIENT_SECRET` の設定(手作業)

Refs #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH