### PR TITLE
feat: Helix Cheermotes API でチャンネル独自 Cheermote に対応し、静的一覧をフォールバックに置き換える

### DIFF
--- a/src/lib/twitch/cheermotes.test.ts
+++ b/src/lib/twitch/cheermotes.test.ts
@@ -1,87 +1,272 @@
 /**
  * src/lib/twitch/cheermotes.ts のテスト。
  *
- * bits 付き発言の本文に含まれる Cheering Emote(`Cheer100` / `showLove1000` など)を
- * 位置情報(EmotePosition)として既存の emote 処理に合成する純関数を検証する。
+ * Helix の Cheermotes API から取得した一覧(CheermoteSet)をもとに、bits 付き発言の
+ * 本文に含まれる Cheering Emote(`Cheer100` / `showLove1000` など)を位置情報
+ * (EmotePosition)として既存の emote 処理に合成する流れと、
+ * API レスポンスの解析・フォールバック用静的一覧を検証する。
  */
-import { describe, expect, it } from "vitest";
-import { mergeCheermotePositions, resolveCheermoteTier } from "./cheermotes";
+import { describe, expect, it, vi } from "vitest";
+import {
+  STATIC_CHEERMOTE_SET,
+  buildCheermoteImageUrlMap,
+  fetchCheermoteSet,
+  mergeCheermotePositions,
+  parseCheermoteSet,
+  resolveCheermoteTier,
+  type CheermoteTier,
+} from "./cheermotes";
 import type { EmotePosition } from "./irc-parser";
 
+/** テスト用のティア一覧(minBits の降順)。実際の Cheer と同じ 5 段階 */
+const SAMPLE_TIERS: readonly CheermoteTier[] = [
+  { minBits: 10000, imageUrl: "https://example.com/cheer/10000.gif" },
+  { minBits: 5000, imageUrl: "https://example.com/cheer/5000.gif" },
+  { minBits: 1000, imageUrl: "https://example.com/cheer/1000.gif" },
+  { minBits: 100, imageUrl: "https://example.com/cheer/100.gif" },
+  { minBits: 1, imageUrl: "https://example.com/cheer/1.gif" },
+];
+
 describe("resolveCheermoteTier", () => {
-  it("bits 数に応じて表示ティア(1 / 100 / 1000 / 5000 / 10000)を返す", () => {
-    expect(resolveCheermoteTier(1)).toBe(1);
-    expect(resolveCheermoteTier(99)).toBe(1);
-    expect(resolveCheermoteTier(100)).toBe(100);
-    expect(resolveCheermoteTier(999)).toBe(100);
-    expect(resolveCheermoteTier(1000)).toBe(1000);
-    expect(resolveCheermoteTier(4999)).toBe(1000);
-    expect(resolveCheermoteTier(5000)).toBe(5000);
-    expect(resolveCheermoteTier(9999)).toBe(5000);
-    expect(resolveCheermoteTier(10000)).toBe(10000);
-    expect(resolveCheermoteTier(123456)).toBe(10000);
+  it("bits 数以下で最大の minBits を持つティアを返す", () => {
+    expect(resolveCheermoteTier(1, SAMPLE_TIERS)?.minBits).toBe(1);
+    expect(resolveCheermoteTier(99, SAMPLE_TIERS)?.minBits).toBe(1);
+    expect(resolveCheermoteTier(100, SAMPLE_TIERS)?.minBits).toBe(100);
+    expect(resolveCheermoteTier(999, SAMPLE_TIERS)?.minBits).toBe(100);
+    expect(resolveCheermoteTier(1000, SAMPLE_TIERS)?.minBits).toBe(1000);
+    expect(resolveCheermoteTier(4999, SAMPLE_TIERS)?.minBits).toBe(1000);
+    expect(resolveCheermoteTier(5000, SAMPLE_TIERS)?.minBits).toBe(5000);
+    expect(resolveCheermoteTier(9999, SAMPLE_TIERS)?.minBits).toBe(5000);
+    expect(resolveCheermoteTier(10000, SAMPLE_TIERS)?.minBits).toBe(10000);
+    expect(resolveCheermoteTier(123456, SAMPLE_TIERS)?.minBits).toBe(10000);
+  });
+
+  it("最小ティアに満たない bits 数(チャンネル独自の最低 100 bits など)では null を返す", () => {
+    const tiers: readonly CheermoteTier[] = [
+      { minBits: 1000, imageUrl: "https://example.com/custom/1000.gif" },
+      { minBits: 100, imageUrl: "https://example.com/custom/100.gif" },
+    ];
+    expect(resolveCheermoteTier(99, tiers)).toBeNull();
+  });
+});
+
+describe("STATIC_CHEERMOTE_SET(Helix 利用不可時のフォールバック)", () => {
+  it("グローバル Cheermote のプレフィックスを 5 ティア構成で持つ", () => {
+    const tiers = STATIC_CHEERMOTE_SET.get("cheer");
+    expect(tiers?.map((tier) => tier.minBits)).toEqual([10000, 5000, 1000, 100, 1]);
+    expect(STATIC_CHEERMOTE_SET.has("showlove")).toBe(true);
+    expect(STATIC_CHEERMOTE_SET.has("kappa")).toBe(true);
+  });
+
+  it("画像 URL は静的 CDN(ダーク・アニメ・2倍)の URL を持つ", () => {
+    const tiers = STATIC_CHEERMOTE_SET.get("cheer");
+    expect(tiers?.find((tier) => tier.minBits === 100)?.imageUrl).toBe(
+      "https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/100/2.gif",
+    );
   });
 });
 
 describe("mergeCheermotePositions", () => {
   it("bits が null(Cheer していない発言)の場合は、公式 emote の位置情報をそのまま返す", () => {
     const twitchEmotes: EmotePosition[] = [{ id: "25", start: 0, end: 4 }];
-    expect(mergeCheermotePositions("Kappa Cheer100", twitchEmotes, null)).toEqual(twitchEmotes);
+    expect(mergeCheermotePositions("Kappa Cheer100", twitchEmotes, null, STATIC_CHEERMOTE_SET)).toEqual(twitchEmotes);
   });
 
   it("Cheer100 のプレフィックス部分だけを emote 位置として合成する(数値はテキストのまま残す)", () => {
-    const result = mergeCheermotePositions("Cheer100 nice", [], 100);
+    const result = mergeCheermotePositions("Cheer100 nice", [], 100, STATIC_CHEERMOTE_SET);
     expect(result).toEqual([{ id: "cheer:cheer/100", start: 0, end: 4 }]);
   });
 
   it("showLove1000 は小文字化したプレフィックスと bits 数のティアで ID を組み立てる", () => {
-    const result = mergeCheermotePositions("showLove1000", [], 1000);
+    const result = mergeCheermotePositions("showLove1000", [], 1000, STATIC_CHEERMOTE_SET);
     expect(result).toEqual([{ id: "cheer:showlove/1000", start: 0, end: 7 }]);
   });
 
   it("プレフィックスは大文字小文字を区別せずに照合する(Twitch の仕様)", () => {
-    expect(mergeCheermotePositions("cheer100", [], 100)).toEqual([{ id: "cheer:cheer/100", start: 0, end: 4 }]);
-    expect(mergeCheermotePositions("CHEER100", [], 100)).toEqual([{ id: "cheer:cheer/100", start: 0, end: 4 }]);
+    expect(mergeCheermotePositions("cheer100", [], 100, STATIC_CHEERMOTE_SET)).toEqual([
+      { id: "cheer:cheer/100", start: 0, end: 4 },
+    ]);
+    expect(mergeCheermotePositions("CHEER100", [], 100, STATIC_CHEERMOTE_SET)).toEqual([
+      { id: "cheer:cheer/100", start: 0, end: 4 },
+    ]);
   });
 
   it("ティアは各トークンの bits 数から決める(発言全体の bits 合計ではない)", () => {
-    const result = mergeCheermotePositions("Cheer1 Cheer5000", [], 5001);
+    const result = mergeCheermotePositions("Cheer1 Cheer5000", [], 5001, STATIC_CHEERMOTE_SET);
     expect(result).toEqual([
       { id: "cheer:cheer/1", start: 0, end: 4 },
       { id: "cheer:cheer/5000", start: 7, end: 11 },
     ]);
   });
 
-  it("既知のプレフィックスでない単語(hello100 など)は emote にしない", () => {
-    expect(mergeCheermotePositions("hello100", [], 100)).toEqual([]);
+  it("一覧に無いプレフィックスの単語(hello100 など)は emote にしない", () => {
+    expect(mergeCheermotePositions("hello100", [], 100, STATIC_CHEERMOTE_SET)).toEqual([]);
+  });
+
+  it("チャンネル独自 Cheermote のプレフィックスを含む一覧なら、その単語も emote にする", () => {
+    const customSet = new Map([
+      ...STATIC_CHEERMOTE_SET,
+      ["mycustom", SAMPLE_TIERS],
+    ]);
+    expect(mergeCheermotePositions("myCustom100", [], 100, customSet)).toEqual([
+      { id: "cheer:mycustom/100", start: 0, end: 7 },
+    ]);
+  });
+
+  it("最小ティアに満たない bits 数のトークンは emote にしない", () => {
+    const customSet = new Map([
+      ["mycustom", [{ minBits: 100, imageUrl: "https://example.com/custom/100.gif" }]],
+    ]);
+    expect(mergeCheermotePositions("myCustom50", [], 50, customSet)).toEqual([]);
   });
 
   it("数値が続かない単語(Cheer のみ)や 0 bits(Cheer0)は emote にしない", () => {
-    expect(mergeCheermotePositions("Cheer", [], 100)).toEqual([]);
-    expect(mergeCheermotePositions("Cheer0", [], 100)).toEqual([]);
+    expect(mergeCheermotePositions("Cheer", [], 100, STATIC_CHEERMOTE_SET)).toEqual([]);
+    expect(mergeCheermotePositions("Cheer0", [], 100, STATIC_CHEERMOTE_SET)).toEqual([]);
   });
 
   it("単語の一部だけの一致(Cheer100! など)は emote にしない", () => {
-    expect(mergeCheermotePositions("Cheer100!", [], 100)).toEqual([]);
+    expect(mergeCheermotePositions("Cheer100!", [], 100, STATIC_CHEERMOTE_SET)).toEqual([]);
   });
 
   it("公式 emote の範囲と重なる単語は公式 emote を優先して emote にしない", () => {
     const twitchEmotes: EmotePosition[] = [{ id: "999", start: 0, end: 7 }];
-    expect(mergeCheermotePositions("Cheer100", twitchEmotes, 100)).toEqual(twitchEmotes);
+    expect(mergeCheermotePositions("Cheer100", twitchEmotes, 100, STATIC_CHEERMOTE_SET)).toEqual(twitchEmotes);
   });
 
   it("サロゲートペアの絵文字が前にあっても、コードポイント単位で位置を数える", () => {
     // "🌿 Cheer100" — 🌿 はコードポイント1つ(UTF-16では2ユニット)
-    const result = mergeCheermotePositions("🌿 Cheer100", [], 100);
+    const result = mergeCheermotePositions("🌿 Cheer100", [], 100, STATIC_CHEERMOTE_SET);
     expect(result).toEqual([{ id: "cheer:cheer/100", start: 2, end: 6 }]);
   });
 
   it("公式 emote と合成した結果は開始位置の昇順で返す", () => {
     const twitchEmotes: EmotePosition[] = [{ id: "25", start: 9, end: 13 }];
-    const result = mergeCheermotePositions("Cheer100 Kappa", twitchEmotes, 100);
+    const result = mergeCheermotePositions("Cheer100 Kappa", twitchEmotes, 100, STATIC_CHEERMOTE_SET);
     expect(result).toEqual([
       { id: "cheer:cheer/100", start: 0, end: 4 },
       { id: "25", start: 9, end: 13 },
     ]);
+  });
+});
+
+/** Helix の Cheermotes API レスポンス(必要な項目のみ)のサンプルを作る */
+function createHelixCheermotesJson(): unknown {
+  return {
+    data: [
+      {
+        prefix: "Cheer",
+        tiers: [
+          {
+            min_bits: 1,
+            id: "1",
+            images: { dark: { animated: { "1": "https://example.com/cheer/1/1.gif", "2": "https://example.com/cheer/1/2.gif" } } },
+          },
+          {
+            min_bits: 100,
+            id: "100",
+            images: { dark: { animated: { "1": "https://example.com/cheer/100/1.gif", "2": "https://example.com/cheer/100/2.gif" } } },
+          },
+        ],
+        type: "global_first_party",
+      },
+      {
+        prefix: "myCustom",
+        tiers: [
+          {
+            min_bits: 100,
+            id: "100",
+            images: { dark: { animated: { "2": "https://example.com/mycustom/100/2.gif" } } },
+          },
+        ],
+        type: "channel_custom",
+      },
+    ],
+  };
+}
+
+describe("parseCheermoteSet", () => {
+  it("プレフィックスを小文字化し、ティアを minBits の降順に並べた CheermoteSet を返す", () => {
+    const set = parseCheermoteSet(createHelixCheermotesJson());
+
+    expect(set.get("cheer")).toEqual([
+      { minBits: 100, imageUrl: "https://example.com/cheer/100/2.gif" },
+      { minBits: 1, imageUrl: "https://example.com/cheer/1/2.gif" },
+    ]);
+    expect(set.get("mycustom")).toEqual([
+      { minBits: 100, imageUrl: "https://example.com/mycustom/100/2.gif" },
+    ]);
+  });
+
+  it("形式が想定と異なる項目(prefix 欠落・2倍画像なしのティアなど)は読み飛ばす", () => {
+    const set = parseCheermoteSet({
+      data: [
+        { tiers: [] },
+        {
+          prefix: "Broken",
+          tiers: [{ min_bits: 1, images: { dark: { animated: {} } } }],
+        },
+        {
+          prefix: "Ok",
+          tiers: [
+            { min_bits: 1, images: { dark: { animated: { "2": "https://example.com/ok/1/2.gif" } } } },
+            "invalid-tier",
+          ],
+        },
+      ],
+    });
+
+    expect([...set.keys()]).toEqual(["ok"]);
+    expect(set.get("ok")).toEqual([{ minBits: 1, imageUrl: "https://example.com/ok/1/2.gif" }]);
+  });
+
+  it("配列でない・data が無いレスポンスは空の CheermoteSet を返す", () => {
+    expect(parseCheermoteSet(null).size).toBe(0);
+    expect(parseCheermoteSet({}).size).toBe(0);
+    expect(parseCheermoteSet({ data: "oops" }).size).toBe(0);
+  });
+});
+
+describe("buildCheermoteImageUrlMap", () => {
+  it("emote ID(cheer: 以降の `プレフィックス/ティア`)から画像 URL への対応表を作る", () => {
+    const set = parseCheermoteSet(createHelixCheermotesJson());
+    const urlMap = buildCheermoteImageUrlMap(set);
+
+    expect(urlMap.get("cheer/100")).toBe("https://example.com/cheer/100/2.gif");
+    expect(urlMap.get("cheer/1")).toBe("https://example.com/cheer/1/2.gif");
+    expect(urlMap.get("mycustom/100")).toBe("https://example.com/mycustom/100/2.gif");
+  });
+});
+
+describe("fetchCheermoteSet", () => {
+  it("Helix プロキシに broadcaster_id 付きで GET し、解析した CheermoteSet を返す", async () => {
+    const fetchFn = vi.fn(async () => Response.json(createHelixCheermotesJson()));
+
+    const set = await fetchCheermoteSet("552120296", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/bits/cheermotes?broadcaster_id=552120296");
+    expect(set?.get("mycustom")).toEqual([
+      { minBits: 100, imageUrl: "https://example.com/mycustom/100/2.gif" },
+    ]);
+  });
+
+  it("HTTP エラー(503: Helix 未設定など)の場合は null を返す(静的一覧へのフォールバック用)", async () => {
+    const fetchFn = vi.fn(async () => Response.json({ error: "Helix API が設定されていません" }, { status: 503 }));
+
+    expect(await fetchCheermoteSet("552120296", fetchFn)).toBeNull();
+  });
+
+  it("ネットワークエラーの場合は null を返す", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    expect(await fetchCheermoteSet("552120296", fetchFn)).toBeNull();
+  });
+
+  it("Cheermote が 1 件も無いレスポンスは null を返す(グローバル Cheermote は常に存在するはずのため)", async () => {
+    const fetchFn = vi.fn(async () => Response.json({ data: [] }));
+
+    expect(await fetchCheermoteSet("552120296", fetchFn)).toBeNull();
   });
 });

--- a/src/lib/twitch/cheermotes.ts
+++ b/src/lib/twitch/cheermotes.ts
@@ -8,23 +8,43 @@
  * textless 判定)はサードパーティ emote(`third-party-emotes.ts`)と同様に
  * 既存の emote 処理をそのまま使える。
  *
- * - このアプリは Helix API を使わない匿名 IRC 接続のため、チャンネル独自の Cheermote は
- *   取得できない。Twitch 公式ドキュメントに載っているグローバル Cheermote の
- *   プレフィックスを静的な一覧として持つ(BibleThump / EleGiggle は CDN 上に
- *   画像が存在しなくなっているため一覧から除外した。2026-09 に確認)
+ * Cheermote の一覧(`CheermoteSet`)は Helix の Cheermotes API
+ * (`GET /bits/cheermotes?broadcaster_id=`)を Next.js プロキシ(`/api/twitch/`)経由で
+ * 取得する(`fetchCheermoteSet`)。これによりグローバル Cheermote に加えて
+ * チャンネル独自 Cheermote にも対応し、CDN 側の変化(BibleThump / EleGiggle の
+ * 画像消失のような事象)にも自動追従する(issue #53)。
+ *
+ * Helix が利用できない場合(環境変数未設定の 503・障害など)は、グローバル Cheermote の
+ * 静的一覧 `STATIC_CHEERMOTE_SET` にフォールバックする(意図した仕様。
+ * 読み込みの流れとフォールバックの保持は `src/store/cheermotes.ts` が担う)。
+ *
  * - emote 位置はプレフィックス部分だけを覆い、bits 数はテキストとして残す
  *   (Twitch 本家のチャット UI と同じく「画像 + 数値」で表示するため)
- * - ID は `cheer:{プレフィックス小文字}/{ティア}` 形式とし、`emotes.ts` の
- *   `buildEmoteImageUrl` が静的 CDN の URL に組み立てる
+ * - ID は `cheer:{プレフィックス小文字}/{ティアの min_bits}` 形式とし、`emotes.ts` の
+ *   `buildEmoteImageUrl` が画像 URL に解決する(API 取得済みならレジストリの URL、
+ *   未取得なら静的 CDN URL)
  * - 位置は Twitch の `emotes` タグと同じくコードポイント単位・end は inclusive
  */
 import type { EmotePosition } from "./irc-parser";
 
+/** Cheermote の 1 ティア(bits 数の閾値と、その段階の画像 URL) */
+export interface CheermoteTier {
+  /** このティアが適用される最小の bits 数(Helix の `min_bits`) */
+  minBits: number;
+  /** このティアの画像 URL(ダーク・アニメ・2倍) */
+  imageUrl: string;
+}
+
+/** プレフィックス(小文字)→ ティア一覧(minBits の降順)の対応表 */
+export type CheermoteSet = ReadonlyMap<string, readonly CheermoteTier[]>;
+
 /**
  * グローバル Cheermote のプレフィックス一覧(小文字)。
+ * Helix が利用できない場合のフォールバック(`STATIC_CHEERMOTE_SET`)にのみ使う。
  * 出典: https://dev.twitch.tv/docs/irc/emotes/(Cheermotes の節)
+ * BibleThump / EleGiggle は CDN 上に画像が存在しなくなっているため除外した(2026-09 に確認)。
  */
-const GLOBAL_CHEERMOTE_PREFIXES: ReadonlySet<string> = new Set([
+const GLOBAL_CHEERMOTE_PREFIXES: readonly string[] = [
   "cheer",
   "doodlecheer",
   "cheerwhal",
@@ -50,20 +70,40 @@ const GLOBAL_CHEERMOTE_PREFIXES: ReadonlySet<string> = new Set([
   "bday",
   "ripcheer",
   "shamrock",
-]);
+];
 
-/** Cheermote の画像が用意されている bits 数の閾値(降順) */
-const CHEERMOTE_TIERS = [10000, 5000, 1000, 100, 1] as const;
+/** グローバル Cheermote に共通のティア閾値(降順) */
+const STATIC_CHEERMOTE_TIERS = [10000, 5000, 1000, 100, 1] as const;
+
+/** 静的 CDN の Cheermote 画像 URL(ダーク・アニメ・2倍)を組み立てる */
+function buildStaticCheermoteImageUrl(prefix: string, minBits: number): string {
+  return `https://d3aqoihi2n8ty8.cloudfront.net/actions/${prefix}/dark/animated/${minBits}/2.gif`;
+}
 
 /**
- * bits 数から Cheermote の表示ティア(画像・色の段階)を返す。
- * 1〜99 → 1、100〜999 → 100、1000〜4999 → 1000、5000〜9999 → 5000、10000〜 → 10000。
+ * Helix が利用できない場合のフォールバック用の静的な Cheermote 一覧。
+ * グローバル Cheermote のみを含み、画像 URL は静的 CDN の URL を使う。
  */
-export function resolveCheermoteTier(bits: number): number {
-  for (const tier of CHEERMOTE_TIERS) {
-    if (bits >= tier) return tier;
+export const STATIC_CHEERMOTE_SET: CheermoteSet = new Map(
+  GLOBAL_CHEERMOTE_PREFIXES.map((prefix) => [
+    prefix,
+    STATIC_CHEERMOTE_TIERS.map((minBits) => ({
+      minBits,
+      imageUrl: buildStaticCheermoteImageUrl(prefix, minBits),
+    })),
+  ]),
+);
+
+/**
+ * bits 数に応じた表示ティア(画像・色の段階)を返す。
+ * ティア一覧(minBits の降順)から「bits 数以下で最大の minBits」のティアを選ぶ。
+ * 最小ティアに満たない bits 数(チャンネル独自 Cheermote の最低 bits 未満など)は null。
+ */
+export function resolveCheermoteTier(bits: number, tiers: readonly CheermoteTier[]): CheermoteTier | null {
+  for (const tier of tiers) {
+    if (bits >= tier.minBits) return tier;
   }
-  return 1;
+  return null;
 }
 
 /** 「英字プレフィックス + bits 数」のトークン(例: `Cheer100`)にマッチするパターン */
@@ -80,7 +120,8 @@ function overlapsAnyEmote(start: number, end: number, emotes: EmotePosition[]): 
  * Cheermote は成立しないため、公式 emote の位置情報をそのまま返す。
  *
  * - プレフィックスは Twitch の仕様どおり大文字小文字を区別せずに照合する
- * - 単語全体が「プレフィックス + 1 以上の数値」の場合のみ Cheermote とする
+ *   (`cheermotes` のキーが小文字なので、トークン側を小文字化して引く)
+ * - 単語全体が「プレフィックス + 1 以上の数値」で、bits 数が最小ティア以上の場合のみ Cheermote とする
  * - emote 位置はプレフィックス部分だけを覆い、bits 数はテキストとして残す
  * - 公式 emote の範囲と重なる単語は公式 emote を優先して対象外とする
  */
@@ -88,6 +129,7 @@ export function mergeCheermotePositions(
   text: string,
   twitchEmotes: EmotePosition[],
   bits: number | null,
+  cheermotes: CheermoteSet,
 ): EmotePosition[] {
   if (bits === null || bits <= 0) return twitchEmotes;
 
@@ -109,14 +151,12 @@ export function mergeCheermotePositions(
     if (match !== null) {
       const prefix = match[1].toLowerCase();
       const amount = Number.parseInt(match[2], 10);
-      if (
-        GLOBAL_CHEERMOTE_PREFIXES.has(prefix) &&
-        amount >= 1 &&
-        !overlapsAnyEmote(tokenStart, i - 1, twitchEmotes)
-      ) {
+      const tiers = cheermotes.get(prefix);
+      const tier = tiers !== undefined && amount >= 1 ? resolveCheermoteTier(amount, tiers) : null;
+      if (tier !== null && !overlapsAnyEmote(tokenStart, i - 1, twitchEmotes)) {
         // 画像が覆うのはプレフィックス部分だけ。bits 数は後続のテキストセグメントとして残る
         const prefixEnd = tokenStart + match[1].length - 1;
-        merged.push({ id: `cheer:${prefix}/${resolveCheermoteTier(amount)}`, start: tokenStart, end: prefixEnd });
+        merged.push({ id: `cheer:${prefix}/${tier.minBits}`, start: tokenStart, end: prefixEnd });
       }
     }
     tokenStart = -1;
@@ -124,4 +164,96 @@ export function mergeCheermotePositions(
 
   merged.sort((a, b) => a.start - b.start);
   return merged;
+}
+
+/**
+ * CheermoteSet から「emote ID の `cheer:` 以降(`プレフィックス/ティア`)→ 画像 URL」の
+ * 対応表を作る。`emotes.ts` の `registerCheermoteImageUrls` に渡し、
+ * `buildEmoteImageUrl` が API 由来の画像 URL を返せるようにする。
+ */
+export function buildCheermoteImageUrlMap(cheermotes: CheermoteSet): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const [prefix, tiers] of cheermotes) {
+    for (const tier of tiers) {
+      map.set(`${prefix}/${tier.minBits}`, tier.imageUrl);
+    }
+  }
+  return map;
+}
+
+/** Helix の Cheermotes API のティア 1 件から CheermoteTier を組み立てる。形式が想定と異なる場合は null */
+function parseCheermoteTier(value: unknown): CheermoteTier | null {
+  if (typeof value !== "object" || value === null) return null;
+  const record = value as Record<string, unknown>;
+  if (typeof record.min_bits !== "number") return null;
+
+  // 画像はダーク・アニメ・2倍を使う(既存の静的 CDN URL と同じ表示条件)
+  const images = record.images as Record<string, unknown> | undefined;
+  const dark = (images?.dark ?? null) as Record<string, unknown> | null;
+  const animated = (dark?.animated ?? null) as Record<string, unknown> | null;
+  const imageUrl = animated?.["2"];
+  if (typeof imageUrl !== "string") return null;
+
+  return { minBits: record.min_bits, imageUrl };
+}
+
+/**
+ * Helix の Cheermotes API レスポンス(`{data: [{prefix, tiers: [...]}]}`)を解析して
+ * CheermoteSet を作る。API 側の仕様変更などで形式が想定と異なる項目は読み飛ばす。
+ * ティアは minBits の降順に並べる(`resolveCheermoteTier` が先頭から照合するため)。
+ */
+export function parseCheermoteSet(json: unknown): CheermoteSet {
+  const set = new Map<string, readonly CheermoteTier[]>();
+  if (typeof json !== "object" || json === null) return set;
+  const data = (json as Record<string, unknown>).data;
+  if (!Array.isArray(data)) return set;
+
+  for (const entry of data) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.prefix !== "string" || !Array.isArray(record.tiers)) continue;
+
+    const tiers = record.tiers
+      .map(parseCheermoteTier)
+      .filter((tier): tier is CheermoteTier => tier !== null)
+      .sort((a, b) => b.minBits - a.minBits);
+    if (tiers.length === 0) continue;
+
+    set.set(record.prefix.toLowerCase(), tiers);
+  }
+  return set;
+}
+
+/**
+ * Helix プロキシ(`/api/twitch/bits/cheermotes`)から、指定した配信者の
+ * Cheermote 一覧(グローバル + チャンネル独自)を取得する。
+ *
+ * 取得できない場合は null を返す(呼び出し側の `src/store/cheermotes.ts` が
+ * 静的一覧 `STATIC_CHEERMOTE_SET` へフォールバックする。意図した仕様):
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害などの HTTP エラー
+ * - ネットワークエラー
+ * - Cheermote が 1 件も解析できないレスポンス(グローバル Cheermote は常に存在するはずのため異常とみなす)
+ */
+export async function fetchCheermoteSet(
+  broadcasterId: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<CheermoteSet | null> {
+  try {
+    const response = await fetchFn(
+      `/api/twitch/bits/cheermotes?broadcaster_id=${encodeURIComponent(broadcasterId)}`,
+    );
+    if (!response.ok) {
+      console.warn(`Cheermote 一覧の取得に失敗しました(HTTP ${response.status})。静的一覧を使います`);
+      return null;
+    }
+    const set = parseCheermoteSet(await response.json());
+    if (set.size === 0) {
+      console.warn("Cheermote 一覧のレスポンスを解析できませんでした。静的一覧を使います");
+      return null;
+    }
+    return set;
+  } catch (error) {
+    console.warn("Cheermote 一覧の取得に失敗しました。静的一覧を使います", error);
+    return null;
+  }
 }

--- a/src/lib/twitch/emotes.test.ts
+++ b/src/lib/twitch/emotes.test.ts
@@ -5,7 +5,7 @@
  * 実際の画像表示に使えるCDN URLや、テキスト/emoteが交互に並ぶ
  * 描画用セグメントに変換する純関数を検証する。
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   buildEmoteImageUrl,
   extractPlainText,
@@ -14,6 +14,7 @@ import {
   maskEmotesWithPlaceholders,
   restoreEmotesFromPlaceholders,
   splitMessageIntoSegments,
+  registerCheermoteImageUrls,
 } from "./emotes";
 import type { EmotePosition } from "./irc-parser";
 
@@ -277,6 +278,36 @@ describe("buildEmoteImageUrl(Cheering Emote)", () => {
     );
     expect(buildEmoteImageUrl("cheer:showlove/1000")).toBe(
       "https://d3aqoihi2n8ty8.cloudfront.net/actions/showlove/dark/animated/1000/2.gif",
+    );
+  });
+});
+
+describe("registerCheermoteImageUrls(Helix Cheermotes API の画像 URL)", () => {
+  afterEach(() => {
+    // モジュールスコープのレジストリを空(静的 CDN URL へのフォールバック)に戻す
+    registerCheermoteImageUrls(new Map());
+  });
+
+  it("登録済みの ID は API 由来の画像 URL を返す", () => {
+    registerCheermoteImageUrls(new Map([["mycustom/100", "https://example.com/mycustom/100/2.gif"]]));
+
+    expect(buildEmoteImageUrl("cheer:mycustom/100")).toBe("https://example.com/mycustom/100/2.gif");
+  });
+
+  it("未登録の ID は静的 CDN URL にフォールバックする", () => {
+    registerCheermoteImageUrls(new Map([["mycustom/100", "https://example.com/mycustom/100/2.gif"]]));
+
+    expect(buildEmoteImageUrl("cheer:cheer/100")).toBe(
+      "https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/100/2.gif",
+    );
+  });
+
+  it("空の対応表を登録すると、すべて静的 CDN URL に戻る", () => {
+    registerCheermoteImageUrls(new Map([["cheer/100", "https://example.com/cheer/100/2.gif"]]));
+    registerCheermoteImageUrls(new Map());
+
+    expect(buildEmoteImageUrl("cheer:cheer/100")).toBe(
+      "https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/100/2.gif",
     );
   });
 });

--- a/src/lib/twitch/emotes.ts
+++ b/src/lib/twitch/emotes.ts
@@ -39,6 +39,22 @@ export interface EmoteSegment {
 export type MessageSegment = TextSegment | EmoteSegment;
 
 /**
+ * Cheermote(`cheer:` プレフィックス)の「`プレフィックス/ティア` → 画像 URL」対応表。
+ * Helix の Cheermotes API から取得した画像 URL を `src/store/cheermotes.ts` が
+ * `registerCheermoteImageUrls` で登録する。未登録の ID は静的 CDN URL にフォールバックする
+ * (Helix が利用できない場合の意図した仕様。issue #53)。
+ */
+let cheermoteImageUrls: ReadonlyMap<string, string> = new Map();
+
+/**
+ * Cheermote の画像 URL 対応表を登録する(全体を置き換える)。
+ * 空の Map を渡すと静的 CDN URL へのフォールバックに戻る(チャンネル切り替え時)。
+ */
+export function registerCheermoteImageUrls(urls: ReadonlyMap<string, string>): void {
+  cheermoteImageUrls = urls;
+}
+
+/**
  * プレフィックス付き ID(サードパーティ emote: `third-party-emotes.ts`、
  * Cheering Emote: `cheermotes.ts`)から各サービスの CDN URL を組み立てる関数の表。
  * theme / scale の指定には対応していないため、ライブチャット表示に適した
@@ -48,8 +64,11 @@ const PREFIXED_EMOTE_URL_BUILDERS: Record<string, (id: string) => string> = {
   bttv: (id) => `https://cdn.betterttv.net/emote/${id}/2x`,
   ffz: (id) => `https://cdn.frankerfacez.com/emote/${id}/2`,
   "7tv": (id) => `https://cdn.7tv.app/emote/${id}/2x.webp`,
-  // Cheering Emote(cheermotes.ts): `cheer:{プレフィックス}/{ティア}` 形式の ID から静的 CDN URL を組み立てる
+  // Cheering Emote(cheermotes.ts): `cheer:{プレフィックス}/{ティア}` 形式の ID。
+  // API 由来の登録済み URL を優先し、未登録なら静的 CDN URL を組み立てる
   cheer: (id) => {
+    const registered = cheermoteImageUrls.get(id);
+    if (registered !== undefined) return registered;
     const [name, tier] = id.split("/");
     return `https://d3aqoihi2n8ty8.cloudfront.net/actions/${name}/dark/animated/${tier}/2.gif`;
   },

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -44,6 +44,22 @@ vi.mock("./third-party-emotes", () => ({
   getThirdPartyEmoteMap: () => fakeThirdPartyEmoteMap,
 }));
 
+// Cheermote 一覧の読み込みも実 API(Helix プロキシ)を呼ぶため、ストア連携だけをモックで検証する。
+// getCheermoteSet は静的一覧を返し、既存の Cheermote 合成テストは静的一覧の挙動で検証する
+const mockLoadCheermotes = vi.fn();
+const mockClearCheermotes = vi.fn();
+
+vi.mock("./cheermotes", async () => {
+  const { STATIC_CHEERMOTE_SET } = await vi.importActual<typeof import("@/lib/twitch/cheermotes")>(
+    "@/lib/twitch/cheermotes",
+  );
+  return {
+    loadCheermotes: (roomId: string) => mockLoadCheermotes(roomId),
+    clearCheermotes: () => mockClearCheermotes(),
+    getCheermoteSet: () => STATIC_CHEERMOTE_SET,
+  };
+});
+
 import { resetBotFilterStoreForTests, useBotFilterStore } from "./bot-filter";
 import { resetChatConnectionStoreForTests, subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
 
@@ -77,6 +93,8 @@ afterEach(() => {
   mockDisconnect.mockClear();
   mockLoadThirdPartyEmotes.mockClear();
   mockClearThirdPartyEmotes.mockClear();
+  mockLoadCheermotes.mockClear();
+  mockClearCheermotes.mockClear();
   fakeThirdPartyEmoteMap = new Map();
   window.localStorage.clear();
 });
@@ -299,5 +317,51 @@ describe("Cheering Emote(Cheermote)", () => {
     const expected = [{ id: "cheer:cheer/100", start: 0, end: 4 }];
     expect(useChatConnectionStore.getState().messages[0].emotes).toEqual(expected);
     expect(received[0].emotes).toEqual(expected);
+  });
+});
+
+describe("Cheermote 一覧(Helix Cheermotes API)", () => {
+  it("roomstate イベントを受信すると、room-id を使って Cheermote 一覧の読み込みを開始する", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onEvent({
+      type: "roomstate",
+      channel: "zackrawrr",
+      state: {
+        emoteOnly: false,
+        followersOnlyMinutes: null,
+        r9k: false,
+        slowSeconds: 0,
+        subsOnly: false,
+        roomId: "552120296",
+      },
+    });
+
+    expect(mockLoadCheermotes).toHaveBeenCalledWith("552120296");
+  });
+
+  it("room-id が無い roomstate では読み込みを開始しない", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onEvent({
+      type: "roomstate",
+      channel: "zackrawrr",
+      state: {
+        emoteOnly: false,
+        followersOnlyMinutes: null,
+        r9k: false,
+        slowSeconds: 0,
+        subsOnly: false,
+        roomId: null,
+      },
+    });
+
+    expect(mockLoadCheermotes).not.toHaveBeenCalled();
+  });
+
+  it("connect() を呼ぶと、前のチャンネルの Cheermote 一覧をクリアする", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(mockClearCheermotes).toHaveBeenCalled();
   });
 });

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -30,6 +30,7 @@ import { mergeThirdPartyEmotePositions } from "@/lib/twitch/third-party-emotes";
 import { matchesBotFilter } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
 import { clearThirdPartyEmotes, getThirdPartyEmoteMap, loadThirdPartyEmotes } from "./third-party-emotes";
+import { clearCheermotes, getCheermoteSet, loadCheermotes } from "./cheermotes";
 
 /** チャットに表示する発言の最大保持件数(古いものから捨てるリングバッファ) */
 const MAX_DISPLAYED_MESSAGES = 300;
@@ -59,8 +60,12 @@ function getClient(): TwitchIrcClient {
       onStateChange: (state) => useChatConnectionStore.setState({ connectionState: state }),
       onEvent: (event) => {
         if (event.type === "roomstate") {
-          // room-id(配信者の Twitch ユーザー ID)が判明した時点でサードパーティ emote を読み込む
-          if (event.state.roomId !== null) void loadThirdPartyEmotes(event.state.roomId);
+          // room-id(配信者の Twitch ユーザー ID)が判明した時点で
+          // サードパーティ emote と Cheermote 一覧(Helix)を読み込む
+          if (event.state.roomId !== null) {
+            void loadThirdPartyEmotes(event.state.roomId);
+            void loadCheermotes(event.state.roomId);
+          }
           return;
         }
         if (event.type !== "privmsg") return;
@@ -72,6 +77,7 @@ function getClient(): TwitchIrcClient {
           event.message.text,
           event.message.emotes,
           event.message.bits,
+          getCheermoteSet(),
         );
         const message: TwitchChatMessage = {
           ...event.message,
@@ -96,8 +102,10 @@ export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
   messages: [],
   channel: null,
   connect: (channel) => {
-    // 前のチャンネルのサードパーティ emote 対応表を持ち越さない(ROOMSTATE 受信後に再読み込みされる)
+    // 前のチャンネルのサードパーティ emote 対応表・Cheermote 一覧を持ち越さない
+    // (ROOMSTATE 受信後に再読み込みされる)
     clearThirdPartyEmotes();
+    clearCheermotes();
     set({ messages: [], channel: normalizeChannelName(channel) });
     getClient().connect(channel);
   },

--- a/src/store/cheermotes.test.ts
+++ b/src/store/cheermotes.test.ts
@@ -84,6 +84,26 @@ describe("loadCheermotes", () => {
     expect(getCheermoteSet()).toBe(STATIC_CHEERMOTE_SET);
   });
 
+  it("別チャンネルの読み込みが先に完了した後、古いチャンネルの結果が遅れて届いても上書きしない", async () => {
+    // ROOMSTATE が別チャンネルで連続した場合(clearCheermotes を挟まないケース)のレース対策
+    let resolveOldFetch: (set: CheermoteSet | null) => void = () => {};
+    const oldSet: CheermoteSet = new Map([
+      ["oldcustom", [{ minBits: 1, imageUrl: "https://example.com/oldcustom/1/2.gif" }]],
+    ]);
+    const fetchOld = vi.fn(
+      () => new Promise<CheermoteSet | null>((resolve) => (resolveOldFetch = resolve)),
+    );
+    const fetchNew = vi.fn(async () => FAKE_CHEERMOTE_SET);
+
+    const oldLoading = loadCheermotes("11111", fetchOld);
+    await loadCheermotes("22222", fetchNew);
+    resolveOldFetch(oldSet);
+    await oldLoading;
+
+    expect(getCheermoteSet()).toBe(FAKE_CHEERMOTE_SET);
+    expect(buildEmoteImageUrl("cheer:mycustom/1")).toBe("https://example.com/mycustom/1/2.gif");
+  });
+
   it("clearCheermotes すると静的一覧・静的 CDN URL に戻り、同じ ID でも再読み込みできる", async () => {
     const fetchSet = vi.fn(async () => FAKE_CHEERMOTE_SET);
 

--- a/src/store/cheermotes.test.ts
+++ b/src/store/cheermotes.test.ts
@@ -1,0 +1,103 @@
+/**
+ * src/store/cheermotes.ts(Cheermote 一覧のモジュールスコープ保持)のテスト。
+ *
+ * ROOMSTATE で判明した配信者の Twitch ID から Helix の Cheermotes API 経由で
+ * Cheermote 一覧(グローバル + チャンネル独自)を読み込み、`chat-connection.ts` が
+ * 発言受信時に同期的に参照できる一覧として保持する流れと、
+ * Helix が利用できない場合の静的一覧へのフォールバックを検証する。
+ * 実際の API 呼び出しは行わず、フェイクの読み込み関数を注入する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { STATIC_CHEERMOTE_SET, type CheermoteSet } from "@/lib/twitch/cheermotes";
+import { buildEmoteImageUrl } from "@/lib/twitch/emotes";
+import { clearCheermotes, getCheermoteSet, loadCheermotes, resetCheermotesForTests } from "./cheermotes";
+
+afterEach(() => {
+  resetCheermotesForTests();
+});
+
+/** テスト用の Cheermote 一覧(チャンネル独自 Cheermote を1件含む) */
+const FAKE_CHEERMOTE_SET: CheermoteSet = new Map([
+  [
+    "cheer",
+    [
+      { minBits: 100, imageUrl: "https://example.com/cheer/100/2.gif" },
+      { minBits: 1, imageUrl: "https://example.com/cheer/1/2.gif" },
+    ],
+  ],
+  ["mycustom", [{ minBits: 1, imageUrl: "https://example.com/mycustom/1/2.gif" }]],
+]);
+
+describe("loadCheermotes", () => {
+  it("未読み込みの間は静的一覧(STATIC_CHEERMOTE_SET)を返す", () => {
+    expect(getCheermoteSet()).toBe(STATIC_CHEERMOTE_SET);
+  });
+
+  it("読み込んだ一覧を getCheermoteSet で参照できる", async () => {
+    const fetchSet = vi.fn(async () => FAKE_CHEERMOTE_SET);
+
+    await loadCheermotes("12345", fetchSet);
+
+    expect(fetchSet).toHaveBeenCalledWith("12345");
+    expect(getCheermoteSet()).toBe(FAKE_CHEERMOTE_SET);
+  });
+
+  it("読み込み成功後は buildEmoteImageUrl が API の画像 URL を返す(レジストリへの登録)", async () => {
+    await loadCheermotes("12345", async () => FAKE_CHEERMOTE_SET);
+
+    expect(buildEmoteImageUrl("cheer:mycustom/1")).toBe("https://example.com/mycustom/1/2.gif");
+    expect(buildEmoteImageUrl("cheer:cheer/100")).toBe("https://example.com/cheer/100/2.gif");
+  });
+
+  it("同じ Twitch ID の2回目の読み込みは行わない(ROOMSTATE は再接続などで複数回届く)", async () => {
+    const fetchSet = vi.fn(async () => FAKE_CHEERMOTE_SET);
+
+    await loadCheermotes("12345", fetchSet);
+    await loadCheermotes("12345", fetchSet);
+
+    expect(fetchSet).toHaveBeenCalledTimes(1);
+  });
+
+  it("読み込みに失敗(null)した場合は静的一覧のまま、同じ ID で再試行できる", async () => {
+    const fetchSet = vi.fn(async () => null);
+
+    await loadCheermotes("12345", fetchSet);
+
+    expect(getCheermoteSet()).toBe(STATIC_CHEERMOTE_SET);
+
+    await loadCheermotes("12345", fetchSet);
+
+    expect(fetchSet).toHaveBeenCalledTimes(2);
+  });
+
+  it("読み込み完了前に clearCheermotes された場合は結果を破棄する(チャンネル切り替え)", async () => {
+    let resolveFetch: (set: CheermoteSet | null) => void = () => {};
+    const fetchSet = vi.fn(
+      () => new Promise<CheermoteSet | null>((resolve) => (resolveFetch = resolve)),
+    );
+
+    const loading = loadCheermotes("12345", fetchSet);
+    clearCheermotes();
+    resolveFetch(FAKE_CHEERMOTE_SET);
+    await loading;
+
+    expect(getCheermoteSet()).toBe(STATIC_CHEERMOTE_SET);
+  });
+
+  it("clearCheermotes すると静的一覧・静的 CDN URL に戻り、同じ ID でも再読み込みできる", async () => {
+    const fetchSet = vi.fn(async () => FAKE_CHEERMOTE_SET);
+
+    await loadCheermotes("12345", fetchSet);
+    clearCheermotes();
+
+    expect(getCheermoteSet()).toBe(STATIC_CHEERMOTE_SET);
+    expect(buildEmoteImageUrl("cheer:cheer/100")).toBe(
+      "https://d3aqoihi2n8ty8.cloudfront.net/actions/cheer/dark/animated/100/2.gif",
+    );
+
+    await loadCheermotes("12345", fetchSet);
+
+    expect(fetchSet).toHaveBeenCalledTimes(2);
+    expect(getCheermoteSet()).toBe(FAKE_CHEERMOTE_SET);
+  });
+});

--- a/src/store/cheermotes.ts
+++ b/src/store/cheermotes.ts
@@ -27,7 +27,7 @@ import { registerCheermoteImageUrls } from "@/lib/twitch/emotes";
 let cheermoteSet: CheermoteSet = STATIC_CHEERMOTE_SET;
 /** 読み込み済み(または読み込み中)の Twitch ユーザー ID。未読み込みなら null */
 let loadedRoomId: string | null = null;
-/** クリアのたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
+/** クリア・読み込み開始のたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
 let generation = 0;
 
 /** 現在の Cheermote 一覧を返す。未読み込み・クリア直後は静的一覧(STATIC_CHEERMOTE_SET) */
@@ -46,7 +46,9 @@ export async function loadCheermotes(
 ): Promise<void> {
   if (loadedRoomId === roomId) return;
   loadedRoomId = roomId;
-  const requestGeneration = generation;
+  // 世代番号を進めてから控える。別チャンネルの読み込みを新しく開始した時点で
+  // 進行中の古い読み込みを無効化し、遅れて届いた結果による上書きを防ぐ
+  const requestGeneration = ++generation;
 
   const set = await fetchSet(roomId);
 

--- a/src/store/cheermotes.ts
+++ b/src/store/cheermotes.ts
@@ -1,0 +1,77 @@
+/**
+ * Cheermote 一覧(グローバル + チャンネル独自)を保持するモジュールスコープのストア。
+ *
+ * `chat-connection.ts` が ROOMSTATE の `room-id`(配信者の Twitch ユーザー ID)を受け取った時点で
+ * `loadCheermotes` を呼び、以降の発言受信時に `getCheermoteSet` で同期的に参照する。
+ * 発言の受信は高頻度なため、一覧は React の state ではなくモジュールスコープに置き、
+ * 受信ハンドラから直接読めるようにする(`third-party-emotes.ts` と同じ方針)。
+ *
+ * - 読み込み成功時は `emotes.ts` の `registerCheermoteImageUrls` にも画像 URL を登録し、
+ *   `buildEmoteImageUrl` が Helix API 由来の画像 URL を返せるようにする
+ * - Helix が利用できない場合(`fetchCheermoteSet` が null)は静的一覧
+ *   `STATIC_CHEERMOTE_SET` のまま動作する(意図したフォールバック。issue #53)。
+ *   一時的な失敗の可能性があるため、次の ROOMSTATE で再試行できるように未読み込み状態へ戻す
+ * - 同じ Twitch ID への読み込みは 1 回だけ行う(ROOMSTATE は再接続などで複数回届く)
+ * - チャンネル切り替え(`connect()`)時は `clearCheermotes` で一覧を破棄し、
+ *   読み込み途中だった前チャンネルの結果は世代番号の比較で捨てる
+ */
+import {
+  STATIC_CHEERMOTE_SET,
+  buildCheermoteImageUrlMap,
+  fetchCheermoteSet,
+  type CheermoteSet,
+} from "@/lib/twitch/cheermotes";
+import { registerCheermoteImageUrls } from "@/lib/twitch/emotes";
+
+/** 現在の Cheermote 一覧。未読み込み・クリア直後・読み込み失敗時は静的一覧 */
+let cheermoteSet: CheermoteSet = STATIC_CHEERMOTE_SET;
+/** 読み込み済み(または読み込み中)の Twitch ユーザー ID。未読み込みなら null */
+let loadedRoomId: string | null = null;
+/** クリアのたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
+let generation = 0;
+
+/** 現在の Cheermote 一覧を返す。未読み込み・クリア直後は静的一覧(STATIC_CHEERMOTE_SET) */
+export function getCheermoteSet(): CheermoteSet {
+  return cheermoteSet;
+}
+
+/**
+ * 指定した配信者の Twitch ユーザー ID で Cheermote 一覧を読み込む。
+ * 同じ ID で読み込み済み(読み込み中を含む)の場合は何もしない。
+ * 読み込みに失敗した場合は静的一覧のまま、次の ROOMSTATE で再試行できる状態に戻す。
+ */
+export async function loadCheermotes(
+  roomId: string,
+  fetchSet: (broadcasterId: string) => Promise<CheermoteSet | null> = fetchCheermoteSet,
+): Promise<void> {
+  if (loadedRoomId === roomId) return;
+  loadedRoomId = roomId;
+  const requestGeneration = generation;
+
+  const set = await fetchSet(roomId);
+
+  // 読み込み中にチャンネルが切り替わっていたら(クリア済みなら)、前チャンネルの結果は捨てる
+  if (generation !== requestGeneration) return;
+
+  if (set === null) {
+    // Helix 利用不可・一時的な失敗: 静的一覧のまま、次の ROOMSTATE で再試行できるようにする
+    loadedRoomId = null;
+    return;
+  }
+
+  cheermoteSet = set;
+  registerCheermoteImageUrls(buildCheermoteImageUrlMap(set));
+}
+
+/** 一覧を静的一覧・静的 CDN URL に戻して未読み込み状態にする。チャンネル切り替え時に呼ぶ */
+export function clearCheermotes(): void {
+  generation += 1;
+  cheermoteSet = STATIC_CHEERMOTE_SET;
+  loadedRoomId = null;
+  registerCheermoteImageUrls(new Map());
+}
+
+/** テスト専用: モジュールスコープの状態を初期状態に戻す。各テストの afterEach で呼び出すこと */
+export function resetCheermotesForTests(): void {
+  clearCheermotes();
+}


### PR DESCRIPTION
## Summary

PR #51 で静的一覧として保持していたグローバル Cheermote のプレフィックスを、Helix の Cheermotes API(`GET /bits/cheermotes?broadcaster_id=`)の取得結果に置き換えます。これによりチャンネル独自 Cheermote に対応し、CDN 側の変化(BibleThump / EleGiggle の画像消失のような事象)にも自動追従します。

## 変更内容

- **`src/lib/twitch/cheermotes.ts`**: Helix プロキシ(#55)経由で Cheermote 一覧(グローバル + チャンネル独自)を取得する `fetchCheermoteSet` / `parseCheermoteSet` を実装しました。`mergeCheermotePositions` は静的プレフィックス一覧の代わりに取得結果(`CheermoteSet`)を受け取り、ティアも API の `min_bits` から解決します(チャンネル独自のティア構成に対応)。トークン検出・位置合成ロジックは流用しています
- **`src/lib/twitch/emotes.ts`**: 画像 URL は API レスポンスの `images`(dark / animated / 2x)を使用します。`registerCheermoteImageUrls` で登録された対応表を `buildEmoteImageUrl` が優先し、未登録時は既存の静的 CDN URL の組み立てにフォールバックします
- **`src/store/cheermotes.ts`(新規)**: ROOMSTATE の room-id を契機に読み込むモジュールスコープストアです(`src/store/third-party-emotes.ts` と同方式)。チャンネル切り替え(`connect()`)でクリアし、読み込み途中の前チャンネルの結果は世代番号の比較で破棄します
- **`src/store/chat-connection.ts`**: ROOMSTATE 受信時の `loadCheermotes`・`connect()` 時の `clearCheermotes` を配線しました

## Helix が利用できない場合の仕様

Helix 未設定(プロキシが 503)・障害・ネットワークエラーの場合、`fetchCheermoteSet` は null を返し、既存の静的一覧 `STATIC_CHEERMOTE_SET`(グローバル Cheermote + 静的 CDN URL)にフォールバックします(意図した仕様)。一時的な失敗の可能性があるため、次の ROOMSTATE で再試行できるように未読み込み状態へ戻します。

## テスト

- 541 件すべてパス(Lint 警告ゼロ・型チェック・ビルド成功)
- CodeRabbit レビューを実施し、指摘 1 件(別チャンネルの読み込みが遅れて完了した際に新しい一覧を上書きするレース)に対応済みです

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH