### PR TITLE
feat: チャンネル名入力にオートコンプリートを追加する(Helix /search/channels)

### DIFF
--- a/src/app/api/twitch/[...path]/route.test.ts
+++ b/src/app/api/twitch/[...path]/route.test.ts
@@ -75,6 +75,16 @@ describe("GET /api/twitch/[...path]", () => {
     expect(headers.get("Client-Id")).toBe("test-client-id");
   });
 
+  it("チャンネル検索(search/channels)も中継できる", async () => {
+    fetchMock.mockResolvedValueOnce(helixResponse({ data: [] }));
+
+    const response = await callGet(["search", "channels"], "?query=zack");
+
+    expect(response.status).toBe(200);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("https://api.twitch.tv/helix/search/channels?query=zack");
+  });
+
   it("複数セグメントのエンドポイント(bits/cheermotes)も中継できる", async () => {
     fetchMock.mockResolvedValueOnce(helixResponse({ data: [] }));
 

--- a/src/app/api/twitch/[...path]/route.ts
+++ b/src/app/api/twitch/[...path]/route.ts
@@ -34,6 +34,7 @@ const ALLOWED_ENDPOINTS: ReadonlySet<string> = new Set([
   "channels",
   "bits/cheermotes",
   "chat/emotes",
+  "search/channels",
 ]);
 
 /** エラーレスポンス(JSON)を組み立てる */

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -47,6 +47,13 @@ vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
   runBrowserDiagnosis: () => new Promise(() => {}),
 }));
 
+// チャンネル名のオートコンプリート(issue #59)の候補取得はネットワークに触れるためモックする。
+// null = Helix 利用不可(候補なし)として、ここでは手入力だけの動作を検証する
+vi.mock("@/lib/twitch/channel-search", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/twitch/channel-search")>()),
+  fetchChannelSuggestions: () => Promise.resolve(null),
+}));
+
 import Home from "./page";
 
 const サンプル発言: TwitchChatMessage = {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,10 +34,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronsDownIcon, EyeIcon, EyeOffIcon } from "lucide-react";
 import { BotFilterDialog } from "@/components/bot-filter-dialog";
+import { ChannelAutocompleteInput } from "@/components/channel-autocomplete";
 import { ExplanationLanguageDialog, LearningLanguagesDialog } from "@/components/language-dialogs";
 import { SettingsDialog } from "@/components/settings-dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -197,11 +197,11 @@ export default function Home() {
         <div className="flex flex-col gap-1.5">
           <Label htmlFor="channel-input">Channel</Label>
           <div className="flex items-center gap-2">
-            <Input
+            <ChannelAutocompleteInput
               id="channel-input"
               placeholder="e.g. zackrawrr"
               value={channelInput}
-              onChange={(e) => setChannelInput(e.target.value)}
+              onValueChange={setChannelInput}
               disabled={connected}
             />
             {connected ? (

--- a/src/components/channel-autocomplete.test.tsx
+++ b/src/components/channel-autocomplete.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * src/components/channel-autocomplete.tsx(チャンネル名入力のオートコンプリート)のテスト。
+ *
+ * 入力のデバウンス後に候補を取得してドロップダウン表示すること、クリック・キーボード操作で
+ * 候補を選択して入力を確定できること、IME 変換中の Enter では選択しないこと、
+ * Helix が利用できない場合(取得結果 null)は候補を出さず手入力だけで動作することを検証する。
+ * チャンネル検索(`fetchChannelSuggestions`)はフェイクを注入し、実際の API 呼び出しは行わない。
+ * デバウンスの経過はフェイクタイマーで進める(userEvent はフェイクタイマーと相性が悪いため
+ * fireEvent で入力・キー操作を再現する)。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import type { ChannelSuggestion } from "@/lib/twitch/channel-search";
+import { ChannelAutocompleteInput, SUGGESTION_DEBOUNCE_MS } from "./channel-autocomplete";
+import { useState } from "react";
+
+/** 検索結果のサンプル候補 */
+const サンプル候補: ChannelSuggestion[] = [
+  { login: "zackrawrr", displayName: "ZackRawrr", isLive: true },
+  { login: "zackfair", displayName: "ザックス", isLive: false },
+];
+
+/** 親(ホーム画面)と同じく value を state で制御するテスト用ラッパー */
+function ControlledInput({
+  fetchSuggestions,
+}: {
+  fetchSuggestions: (query: string, options: { signal?: AbortSignal }) => Promise<ChannelSuggestion[] | null>;
+}) {
+  const [value, setValue] = useState("");
+  return (
+    <ChannelAutocompleteInput
+      id="channel-input"
+      aria-label="Channel"
+      value={value}
+      onValueChange={setValue}
+      fetchSuggestions={fetchSuggestions}
+    />
+  );
+}
+
+/** 入力欄に文字列を入力する(change イベント) */
+function typeInto(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+}
+
+/** デバウンス時間を経過させ、取得の Promise を解決させる */
+async function advanceDebounce() {
+  await act(async () => {
+    vi.advanceTimersByTime(SUGGESTION_DEBOUNCE_MS);
+    // fetchSuggestions の Promise 解決(マイクロタスク)を消化する
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ChannelAutocompleteInput", () => {
+  it("入力からデバウンス経過後に候補を取得し、ドロップダウンに login・表示名・ライブ状態を表示する", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    typeInto(screen.getByLabelText("Channel"), "zack");
+    await advanceDebounce();
+
+    expect(fetchSuggestions).toHaveBeenCalledTimes(1);
+    expect(fetchSuggestions).toHaveBeenCalledWith("zack", { signal: expect.any(AbortSignal) });
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveTextContent("zackrawrr");
+    expect(options[0]).toHaveTextContent("LIVE");
+    expect(options[1]).toHaveTextContent("zackfair");
+    expect(options[1]).toHaveTextContent("ザックス");
+    expect(options[1]).not.toHaveTextContent("LIVE");
+  });
+
+  it("連続入力ではデバウンスされ、最後の入力文字列で1回だけ取得する", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    for (const partial of ["z", "za", "zac", "zack", "zackr"]) {
+      typeInto(input, partial);
+      // デバウンス時間内(半分だけ経過)に次の入力が続く
+      act(() => vi.advanceTimersByTime(SUGGESTION_DEBOUNCE_MS / 2));
+    }
+    await advanceDebounce();
+
+    expect(fetchSuggestions).toHaveBeenCalledTimes(1);
+    expect(fetchSuggestions).toHaveBeenCalledWith("zackr", { signal: expect.any(AbortSignal) });
+  });
+
+  it("候補のクリック(mousedown)で入力値が login に確定し、ドロップダウンが閉じる", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    typeInto(screen.getByLabelText("Channel"), "zack");
+    await advanceDebounce();
+    fireEvent.mouseDown(screen.getAllByRole("option")[1]);
+
+    expect(screen.getByLabelText("Channel")).toHaveValue("zackfair");
+    expect(screen.queryByRole("listbox")).toBeNull();
+    // 選択による値の変化では再取得しない
+    await advanceDebounce();
+    expect(fetchSuggestions).toHaveBeenCalledTimes(1);
+  });
+
+  it("ArrowDown で候補を選び、Enter で入力値に確定できる", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    typeInto(input, "zack");
+    await advanceDebounce();
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(input).toHaveValue("zackfair");
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("IME 変換中(isComposing)の Enter では候補を確定しない", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    typeInto(input, "zack");
+    await advanceDebounce();
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter", isComposing: true });
+
+    // 変換確定の Enter なので入力値はそのまま・ドロップダウンも開いたまま
+    expect(input).toHaveValue("zack");
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+  });
+
+  it("Escape でドロップダウンを閉じる", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    typeInto(input, "zack");
+    await advanceDebounce();
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("入力欄からフォーカスが外れたらドロップダウンを閉じる", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    typeInto(input, "zack");
+    await advanceDebounce();
+    fireEvent.blur(input);
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("取得結果が null(Helix 利用不可)の場合は候補を表示せず、手入力だけで動作する", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(null);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    typeInto(screen.getByLabelText("Channel"), "zack");
+    await advanceDebounce();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(screen.getByLabelText("Channel")).toHaveValue("zack");
+  });
+
+  it("空(空白のみ)の入力では候補を取得しない", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    typeInto(screen.getByLabelText("Channel"), "  ");
+    await advanceDebounce();
+
+    expect(fetchSuggestions).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+
+  it("入力を空に戻すとドロップダウンを閉じ、取得もしない", async () => {
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ControlledInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    typeInto(input, "zack");
+    await advanceDebounce();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    typeInto(input, "");
+    await advanceDebounce();
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+    expect(fetchSuggestions).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/channel-autocomplete.tsx
+++ b/src/components/channel-autocomplete.tsx
@@ -1,0 +1,186 @@
+/**
+ * チャンネル名入力のオートコンプリート(issue #59)。
+ *
+ * ホーム画面(`src/app/page.tsx`)の Channel 入力欄として使う。入力文字列を
+ * デバウンスしてチャンネル検索(`src/lib/twitch/channel-search.ts`)へ問い合わせ、
+ * 候補(login・表示名・ライブ状態)をドロップダウンに表示する。
+ * 候補の選択(クリック・ArrowDown/ArrowUp + Enter)で入力値を login に確定する。
+ *
+ * - 入力の変化ごとに前のリクエストを AbortController で中断する(遅れて届いた
+ *   古い結果による上書きも防ぐ)
+ * - IME 変換確定の Enter(`isComposing`)では候補を確定しない
+ * - Helix が利用できない場合(取得結果 null)・候補ゼロの場合はドロップダウンを
+ *   表示せず、現行どおり手入力だけで動作する(意図した仕様)
+ * - value は親が制御する(接続時の値の利用・接続中の無効化は親の責務)
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { fetchChannelSuggestions, type ChannelSuggestion } from "@/lib/twitch/channel-search";
+
+/** 入力からチャンネル検索までのデバウンス時間(ミリ秒) */
+export const SUGGESTION_DEBOUNCE_MS = 300;
+
+/** ドロップダウンのリストの id(aria-controls と対応させる) */
+const LISTBOX_ID = "channel-suggestion-listbox";
+
+/** 候補 1 件の option 要素の id(aria-activedescendant と対応させる) */
+function optionId(index: number): string {
+  return `channel-suggestion-option-${index}`;
+}
+
+export function ChannelAutocompleteInput({
+  value,
+  onValueChange,
+  fetchSuggestions = fetchChannelSuggestions,
+  ...inputProps
+}: {
+  /** 入力値(親が制御する) */
+  value: string;
+  /** 手入力・候補の選択による入力値の変化 */
+  onValueChange: (value: string) => void;
+  /** チャンネル検索(テストではフェイクを注入する) */
+  fetchSuggestions?: (
+    query: string,
+    options: { signal?: AbortSignal },
+  ) => Promise<ChannelSuggestion[] | null>;
+} & Omit<React.ComponentProps<"input">, "value" | "onChange">) {
+  const [suggestions, setSuggestions] = useState<ChannelSuggestion[]>([]);
+  const [open, setOpen] = useState(false);
+  /** キーボードで選択中の候補の位置。未選択は -1 */
+  const [activeIndex, setActiveIndex] = useState(-1);
+  /** 候補の選択で value を変えた直後は true にし、その変化による再検索を抑止する */
+  const skipNextSearchRef = useRef(false);
+
+  // 入力の変化をデバウンスして候補を検索する。次の入力・アンマウントでタイマーと
+  // 進行中のリクエストを破棄するため、古い結果が後から表示されることはない
+  useEffect(() => {
+    if (skipNextSearchRef.current) {
+      skipNextSearchRef.current = false;
+      return;
+    }
+    // 空入力時のクリアは handleInputChange(イベントハンドラ)で行うため、ここでは検索しないだけでよい
+    const query = value.trim();
+    if (query === "") return;
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => {
+      void (async () => {
+        const result = await fetchSuggestions(query, { signal: controller.signal });
+        if (controller.signal.aborted) return;
+        // null(Helix 利用不可)・候補ゼロはドロップダウンを出さない(手入力だけで動作する)
+        setSuggestions(result ?? []);
+        setOpen(result !== null && result.length > 0);
+        setActiveIndex(-1);
+      })();
+    }, SUGGESTION_DEBOUNCE_MS);
+
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [value, fetchSuggestions]);
+
+  /** 手入力による値の変化。空(空白のみ)になったらドロップダウンを閉じて候補を破棄する */
+  const handleInputChange = (next: string) => {
+    onValueChange(next);
+    if (next.trim() === "") {
+      setSuggestions([]);
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  };
+
+  /** 候補を入力値に確定してドロップダウンを閉じる */
+  const selectSuggestion = (suggestion: ChannelSuggestion) => {
+    skipNextSearchRef.current = true;
+    onValueChange(suggestion.login);
+    setSuggestions([]);
+    setOpen(false);
+    setActiveIndex(-1);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return;
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setActiveIndex((prev) => (prev + 1) % suggestions.length);
+        break;
+      case "ArrowUp":
+        event.preventDefault();
+        setActiveIndex((prev) => (prev <= 0 ? suggestions.length - 1 : prev - 1));
+        break;
+      case "Enter":
+        // IME 変換確定の Enter では候補を確定しない(@rules/ime-handling.md)
+        if (event.nativeEvent.isComposing) return;
+        if (activeIndex >= 0 && activeIndex < suggestions.length) {
+          event.preventDefault();
+          selectSuggestion(suggestions[activeIndex]);
+        }
+        break;
+      case "Escape":
+        event.preventDefault();
+        setOpen(false);
+        setActiveIndex(-1);
+        break;
+    }
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        {...inputProps}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={LISTBOX_ID}
+        aria-autocomplete="list"
+        aria-activedescendant={open && activeIndex >= 0 ? optionId(activeIndex) : undefined}
+        autoComplete="off"
+        value={value}
+        onChange={(e) => handleInputChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={() => setOpen(false)}
+      />
+      {open && (
+        <ul
+          id={LISTBOX_ID}
+          role="listbox"
+          aria-label="Channel suggestions"
+          className="absolute top-full left-0 z-20 mt-1 max-h-64 w-full min-w-48 overflow-y-auto rounded-lg border bg-popover p-1 text-popover-foreground shadow-md"
+        >
+          {suggestions.map((suggestion, index) => (
+            <li
+              key={suggestion.login}
+              id={optionId(index)}
+              role="option"
+              aria-selected={index === activeIndex}
+              className={cn(
+                "flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-sm",
+                index === activeIndex && "bg-accent text-accent-foreground",
+              )}
+              // フォーカスを入力欄に残したまま選択できるよう、blur を起こす mousedown で確定する
+              onMouseDown={(e) => {
+                e.preventDefault();
+                selectSuggestion(suggestion);
+              }}
+              onMouseEnter={() => setActiveIndex(index)}
+            >
+              <span className="font-medium">{suggestion.login}</span>
+              {suggestion.displayName !== suggestion.login && (
+                <span className="truncate text-muted-foreground">{suggestion.displayName}</span>
+              )}
+              {suggestion.isLive && (
+                <span className="ml-auto shrink-0 rounded-sm bg-red-600 px-1 text-[10px] font-semibold text-white">
+                  LIVE
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/lib/twitch/channel-search.test.ts
+++ b/src/lib/twitch/channel-search.test.ts
@@ -1,0 +1,118 @@
+/**
+ * src/lib/twitch/channel-search.ts(チャンネル検索)のテスト。
+ *
+ * Helix の Search Channels API(`GET /search/channels?query=`)のレスポンスを
+ * チャンネル候補(login・表示名・ライブ状態)として解析する処理と、
+ * Next.js プロキシ(`/api/twitch/search/channels`)経由の取得を検証する。
+ * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fetchChannelSuggestions, parseChannelSuggestions } from "./channel-search";
+
+/** Helix Search Channels API のレスポンス(検証に使う部分のみ) */
+function createHelixSearchJson(): unknown {
+  return {
+    data: [
+      {
+        broadcaster_login: "zackrawrr",
+        display_name: "ZackRawrr",
+        is_live: true,
+        game_name: "World of Warcraft",
+      },
+      {
+        broadcaster_login: "zackfair",
+        display_name: "ザックス",
+        is_live: false,
+        game_name: "",
+      },
+    ],
+  };
+}
+
+describe("parseChannelSuggestions", () => {
+  it("レスポンスから候補一覧(login・表示名・ライブ状態)を順序どおり取り出す", () => {
+    expect(parseChannelSuggestions(createHelixSearchJson())).toEqual([
+      { login: "zackrawrr", displayName: "ZackRawrr", isLive: true },
+      { login: "zackfair", displayName: "ザックス", isLive: false },
+    ]);
+  });
+
+  it("data が空の場合は空配列を返す", () => {
+    expect(parseChannelSuggestions({ data: [] })).toEqual([]);
+  });
+
+  it("login が無い項目・型が想定と異なる項目は読み飛ばす", () => {
+    const json = {
+      data: [
+        { display_name: "loginなし", is_live: false },
+        "文字列の項目",
+        { broadcaster_login: "valid_user", display_name: "ValidUser", is_live: false },
+      ],
+    };
+    expect(parseChannelSuggestions(json)).toEqual([
+      { login: "valid_user", displayName: "ValidUser", isLive: false },
+    ]);
+  });
+
+  it("display_name が無い項目は login を表示名として使う", () => {
+    const json = { data: [{ broadcaster_login: "no_display", is_live: true }] };
+    expect(parseChannelSuggestions(json)).toEqual([
+      { login: "no_display", displayName: "no_display", isLive: true },
+    ]);
+  });
+
+  it("data が配列でない・オブジェクトでない JSON は空配列を返す", () => {
+    expect(parseChannelSuggestions({ data: "壊れたレスポンス" })).toEqual([]);
+    expect(parseChannelSuggestions(null)).toEqual([]);
+  });
+});
+
+describe("fetchChannelSuggestions", () => {
+  it("プロキシへ query をエンコードして問い合わせ、候補一覧を返す", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createHelixSearchJson()), { status: 200 }),
+    );
+
+    const suggestions = await fetchChannelSuggestions("ざっく らー", { fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      "/api/twitch/search/channels?query=%E3%81%96%E3%81%A3%E3%81%8F%20%E3%82%89%E3%83%BC&first=8",
+      { signal: undefined },
+    );
+    expect(suggestions).toEqual([
+      { login: "zackrawrr", displayName: "ZackRawrr", isLive: true },
+      { login: "zackfair", displayName: "ザックス", isLive: false },
+    ]);
+  });
+
+  it("AbortSignal を fetch に引き渡す(入力の変化で前のリクエストを中断できる)", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+    const controller = new AbortController();
+
+    await fetchChannelSuggestions("zack", { fetchFn, signal: controller.signal });
+
+    expect(fetchFn).toHaveBeenCalledWith(expect.any(String), { signal: controller.signal });
+  });
+
+  it("HTTP エラー(Helix 未設定の 503 など)の場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Helix API が設定されていません" }), { status: 503 }),
+    );
+
+    expect(await fetchChannelSuggestions("zack", { fetchFn })).toBeNull();
+  });
+
+  it("ネットワークエラーの場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("network error"));
+
+    expect(await fetchChannelSuggestions("zack", { fetchFn })).toBeNull();
+  });
+
+  it("中断(AbortError)の場合はエラーを握りつぶして null を返す", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new DOMException("aborted", "AbortError"));
+
+    expect(await fetchChannelSuggestions("zack", { fetchFn })).toBeNull();
+  });
+});

--- a/src/lib/twitch/channel-search.ts
+++ b/src/lib/twitch/channel-search.ts
@@ -1,0 +1,78 @@
+/**
+ * チャンネル名入力のオートコンプリート用のチャンネル検索(issue #59)。
+ *
+ * Helix の Search Channels API(`GET /search/channels?query=`)を Next.js プロキシ
+ * (`/api/twitch/`)経由で呼び、入力文字列に一致するチャンネル候補
+ * (login・表示名・ライブ状態)を取得する。ホーム画面の Channel 入力欄
+ * (`src/components/channel-autocomplete.tsx`)がデバウンス付きで利用する。
+ *
+ * - 入力の変化で前のリクエストが不要になるため、`AbortSignal` を受け取って中断できるようにする
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害・ネットワークエラー・中断は
+ *   null を返し、候補なし(現行の手入力だけの動作)にフォールバックする(意図した仕様)
+ */
+
+/** チャンネル候補 1 件(Helix Search Channels API の 1 項目) */
+export interface ChannelSuggestion {
+  /** 接続に使うログイン名(Helix の `broadcaster_login`) */
+  login: string;
+  /** 表示名(Helix の `display_name`。日本語名など)。無ければ login と同じ値 */
+  displayName: string;
+  /** ライブ配信中か(Helix の `is_live`) */
+  isLive: boolean;
+}
+
+/** 1 回の検索で取得する候補の最大件数(Helix の `first` パラメータ) */
+const SUGGESTION_LIMIT = 8;
+
+/**
+ * Helix の Search Channels API レスポンス(`{data: [{broadcaster_login, display_name, is_live, ...}]}`)を
+ * 解析してチャンネル候補一覧を作る。API 側の仕様変更などで形式が想定と異なる項目は読み飛ばす。
+ */
+export function parseChannelSuggestions(json: unknown): ChannelSuggestion[] {
+  if (typeof json !== "object" || json === null) return [];
+  const data = (json as Record<string, unknown>).data;
+  if (!Array.isArray(data)) return [];
+
+  const suggestions: ChannelSuggestion[] = [];
+  for (const entry of data) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.broadcaster_login !== "string" || record.broadcaster_login === "") continue;
+
+    suggestions.push({
+      login: record.broadcaster_login,
+      displayName:
+        typeof record.display_name === "string" && record.display_name !== ""
+          ? record.display_name
+          : record.broadcaster_login,
+      isLive: record.is_live === true,
+    });
+  }
+  return suggestions;
+}
+
+/**
+ * Helix プロキシ(`/api/twitch/search/channels`)から、入力文字列に一致する
+ * チャンネル候補一覧を取得する。
+ *
+ * 取得できない場合は null を返す(呼び出し側は候補を表示しない。意図した仕様):
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害などの HTTP エラー
+ * - ネットワークエラー・`signal` による中断(AbortError)
+ */
+export async function fetchChannelSuggestions(
+  query: string,
+  options: { signal?: AbortSignal; fetchFn?: typeof fetch } = {},
+): Promise<ChannelSuggestion[] | null> {
+  const { signal, fetchFn = fetch } = options;
+  try {
+    const response = await fetchFn(
+      `/api/twitch/search/channels?query=${encodeURIComponent(query)}&first=${SUGGESTION_LIMIT}`,
+      { signal },
+    );
+    if (!response.ok) return null;
+    return parseChannelSuggestions(await response.json());
+  } catch {
+    // 中断(AbortError)・ネットワークエラーのいずれも候補なしとして扱う
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

Helix の `GET /search/channels` を使い、ホーム画面の Channel 入力欄にオートコンプリートを追加します。うろ覚えのチャンネル名でも接続しやすくします。

## 変更内容

- **Helix プロキシ**(`src/app/api/twitch/[...path]/route.ts`): `ALLOWED_ENDPOINTS` に `search/channels` を追加
- **チャンネル検索クライアント**(`src/lib/twitch/channel-search.ts` 新規): プロキシ経由で候補(login・表示名・ライブ状態)を取得。`AbortSignal` による中断に対応し、HTTP エラー・ネットワークエラー・中断は null(候補なし)を返す
- **オートコンプリート UI**(`src/components/channel-autocomplete.tsx` 新規):
  - 入力を 300ms デバウンスして検索し、入力の変化ごとに前のリクエストを中断
  - 候補ドロップダウン(クリック / ArrowDown・ArrowUp + Enter で確定、Escape・blur で閉じる)
  - IME 変換確定の Enter(`isComposing`)では確定しない
  - combobox / listbox / option の ARIA 属性を設定
- **ホーム画面**(`src/app/page.tsx`): Channel 入力欄を `ChannelAutocompleteInput` に置き換え
- Helix 利用不可(503 など)・候補ゼロの場合はドロップダウンを出さず、現行の手入力だけで動作します

## テスト

- `npm run lint` / `npm run type-check` / `npm test`(597 件)/ `npm run build` すべて成功
- CodeRabbit レビュー実施(指摘 0 件)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH