### PR TITLE
fix: loadThirdPartyEmotes に別チャンネルの古い読み込み結果が新しい対応表を上書きするレースを修正

### DIFF
--- a/src/store/third-party-emotes.test.ts
+++ b/src/store/third-party-emotes.test.ts
@@ -50,6 +50,23 @@ describe("loadThirdPartyEmotes", () => {
     expect(getThirdPartyEmoteMap().size).toBe(0);
   });
 
+  it("別チャンネルの読み込みが先に完了した後、古いチャンネルの結果が遅れて届いても上書きしない", async () => {
+    // ROOMSTATE が別チャンネルで連続した場合(clearThirdPartyEmotes を挟まないケース)のレース対策
+    let resolveOldFetch: (map: Map<string, string>) => void = () => {};
+    const fetchOld = vi.fn(
+      () => new Promise<Map<string, string>>((resolve) => (resolveOldFetch = resolve)),
+    );
+    const fetchNew = vi.fn(async () => new Map([["newPog", "7tv:new1"]]));
+
+    const oldLoading = loadThirdPartyEmotes("11111", fetchOld);
+    await loadThirdPartyEmotes("22222", fetchNew);
+    resolveOldFetch(new Map([["oldKEKW", "bttv:old1"]]));
+    await oldLoading;
+
+    expect(getThirdPartyEmoteMap().get("newPog")).toBe("7tv:new1");
+    expect(getThirdPartyEmoteMap().has("oldKEKW")).toBe(false);
+  });
+
   it("clearThirdPartyEmotes すると対応表が空になり、同じ ID でも再読み込みできる", async () => {
     const fetchEmoteMap = vi.fn(async () => new Map([["catJAM", "bttv:g1"]]));
 

--- a/src/store/third-party-emotes.ts
+++ b/src/store/third-party-emotes.ts
@@ -16,7 +16,7 @@ import { fetchThirdPartyEmoteMap } from "@/lib/twitch/third-party-emotes";
 let emoteMap: ReadonlyMap<string, string> = new Map();
 /** 読み込み済み(または読み込み中)の Twitch ユーザー ID。未読み込みなら null */
 let loadedRoomId: string | null = null;
-/** クリアのたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
+/** クリア・読み込み開始のたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
 let generation = 0;
 
 /** 現在の対応表を返す。未読み込み・クリア直後は空の Map */
@@ -34,7 +34,9 @@ export async function loadThirdPartyEmotes(
 ): Promise<void> {
   if (loadedRoomId === roomId) return;
   loadedRoomId = roomId;
-  const requestGeneration = generation;
+  // 世代番号を進めてから控える。別チャンネルの読み込みを新しく開始した時点で
+  // 進行中の古い読み込みを無効化し、遅れて届いた結果による上書きを防ぐ
+  const requestGeneration = ++generation;
 
   const map = await fetchEmoteMap(roomId);
 


### PR DESCRIPTION
## Summary

`src/store/third-party-emotes.ts:37(loadThirdPartyEmotes)` において、`clearThirdPartyEmotes` を挟まずに別チャンネルの ROOMSTATE が連続して届いた場合に、先に開始した古いチャンネルの読み込みが遅れて完了すると世代チェックを通過し、新しいチャンネルの対応表を上書きするレース条件を修正しました。

## 変更内容

- `src/store/third-party-emotes.ts:40(requestGeneration)`: `const requestGeneration = generation;` を `const requestGeneration = ++generation;` に変更し、別チャンネルの読み込みを新しく開始した時点で進行中の古い読み込みを無効化しました(PR #56 の `src/store/cheermotes.ts:53(loadCheermotes)` と同じ修正方式です)
- `src/store/third-party-emotes.test.ts:54(レーステスト)`: deferred-promise を用いて「別チャンネルの読み込みが先に完了した後、古いチャンネルの結果が遅れて届いても上書きしない」ことを検証するテストを追加しました(TDD: RED → GREEN で実施)

## テスト

- `npm test`: 576 件すべて成功
- `npm run lint` / `npm run type-check` / `npm run build`: エラーなし
- CodeRabbit レビュー: 指摘 0 件

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH