### PR TITLE
feat: 発言者アバターを生IRC列に表示する(Helix /users)

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -16,6 +16,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { resetAvatarsForTests, useAvatarStore } from "@/store/avatars";
 import { resetBotFilterStoreForTests, useBotFilterStore } from "@/store/bot-filter";
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetPickupStoreForTests, usePickupStore } from "@/store/pickups";
@@ -90,6 +91,7 @@ afterEach(() => {
   resetPromptApiStoreForTests();
   resetBotFilterStoreForTests();
   resetSettingsStoreForTests();
+  resetAvatarsForTests();
   window.localStorage.clear();
 });
 
@@ -110,6 +112,28 @@ describe("Home(3カラム構成)", () => {
     const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
     expect(within(rawColumn).getByText("viewer_taro")).toBeInTheDocument();
     expect(within(rawColumn).getByText("gg no re chat")).toBeInTheDocument();
+  });
+
+  it("アバター取得済みの発言者には、生IRC列の発言行にアバター画像を表示する", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    // サンプル発言の発言者(userId: "1234")のアバターだけが取得済みの状態
+    useAvatarStore.setState({ avatars: { "1234": "https://cdn.example/taro.png" } });
+
+    render(<Home />);
+
+    const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
+    const avatar = rawColumn.querySelector('img[src="https://cdn.example/taro.png"]');
+    expect(avatar).not.toBeNull();
+  });
+
+  it("アバター未取得の発言者は、アバターなしの現行表示のまま表示する", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+
+    render(<Home />);
+
+    const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
+    expect(within(rawColumn).getByText("viewer_taro")).toBeInTheDocument();
+    expect(rawColumn.querySelector('img[src="https://cdn.example/taro.png"]')).toBeNull();
   });
 
   it("翻訳列とPick up列は初期状態では見えており(ぼかし無し)、トグルでぼかせる", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -112,15 +112,18 @@ export default function Home() {
   const [translationBlurred, setTranslationBlurred] = useState(false);
   const [pickupBlurred, setPickupBlurred] = useState(false);
 
-  // 新着発言への追従。オンの間は発言が増えるたびにスクロール領域を最下部へ送る
+  // 新着発言への追従。オンの間は発言が増えるたびにスクロール領域を最下部へ送る。
+  // アバター(issue #60)は発言の表示後に遅れて届いて行の高さを増やすため、
+  // その反映時にも最下部へ送り直す(でないと最新の発言が見切れたまま追従が止まる)
   const [followLatest, setFollowLatest] = useState(true);
+  const avatars = useAvatarStore((state) => state.avatars);
   const scrollViewportRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (!followLatest) return;
     const viewport = scrollViewportRef.current;
     if (!viewport) return;
     viewport.scrollTop = viewport.scrollHeight;
-  }, [followLatest, messages]);
+  }, [followLatest, messages, avatars]);
   // 利用者が上方向へスクロールして最下部から離れたら、読み返しの邪魔をしないよう追従を自動でオフにする。
   // 追従による最下部へのスクロールもこのイベントを起こすが、その時点では最下部にいるためオフにはならない
   useEffect(() => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,7 @@ import { cn } from "@/lib/utils";
 import type { ConnectionState } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { buildEmoteImageUrl, splitMessageIntoSegments, type MessageSegment } from "@/lib/twitch/emotes";
+import { useAvatarStore } from "@/store/avatars";
 import { hydrateBotFilterStore } from "@/store/bot-filter";
 import { useChatConnectionStore } from "@/store/chat-connection";
 import type { PipelineEntry } from "@/store/auto-pipeline";
@@ -521,9 +522,22 @@ function ChatMessageRow({ message }: { message: TwitchChatMessage }) {
     () => splitMessageIntoSegments(message.text, message.emotes),
     [message.text, message.emotes],
   );
+  // 発言者のアバター(issue #60)。未取得・取得失敗(Helix 利用不可を含む)は undefined で、アバターなしの表示になる
+  const avatarUrl = useAvatarStore((state) =>
+    message.userId === null ? undefined : state.avatars[message.userId],
+  );
 
   return (
     <Row message={message} blurred={false}>
+      {avatarUrl !== undefined && (
+        // eslint-disable-next-line @next/next/no-img-element -- Twitch CDNの外部画像のためnext/imageのドメイン許可設定は不要な単純imgで表示する
+        <img
+          src={avatarUrl}
+          // 直後に表示名がテキストで続くため、アバターは装飾画像として扱う
+          alt=""
+          className="mr-1 inline-block size-5 rounded-full align-text-bottom"
+        />
+      )}
       <span className="font-semibold" style={message.color ? { color: message.color } : undefined}>
         {message.displayName}
       </span>

--- a/src/lib/twitch/user-avatars.test.ts
+++ b/src/lib/twitch/user-avatars.test.ts
@@ -1,0 +1,113 @@
+/**
+ * src/lib/twitch/user-avatars.ts(発言者のプロフィール画像 URL の取得)のテスト。
+ *
+ * Helix の Get Users API(`GET /users?id=`)のレスポンスを
+ * 「ユーザー ID → プロフィール画像 URL」の対応表として解析する処理と、
+ * Next.js プロキシ(`/api/twitch/users`)経由のバッチ取得(1 リクエスト最大 100 件)を検証する。
+ * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fetchUserAvatars, parseUserAvatars } from "./user-avatars";
+
+/** Helix Get Users API のレスポンス(検証に使う部分のみ) */
+function createHelixUsersJson(): unknown {
+  return {
+    data: [
+      { id: "1234", login: "viewer_taro", profile_image_url: "https://cdn.example/taro.png" },
+      { id: "5678", login: "viewer_hanako", profile_image_url: "https://cdn.example/hanako.png" },
+    ],
+  };
+}
+
+describe("parseUserAvatars", () => {
+  it("レスポンスから「ユーザー ID → プロフィール画像 URL」の対応表を作る", () => {
+    expect(parseUserAvatars(createHelixUsersJson())).toEqual(
+      new Map([
+        ["1234", "https://cdn.example/taro.png"],
+        ["5678", "https://cdn.example/hanako.png"],
+      ]),
+    );
+  });
+
+  it("id や profile_image_url が無い・空文字の項目は読み飛ばす", () => {
+    const json = {
+      data: [
+        { id: "1", profile_image_url: "" },
+        { id: "2" },
+        { profile_image_url: "https://cdn.example/no-id.png" },
+        { id: "3", profile_image_url: "https://cdn.example/valid.png" },
+      ],
+    };
+    expect(parseUserAvatars(json)).toEqual(new Map([["3", "https://cdn.example/valid.png"]]));
+  });
+
+  it("data が配列でない・オブジェクトでない JSON は空の対応表を返す", () => {
+    expect(parseUserAvatars({ data: "壊れたレスポンス" })).toEqual(new Map());
+    expect(parseUserAvatars(null)).toEqual(new Map());
+  });
+});
+
+describe("fetchUserAvatars", () => {
+  it("プロキシへ id をクエリで並べて問い合わせ、対応表を返す", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createHelixUsersJson()), { status: 200 }),
+    );
+
+    const avatars = await fetchUserAvatars(["1234", "5678"], fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/users?id=1234&id=5678");
+    expect(avatars).toEqual(
+      new Map([
+        ["1234", "https://cdn.example/taro.png"],
+        ["5678", "https://cdn.example/hanako.png"],
+      ]),
+    );
+  });
+
+  it("100 件を超える ID は 100 件ずつのリクエストに分割する(Helix の上限)", async () => {
+    const ids = Array.from({ length: 150 }, (_, i) => String(i + 1));
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [] }), { status: 200 }),
+    );
+
+    await fetchUserAvatars(ids, fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const firstUrl = (fetchFn.mock.calls[0] as [string])[0];
+    const secondUrl = (fetchFn.mock.calls[1] as [string])[0];
+    expect(firstUrl.match(/id=/g)).toHaveLength(100);
+    expect(secondUrl.match(/id=/g)).toHaveLength(50);
+  });
+
+  it("重複する ID は 1 件にまとめて問い合わせる", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(createHelixUsersJson()), { status: 200 }),
+    );
+
+    await fetchUserAvatars(["1234", "1234", "5678"], fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/users?id=1234&id=5678");
+  });
+
+  it("ID が空の場合はリクエストせず空の対応表を返す", async () => {
+    const fetchFn = vi.fn();
+
+    expect(await fetchUserAvatars([], fetchFn)).toEqual(new Map());
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("HTTP エラー(Helix 未設定の 503 など)の場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ error: "Helix API が設定されていません" }), { status: 503 }),
+    );
+
+    expect(await fetchUserAvatars(["1234"], fetchFn)).toBeNull();
+  });
+
+  it("ネットワークエラーの場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("network error"));
+
+    expect(await fetchUserAvatars(["1234"], fetchFn)).toBeNull();
+  });
+});

--- a/src/lib/twitch/user-avatars.test.ts
+++ b/src/lib/twitch/user-avatars.test.ts
@@ -97,6 +97,23 @@ describe("fetchUserAvatars", () => {
     expect(fetchFn).not.toHaveBeenCalled();
   });
 
+  it("一部のチャンクだけが失敗した場合は、成功したチャンクぶんの対応表を返す(取得済みを捨てない)", async () => {
+    const ids = Array.from({ length: 150 }, (_, i) => String(i + 1));
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: [{ id: "1", profile_image_url: "https://cdn.example/1.png" }] }), {
+          status: 200,
+        }),
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: "Too Many Requests" }), { status: 429 }));
+
+    const avatars = await fetchUserAvatars(ids, fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(avatars).toEqual(new Map([["1", "https://cdn.example/1.png"]]));
+  });
+
   it("HTTP エラー(Helix 未設定の 503 など)の場合は null を返す", async () => {
     const fetchFn = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: "Helix API が設定されていません" }), { status: 503 }),

--- a/src/lib/twitch/user-avatars.ts
+++ b/src/lib/twitch/user-avatars.ts
@@ -8,8 +8,11 @@
  *
  * - `GET /users?id=` は 1 リクエストで最大 100 件まとめて引けるため、
  *   ID を 100 件ずつに分割してバッチで取得する
- * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害・ネットワークエラーは
- *   null を返し、アバターなしの現行表示のまま動作する(意図した仕様)
+ * - すべてのリクエスト(チャンク)が失敗した場合のみ null を返す(Helix 未設定の 503・
+ *   レート制限・障害・ネットワークエラー)。呼び出し側はこれを「Helix 利用不可」として扱い、
+ *   アバターなしの現行表示のまま動作する(意図した仕様)
+ * - 一部のチャンクだけが失敗した場合は、成功したチャンクぶんの対応表を返す
+ *   (取得できたアバターを捨てない)
  */
 
 /** Helix の Get Users API の 1 リクエストで指定できる ID の上限 */
@@ -40,10 +43,10 @@ export function parseUserAvatars(json: unknown): Map<string, string> {
  * Helix プロキシ(`/api/twitch/users`)から、指定した発言者 ID のプロフィール画像 URL を
  * まとめて取得する。重複 ID は 1 件にまとめ、100 件を超える場合はリクエストを分割する。
  *
- * 取得できない場合は null を返す(呼び出し側の `src/store/avatars.ts` が
- * アバターなしとして扱う。意図した仕様):
- * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害などの HTTP エラー
- * - ネットワークエラー
+ * すべてのチャンクが失敗した場合(Helix 未設定の 503・レート制限・障害などの HTTP エラー・
+ * ネットワークエラー)は null を返す(呼び出し側の `src/store/avatars.ts` が
+ * 「Helix 利用不可」として扱う。意図した仕様)。
+ * 一部のチャンクだけが失敗した場合は、成功したチャンクぶんの対応表を返す。
  *
  * レスポンスに含まれない ID(退会済みユーザーなど)は対応表に載らないだけで、エラーではない。
  */
@@ -53,23 +56,26 @@ export async function fetchUserAvatars(
 ): Promise<Map<string, string> | null> {
   const uniqueIds = [...new Set(userIds)];
   const avatars = new Map<string, string>();
+  let anyChunkSucceeded = false;
 
-  try {
-    for (let start = 0; start < uniqueIds.length; start += MAX_IDS_PER_REQUEST) {
-      const chunk = uniqueIds.slice(start, start + MAX_IDS_PER_REQUEST);
-      const query = chunk.map((id) => `id=${encodeURIComponent(id)}`).join("&");
+  for (let start = 0; start < uniqueIds.length; start += MAX_IDS_PER_REQUEST) {
+    const chunk = uniqueIds.slice(start, start + MAX_IDS_PER_REQUEST);
+    const query = chunk.map((id) => `id=${encodeURIComponent(id)}`).join("&");
+    try {
       const response = await fetchFn(`/api/twitch/users?${query}`);
       if (!response.ok) {
         console.warn(`発言者アバターの取得に失敗しました(HTTP ${response.status})。アバターなしで表示します`);
-        return null;
+        // 取得済みのチャンクぶんは捨てない。1 件も取得できていなければ Helix 利用不可(null)
+        return anyChunkSucceeded ? avatars : null;
       }
       for (const [id, url] of parseUserAvatars(await response.json())) {
         avatars.set(id, url);
       }
+      anyChunkSucceeded = true;
+    } catch (error) {
+      console.warn("発言者アバターの取得に失敗しました。アバターなしで表示します", error);
+      return anyChunkSucceeded ? avatars : null;
     }
-    return avatars;
-  } catch (error) {
-    console.warn("発言者アバターの取得に失敗しました。アバターなしで表示します", error);
-    return null;
   }
+  return avatars;
 }

--- a/src/lib/twitch/user-avatars.ts
+++ b/src/lib/twitch/user-avatars.ts
@@ -1,0 +1,75 @@
+/**
+ * 発言者のプロフィール画像(アバター)URL の取得(issue #60)。
+ *
+ * Helix の Get Users API(`GET /users?id=`)を Next.js プロキシ(`/api/twitch/`)経由で呼び、
+ * 発言者の Twitch ユーザー ID(PRIVMSG の `user-id` タグ)からプロフィール画像 URL を取得する。
+ * 生IRC列(`src/app/page.tsx`)の発言行にアバターとして表示する。
+ * 読み込みのバッチ化と保持は `src/store/avatars.ts` が担う。
+ *
+ * - `GET /users?id=` は 1 リクエストで最大 100 件まとめて引けるため、
+ *   ID を 100 件ずつに分割してバッチで取得する
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害・ネットワークエラーは
+ *   null を返し、アバターなしの現行表示のまま動作する(意図した仕様)
+ */
+
+/** Helix の Get Users API の 1 リクエストで指定できる ID の上限 */
+const MAX_IDS_PER_REQUEST = 100;
+
+/**
+ * Helix の Get Users API レスポンス(`{data: [{id, profile_image_url, ...}]}`)を解析して
+ * 「ユーザー ID → プロフィール画像 URL」の対応表を作る。
+ * API 側の仕様変更などで形式が想定と異なる項目・URL が空の項目は読み飛ばす。
+ */
+export function parseUserAvatars(json: unknown): Map<string, string> {
+  const avatars = new Map<string, string>();
+  if (typeof json !== "object" || json === null) return avatars;
+  const data = (json as Record<string, unknown>).data;
+  if (!Array.isArray(data)) return avatars;
+
+  for (const entry of data) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.id !== "string" || record.id === "") continue;
+    if (typeof record.profile_image_url !== "string" || record.profile_image_url === "") continue;
+    avatars.set(record.id, record.profile_image_url);
+  }
+  return avatars;
+}
+
+/**
+ * Helix プロキシ(`/api/twitch/users`)から、指定した発言者 ID のプロフィール画像 URL を
+ * まとめて取得する。重複 ID は 1 件にまとめ、100 件を超える場合はリクエストを分割する。
+ *
+ * 取得できない場合は null を返す(呼び出し側の `src/store/avatars.ts` が
+ * アバターなしとして扱う。意図した仕様):
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害などの HTTP エラー
+ * - ネットワークエラー
+ *
+ * レスポンスに含まれない ID(退会済みユーザーなど)は対応表に載らないだけで、エラーではない。
+ */
+export async function fetchUserAvatars(
+  userIds: readonly string[],
+  fetchFn: typeof fetch = fetch,
+): Promise<Map<string, string> | null> {
+  const uniqueIds = [...new Set(userIds)];
+  const avatars = new Map<string, string>();
+
+  try {
+    for (let start = 0; start < uniqueIds.length; start += MAX_IDS_PER_REQUEST) {
+      const chunk = uniqueIds.slice(start, start + MAX_IDS_PER_REQUEST);
+      const query = chunk.map((id) => `id=${encodeURIComponent(id)}`).join("&");
+      const response = await fetchFn(`/api/twitch/users?${query}`);
+      if (!response.ok) {
+        console.warn(`発言者アバターの取得に失敗しました(HTTP ${response.status})。アバターなしで表示します`);
+        return null;
+      }
+      for (const [id, url] of parseUserAvatars(await response.json())) {
+        avatars.set(id, url);
+      }
+    }
+    return avatars;
+  } catch (error) {
+    console.warn("発言者アバターの取得に失敗しました。アバターなしで表示します", error);
+    return null;
+  }
+}

--- a/src/store/avatars.test.ts
+++ b/src/store/avatars.test.ts
@@ -4,12 +4,20 @@
  * 発言受信時に `requestAvatar` へ渡された発言者 ID を短い待ち時間でバッチにまとめ、
  * Helix の Get Users API(`/users?id=`)経由でプロフィール画像 URL を取得して
  * Zustand ストアに保持する流れを検証する。
- * 実際の API 呼び出しは行わず、フェイクの取得関数を注入する。
+ * 実際の API 呼び出しは行わないよう、取得関数(`fetchUserAvatars`)はモジュールごとモックする。
  * バッチの待ち時間はフェイクタイマーで進める。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetchUserAvatars = vi.fn<(ids: readonly string[]) => Promise<Map<string, string> | null>>();
+
+vi.mock("@/lib/twitch/user-avatars", () => ({
+  fetchUserAvatars: (ids: readonly string[]) => mockFetchUserAvatars(ids),
+}));
+
 import {
   AVATAR_BATCH_WINDOW_MS,
+  MAX_AVATAR_CACHE_ENTRIES,
   clearAvatarLoadFailures,
   requestAvatar,
   resetAvatarsForTests,
@@ -19,12 +27,13 @@ import {
 /** バッチの待ち時間を経過させ、取得の Promise を解決させる */
 async function advanceBatchWindow() {
   vi.advanceTimersByTime(AVATAR_BATCH_WINDOW_MS);
-  // fetchAvatars の Promise 解決(マイクロタスク)を消化する
+  // fetchUserAvatars の Promise 解決(マイクロタスク)を消化する
   await vi.advanceTimersByTimeAsync(0);
 }
 
 beforeEach(() => {
   vi.useFakeTimers();
+  mockFetchUserAvatars.mockReset();
 });
 
 afterEach(() => {
@@ -34,19 +43,19 @@ afterEach(() => {
 
 describe("requestAvatar", () => {
   it("バッチ待ち時間内に要求された複数の発言者 ID を 1 回の取得にまとめ、ストアに保持する", async () => {
-    const fetchAvatars = vi.fn(async () =>
+    mockFetchUserAvatars.mockResolvedValue(
       new Map([
         ["1234", "https://cdn.example/taro.png"],
         ["5678", "https://cdn.example/hanako.png"],
       ]),
     );
 
-    requestAvatar("1234", fetchAvatars);
-    requestAvatar("5678", fetchAvatars);
+    requestAvatar("1234");
+    requestAvatar("5678");
     await advanceBatchWindow();
 
-    expect(fetchAvatars).toHaveBeenCalledTimes(1);
-    expect(fetchAvatars).toHaveBeenCalledWith(["1234", "5678"]);
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(1);
+    expect(mockFetchUserAvatars).toHaveBeenCalledWith(["1234", "5678"]);
     expect(useAvatarStore.getState().avatars).toEqual({
       "1234": "https://cdn.example/taro.png",
       "5678": "https://cdn.example/hanako.png",
@@ -54,95 +63,139 @@ describe("requestAvatar", () => {
   });
 
   it("取得済み・取得中の ID は再取得しない(同じ発言者の連続発言でリクエストを増やさない)", async () => {
-    const fetchAvatars = vi.fn(async () => new Map([["1234", "https://cdn.example/taro.png"]]));
+    mockFetchUserAvatars.mockResolvedValue(new Map([["1234", "https://cdn.example/taro.png"]]));
 
-    requestAvatar("1234", fetchAvatars);
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
+    requestAvatar("1234");
     await advanceBatchWindow();
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
 
-    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(1);
   });
 
-  it("userId が null(タグ無し)の発言は無視する", async () => {
-    const fetchAvatars = vi.fn(async () => new Map<string, string>());
+  it("取得中(リクエスト送信済み・未応答)の ID は、次のバッチにも積まない", async () => {
+    // 1 回目の取得を未解決のままにして「取得中」の状態を作る
+    let resolveFirst: (result: Map<string, string> | null) => void = () => {};
+    mockFetchUserAvatars.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
 
-    requestAvatar(null, fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
+    // 取得中に同じ発言者がもう一度発言する
+    requestAvatar("1234");
+    await advanceBatchWindow();
+    resolveFirst(new Map([["1234", "https://cdn.example/taro.png"]]));
+    await vi.advanceTimersByTimeAsync(0);
 
-    expect(fetchAvatars).not.toHaveBeenCalled();
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(1);
   });
 
-  it("レスポンスに含まれない ID(退会済みなど)はアバターなしのまま、再取得もしない", async () => {
-    const fetchAvatars = vi.fn(async () => new Map<string, string>());
-
-    requestAvatar("9999", fetchAvatars);
-    await advanceBatchWindow();
-    requestAvatar("9999", fetchAvatars);
+  it("userId が null(タグ無し)・空文字(値なしタグ)の発言は無視する", async () => {
+    // IRC パーサーは値なしタグ(`user-id=`)を空文字にするため、空文字も Helix へ送らない
+    requestAvatar(null);
+    requestAvatar("");
     await advanceBatchWindow();
 
-    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(mockFetchUserAvatars).not.toHaveBeenCalled();
+  });
+
+  it("レスポンスに含まれない ID(退会済みなど)はアバターなしとして確定し、再取得しない", async () => {
+    mockFetchUserAvatars.mockResolvedValue(new Map());
+
+    requestAvatar("9999");
+    await advanceBatchWindow();
+    requestAvatar("9999");
+    await advanceBatchWindow();
+
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(1);
     expect(useAvatarStore.getState().avatars).toEqual({});
   });
 
-  it("取得失敗(null = Helix 利用不可)の ID はアバターなしのまま、再取得しない(失敗の記録をクリアするまで)", async () => {
-    const fetchAvatars = vi.fn(async () => null);
+  it("取得失敗(null = Helix 利用不可)後は、新しい ID も含めて取得を止める(発言のたびにリクエストを繰り返さない)", async () => {
+    mockFetchUserAvatars.mockResolvedValue(null);
 
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
-    requestAvatar("1234", fetchAvatars);
+    // 失敗後は同じ ID も初見の ID もリクエストしない
+    requestAvatar("1234");
+    requestAvatar("5678");
     await advanceBatchWindow();
 
-    // Helix 利用不可時に発言のたびにリクエストを繰り返さない
-    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(1);
     expect(useAvatarStore.getState().avatars).toEqual({});
   });
 
   it("clearAvatarLoadFailures(チャンネル切り替え)後は、失敗した ID を再取得できる", async () => {
-    const fetchAvatars = vi
-      .fn()
+    mockFetchUserAvatars
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(new Map([["1234", "https://cdn.example/taro.png"]]));
 
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
     clearAvatarLoadFailures();
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
 
-    expect(fetchAvatars).toHaveBeenCalledTimes(2);
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(2);
     expect(useAvatarStore.getState().avatars).toEqual({
       "1234": "https://cdn.example/taro.png",
     });
   });
 
   it("取得成功した ID は clearAvatarLoadFailures 後も再取得しない(アバターはチャンネル固有ではないため持ち越す)", async () => {
-    const fetchAvatars = vi.fn(async () => new Map([["1234", "https://cdn.example/taro.png"]]));
+    mockFetchUserAvatars.mockResolvedValue(new Map([["1234", "https://cdn.example/taro.png"]]));
 
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
     clearAvatarLoadFailures();
-    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234");
     await advanceBatchWindow();
 
-    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(1);
     expect(useAvatarStore.getState().avatars).toEqual({
       "1234": "https://cdn.example/taro.png",
     });
   });
 
-  it("キャッシュが上限を超えたら古い発言者から削除する(メモリの際限ない増加を防ぐ)", async () => {
-    // 上限 + 1 件を取得させ、最初の 1 件が捨てられることを確認する
-    const { MAX_AVATAR_CACHE_ENTRIES } = await import("./avatars");
-    const fetchAvatars = vi.fn(async (ids: readonly string[]) =>
+  it("clearAvatarLoadFailures 後に完了した(クリア前に開始していた)バッチの失敗は、利用不可として記録しない", async () => {
+    // チャンネル切り替えの瞬間に進行中だった前チャンネルのバッチが失敗しても、
+    // 新チャンネルでの取得を止めてはならない(世代フェンス)
+    let resolveFirst: (result: Map<string, string> | null) => void = () => {};
+    mockFetchUserAvatars
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        }),
+      )
+      .mockResolvedValueOnce(new Map([["5678", "https://cdn.example/hanako.png"]]));
+
+    requestAvatar("1234");
+    await advanceBatchWindow();
+    clearAvatarLoadFailures();
+    resolveFirst(null);
+    await vi.advanceTimersByTimeAsync(0);
+    requestAvatar("5678");
+    await advanceBatchWindow();
+
+    expect(mockFetchUserAvatars).toHaveBeenCalledTimes(2);
+    expect(useAvatarStore.getState().avatars).toEqual({
+      "5678": "https://cdn.example/hanako.png",
+    });
+  });
+
+  it("キャッシュが上限を超えたら、参照が最も古い発言者から削除する(メモリの際限ない増加を防ぐ)", async () => {
+    mockFetchUserAvatars.mockImplementation(async (ids) =>
       new Map(ids.map((id) => [id, `https://cdn.example/${id}.png`])),
     );
 
-    requestAvatar("oldest", fetchAvatars);
+    requestAvatar("oldest");
     await advanceBatchWindow();
     for (let i = 0; i < MAX_AVATAR_CACHE_ENTRIES; i += 1) {
-      requestAvatar(`user-${i}`, fetchAvatars);
+      requestAvatar(`user-${i}`);
     }
     await advanceBatchWindow();
 
@@ -150,5 +203,27 @@ describe("requestAvatar", () => {
     expect(Object.keys(avatars)).toHaveLength(MAX_AVATAR_CACHE_ENTRIES);
     expect(avatars["oldest"]).toBeUndefined();
     expect(avatars["user-0"]).toBe("https://cdn.example/user-0.png");
+  });
+
+  it("取得済み ID への再要求は参照位置を最新に更新し、上限超過時に捨てられにくくする(LRU)", async () => {
+    mockFetchUserAvatars.mockImplementation(async (ids) =>
+      new Map(ids.map((id) => [id, `https://cdn.example/${id}.png`])),
+    );
+
+    requestAvatar("regular");
+    await advanceBatchWindow();
+    requestAvatar("one-shot");
+    await advanceBatchWindow();
+    // 常連(regular)がもう一度発言 → 参照位置が one-shot より新しくなる
+    requestAvatar("regular");
+    // 上限まで埋めて 1 件だけ捨てさせる
+    for (let i = 0; i < MAX_AVATAR_CACHE_ENTRIES - 1; i += 1) {
+      requestAvatar(`user-${i}`);
+    }
+    await advanceBatchWindow();
+
+    const avatars = useAvatarStore.getState().avatars;
+    expect(avatars["one-shot"]).toBeUndefined();
+    expect(avatars["regular"]).toBe("https://cdn.example/regular.png");
   });
 });

--- a/src/store/avatars.test.ts
+++ b/src/store/avatars.test.ts
@@ -1,0 +1,154 @@
+/**
+ * src/store/avatars.ts(発言者アバター URL のキャッシュ)のテスト。
+ *
+ * 発言受信時に `requestAvatar` へ渡された発言者 ID を短い待ち時間でバッチにまとめ、
+ * Helix の Get Users API(`/users?id=`)経由でプロフィール画像 URL を取得して
+ * Zustand ストアに保持する流れを検証する。
+ * 実際の API 呼び出しは行わず、フェイクの取得関数を注入する。
+ * バッチの待ち時間はフェイクタイマーで進める。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  AVATAR_BATCH_WINDOW_MS,
+  clearAvatarLoadFailures,
+  requestAvatar,
+  resetAvatarsForTests,
+  useAvatarStore,
+} from "./avatars";
+
+/** バッチの待ち時間を経過させ、取得の Promise を解決させる */
+async function advanceBatchWindow() {
+  vi.advanceTimersByTime(AVATAR_BATCH_WINDOW_MS);
+  // fetchAvatars の Promise 解決(マイクロタスク)を消化する
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  resetAvatarsForTests();
+  vi.useRealTimers();
+});
+
+describe("requestAvatar", () => {
+  it("バッチ待ち時間内に要求された複数の発言者 ID を 1 回の取得にまとめ、ストアに保持する", async () => {
+    const fetchAvatars = vi.fn(async () =>
+      new Map([
+        ["1234", "https://cdn.example/taro.png"],
+        ["5678", "https://cdn.example/hanako.png"],
+      ]),
+    );
+
+    requestAvatar("1234", fetchAvatars);
+    requestAvatar("5678", fetchAvatars);
+    await advanceBatchWindow();
+
+    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(fetchAvatars).toHaveBeenCalledWith(["1234", "5678"]);
+    expect(useAvatarStore.getState().avatars).toEqual({
+      "1234": "https://cdn.example/taro.png",
+      "5678": "https://cdn.example/hanako.png",
+    });
+  });
+
+  it("取得済み・取得中の ID は再取得しない(同じ発言者の連続発言でリクエストを増やさない)", async () => {
+    const fetchAvatars = vi.fn(async () => new Map([["1234", "https://cdn.example/taro.png"]]));
+
+    requestAvatar("1234", fetchAvatars);
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+
+    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+  });
+
+  it("userId が null(タグ無し)の発言は無視する", async () => {
+    const fetchAvatars = vi.fn(async () => new Map<string, string>());
+
+    requestAvatar(null, fetchAvatars);
+    await advanceBatchWindow();
+
+    expect(fetchAvatars).not.toHaveBeenCalled();
+  });
+
+  it("レスポンスに含まれない ID(退会済みなど)はアバターなしのまま、再取得もしない", async () => {
+    const fetchAvatars = vi.fn(async () => new Map<string, string>());
+
+    requestAvatar("9999", fetchAvatars);
+    await advanceBatchWindow();
+    requestAvatar("9999", fetchAvatars);
+    await advanceBatchWindow();
+
+    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(useAvatarStore.getState().avatars).toEqual({});
+  });
+
+  it("取得失敗(null = Helix 利用不可)の ID はアバターなしのまま、再取得しない(失敗の記録をクリアするまで)", async () => {
+    const fetchAvatars = vi.fn(async () => null);
+
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+
+    // Helix 利用不可時に発言のたびにリクエストを繰り返さない
+    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(useAvatarStore.getState().avatars).toEqual({});
+  });
+
+  it("clearAvatarLoadFailures(チャンネル切り替え)後は、失敗した ID を再取得できる", async () => {
+    const fetchAvatars = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(new Map([["1234", "https://cdn.example/taro.png"]]));
+
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+    clearAvatarLoadFailures();
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+
+    expect(fetchAvatars).toHaveBeenCalledTimes(2);
+    expect(useAvatarStore.getState().avatars).toEqual({
+      "1234": "https://cdn.example/taro.png",
+    });
+  });
+
+  it("取得成功した ID は clearAvatarLoadFailures 後も再取得しない(アバターはチャンネル固有ではないため持ち越す)", async () => {
+    const fetchAvatars = vi.fn(async () => new Map([["1234", "https://cdn.example/taro.png"]]));
+
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+    clearAvatarLoadFailures();
+    requestAvatar("1234", fetchAvatars);
+    await advanceBatchWindow();
+
+    expect(fetchAvatars).toHaveBeenCalledTimes(1);
+    expect(useAvatarStore.getState().avatars).toEqual({
+      "1234": "https://cdn.example/taro.png",
+    });
+  });
+
+  it("キャッシュが上限を超えたら古い発言者から削除する(メモリの際限ない増加を防ぐ)", async () => {
+    // 上限 + 1 件を取得させ、最初の 1 件が捨てられることを確認する
+    const { MAX_AVATAR_CACHE_ENTRIES } = await import("./avatars");
+    const fetchAvatars = vi.fn(async (ids: readonly string[]) =>
+      new Map(ids.map((id) => [id, `https://cdn.example/${id}.png`])),
+    );
+
+    requestAvatar("oldest", fetchAvatars);
+    await advanceBatchWindow();
+    for (let i = 0; i < MAX_AVATAR_CACHE_ENTRIES; i += 1) {
+      requestAvatar(`user-${i}`, fetchAvatars);
+    }
+    await advanceBatchWindow();
+
+    const avatars = useAvatarStore.getState().avatars;
+    expect(Object.keys(avatars)).toHaveLength(MAX_AVATAR_CACHE_ENTRIES);
+    expect(avatars["oldest"]).toBeUndefined();
+    expect(avatars["user-0"]).toBe("https://cdn.example/user-0.png");
+  });
+});

--- a/src/store/avatars.ts
+++ b/src/store/avatars.ts
@@ -9,11 +9,14 @@
  * cheermotes / third-party-emotes と異なり Zustand ストアで保持する。
  *
  * - アバターはユーザー固有でチャンネル固有ではないため、キャッシュはチャンネル切り替えを
- *   またいで持ち越す。ただし上限(`MAX_AVATAR_CACHE_ENTRIES`)を超えたら古い発言者から捨てる
- * - 取得失敗(Helix 利用不可 = null)の ID は失敗として記録し、発言のたびに
- *   リクエストを繰り返さない。チャンネル切り替え(`connect()`)時に
- *   `clearAvatarLoadFailures` で記録をクリアし、再試行できるようにする
- * - レスポンスに含まれない ID(退会済みユーザーなど)はアバターなしとして確定し、再取得しない
+ *   またいで持ち越す。上限(`MAX_AVATAR_CACHE_ENTRIES`)を超えたら参照が最も古い
+ *   発言者から捨てる(LRU。取得済み ID への再要求で参照位置を更新する)
+ * - レスポンスに含まれない ID(退会済みユーザーなど)は「アバターなし」(null)として
+ *   キャッシュに確定し、再取得しない。この負のキャッシュも同じ上限で管理する
+ * - 取得の失敗(全チャンクの失敗 = null)は Helix 側の問題(未設定・障害・レート制限)であり
+ *   ID 固有の問題ではないため、利用不可フラグを立てて以降の取得を止める(発言のたびに
+ *   リクエストを繰り返さない)。チャンネル切り替え(`connect()`)時に
+ *   `clearAvatarLoadFailures` でフラグを下ろし、再試行できるようにする
  * - 未取得・取得失敗の発言者はアバターなしの現行表示のまま動作する(意図した仕様)
  */
 import { create } from "zustand";
@@ -22,44 +25,52 @@ import { fetchUserAvatars } from "@/lib/twitch/user-avatars";
 /** 発言者 ID の要求をバッチにまとめる待ち時間(ミリ秒) */
 export const AVATAR_BATCH_WINDOW_MS = 250;
 
-/** キャッシュに保持するアバター URL の上限件数。超えたら古い発言者から捨てる */
+/** キャッシュに保持する発言者数の上限。超えたら参照が最も古い発言者から捨てる */
 export const MAX_AVATAR_CACHE_ENTRIES = 500;
 
 interface AvatarState {
-  /** 発言者の Twitch ユーザー ID → プロフィール画像 URL。未取得・取得失敗の ID は含まれない */
+  /** 発言者の Twitch ユーザー ID → プロフィール画像 URL。未取得・取得失敗・アバターなし確定の ID は含まれない */
   avatars: Record<string, string>;
 }
 
 export const useAvatarStore = create<AvatarState>(() => ({ avatars: {} }));
 
-/** 取得済みアバター URL のキャッシュ(挿入順 = 取得順。上限超過時に先頭から捨てる) */
-const avatarCache = new Map<string, string>();
-/** 要求済み(取得中・取得済み・アバターなし確定)の ID。二重リクエストを防ぐ */
-const requestedIds = new Set<string>();
-/** 取得失敗(Helix 利用不可)だった ID。クリアされるまで再取得しない */
-const failedIds = new Set<string>();
+/**
+ * 取得結果のキャッシュ(単一の情報源)。値 null は「アバターなし」の確定
+ * (レスポンスに含まれなかった退会済みユーザーなど)。
+ * 挿入順 = 最終参照順として扱い、上限超過時に先頭(最も古い参照)から捨てる。
+ */
+const avatarCache = new Map<string, string | null>();
 /** 次のバッチで取得する ID */
 let pendingIds = new Set<string>();
+/** リクエスト送信済み・未応答の ID。応答までの間の二重リクエストを防ぐ */
+const inFlightIds = new Set<string>();
 /** バッチ取得の待ちタイマー。null なら未スケジュール */
 let flushTimer: ReturnType<typeof setTimeout> | null = null;
-/** 次のバッチ取得に使う取得関数(テストではフェイクを注入する) */
-let pendingFetchAvatars: typeof fetchUserAvatars = fetchUserAvatars;
+/** Helix 利用不可(取得の全面失敗)を検出したか。立っている間は新しい取得を止める */
+let helixUnavailable = false;
+/** clearAvatarLoadFailures のたびに進める世代番号。クリア前に開始したバッチの失敗を利用不可として記録しない */
+let generation = 0;
 
 /**
  * 発言者のアバター取得を要求する。発言(PRIVMSG)受信のたびに呼ばれるため、
- * 要求はバッチにまとめ、要求済みの ID は何もしない。
- * userId が null(タグ無し)の発言は無視する。
+ * 要求はバッチにまとめ、取得済み(アバターなし確定を含む)・取得中の ID は再取得しない。
+ * userId が null(タグ無し)・空文字(値なしタグ)の発言は無視する。
  */
-export function requestAvatar(
-  userId: string | null,
-  fetchAvatars: typeof fetchUserAvatars = fetchUserAvatars,
-): void {
-  if (userId === null) return;
-  if (requestedIds.has(userId) || failedIds.has(userId)) return;
+export function requestAvatar(userId: string | null): void {
+  if (userId === null || userId === "") return;
+  if (helixUnavailable) return;
+  if (pendingIds.has(userId) || inFlightIds.has(userId)) return;
 
-  requestedIds.add(userId);
+  const cached = avatarCache.get(userId);
+  if (cached !== undefined) {
+    // 取得済み: 参照位置を最新に更新し(LRU)、上限超過時に捨てられにくくする
+    avatarCache.delete(userId);
+    avatarCache.set(userId, cached);
+    return;
+  }
+
   pendingIds.add(userId);
-  pendingFetchAvatars = fetchAvatars;
   if (flushTimer === null) {
     flushTimer = setTimeout(() => {
       void flushPendingRequests();
@@ -72,39 +83,50 @@ async function flushPendingRequests(): Promise<void> {
   flushTimer = null;
   const ids = [...pendingIds];
   pendingIds = new Set();
-  const fetchAvatars = pendingFetchAvatars;
+  for (const id of ids) inFlightIds.add(id);
+  const requestGeneration = generation;
 
-  const result = await fetchAvatars(ids);
+  const result = await fetchUserAvatars(ids);
+
+  for (const id of ids) inFlightIds.delete(id);
 
   if (result === null) {
-    // Helix 利用不可・一時的な失敗: 発言のたびに繰り返さないよう失敗として記録する。
-    // チャンネル切り替え時の clearAvatarLoadFailures で再試行できるようになる
-    for (const id of ids) {
-      requestedIds.delete(id);
-      failedIds.add(id);
-    }
+    // Helix 利用不可(全チャンクの失敗): 発言のたびに繰り返さないようフラグを立てる。
+    // ID はキャッシュに入れないため、clearAvatarLoadFailures 後の発言で再試行できる。
+    // クリア(チャンネル切り替え)後に完了した古いバッチの失敗は、新チャンネルの取得を止めない
+    if (generation === requestGeneration) helixUnavailable = true;
     return;
   }
 
-  // レスポンスに含まれない ID(退会済みなど)は requestedIds に残り、アバターなしとして確定する
-  for (const [id, url] of result) {
-    avatarCache.set(id, url);
+  // レスポンスに含まれない ID(退会済みなど)は「アバターなし」(null)として確定する
+  for (const id of ids) {
+    avatarCache.set(id, result.get(id) ?? null);
   }
-  // 上限を超えたぶんは古い発言者(挿入順の先頭)から捨て、再要求できるようにする
+  // 上限を超えたぶんは参照が最も古い発言者(挿入順の先頭)から捨てる
   while (avatarCache.size > MAX_AVATAR_CACHE_ENTRIES) {
-    const oldestId = avatarCache.keys().next().value as string;
+    const oldestId = avatarCache.keys().next().value;
+    if (oldestId === undefined) break;
     avatarCache.delete(oldestId);
-    requestedIds.delete(oldestId);
   }
-  useAvatarStore.setState({ avatars: Object.fromEntries(avatarCache) });
+  publishAvatars();
+}
+
+/** キャッシュのうちアバターありの ID だけをストアへ反映し、生IRC列の行を再描画させる */
+function publishAvatars(): void {
+  const avatars: Record<string, string> = {};
+  for (const [id, url] of avatarCache) {
+    if (url !== null) avatars[id] = url;
+  }
+  useAvatarStore.setState({ avatars });
 }
 
 /**
- * 取得失敗の記録をクリアし、失敗した ID を再取得できるようにする。
+ * Helix 利用不可フラグを下ろし、取得に失敗していた発言者を再取得できるようにする。
  * チャンネル切り替え(`connect()`)時に呼ぶ(取得済みのキャッシュは持ち越す)。
  */
 export function clearAvatarLoadFailures(): void {
-  failedIds.clear();
+  generation += 1;
+  helixUnavailable = false;
 }
 
 /** テスト専用: モジュールスコープの状態を初期状態に戻す。各テストの afterEach で呼び出すこと */
@@ -114,9 +136,9 @@ export function resetAvatarsForTests(): void {
     flushTimer = null;
   }
   avatarCache.clear();
-  requestedIds.clear();
-  failedIds.clear();
   pendingIds = new Set();
-  pendingFetchAvatars = fetchUserAvatars;
+  inFlightIds.clear();
+  helixUnavailable = false;
+  generation += 1;
   useAvatarStore.setState({ avatars: {} });
 }

--- a/src/store/avatars.ts
+++ b/src/store/avatars.ts
@@ -1,0 +1,122 @@
+/**
+ * 発言者アバター(プロフィール画像 URL)のキャッシュを保持する Zustand ストア(issue #60)。
+ *
+ * `chat-connection.ts` が発言(PRIVMSG)受信時に `requestAvatar` へ発言者の
+ * Twitch ユーザー ID(`user-id` タグ)を渡す。ID は短い待ち時間(`AVATAR_BATCH_WINDOW_MS`)で
+ * バッチにまとめ、Helix の Get Users API(`src/lib/twitch/user-avatars.ts`。
+ * 1 リクエスト最大 100 件)でプロフィール画像 URL を取得する。
+ * 生IRC列(`src/app/page.tsx`)は取得結果の反映で行を再描画する必要があるため、
+ * cheermotes / third-party-emotes と異なり Zustand ストアで保持する。
+ *
+ * - アバターはユーザー固有でチャンネル固有ではないため、キャッシュはチャンネル切り替えを
+ *   またいで持ち越す。ただし上限(`MAX_AVATAR_CACHE_ENTRIES`)を超えたら古い発言者から捨てる
+ * - 取得失敗(Helix 利用不可 = null)の ID は失敗として記録し、発言のたびに
+ *   リクエストを繰り返さない。チャンネル切り替え(`connect()`)時に
+ *   `clearAvatarLoadFailures` で記録をクリアし、再試行できるようにする
+ * - レスポンスに含まれない ID(退会済みユーザーなど)はアバターなしとして確定し、再取得しない
+ * - 未取得・取得失敗の発言者はアバターなしの現行表示のまま動作する(意図した仕様)
+ */
+import { create } from "zustand";
+import { fetchUserAvatars } from "@/lib/twitch/user-avatars";
+
+/** 発言者 ID の要求をバッチにまとめる待ち時間(ミリ秒) */
+export const AVATAR_BATCH_WINDOW_MS = 250;
+
+/** キャッシュに保持するアバター URL の上限件数。超えたら古い発言者から捨てる */
+export const MAX_AVATAR_CACHE_ENTRIES = 500;
+
+interface AvatarState {
+  /** 発言者の Twitch ユーザー ID → プロフィール画像 URL。未取得・取得失敗の ID は含まれない */
+  avatars: Record<string, string>;
+}
+
+export const useAvatarStore = create<AvatarState>(() => ({ avatars: {} }));
+
+/** 取得済みアバター URL のキャッシュ(挿入順 = 取得順。上限超過時に先頭から捨てる) */
+const avatarCache = new Map<string, string>();
+/** 要求済み(取得中・取得済み・アバターなし確定)の ID。二重リクエストを防ぐ */
+const requestedIds = new Set<string>();
+/** 取得失敗(Helix 利用不可)だった ID。クリアされるまで再取得しない */
+const failedIds = new Set<string>();
+/** 次のバッチで取得する ID */
+let pendingIds = new Set<string>();
+/** バッチ取得の待ちタイマー。null なら未スケジュール */
+let flushTimer: ReturnType<typeof setTimeout> | null = null;
+/** 次のバッチ取得に使う取得関数(テストではフェイクを注入する) */
+let pendingFetchAvatars: typeof fetchUserAvatars = fetchUserAvatars;
+
+/**
+ * 発言者のアバター取得を要求する。発言(PRIVMSG)受信のたびに呼ばれるため、
+ * 要求はバッチにまとめ、要求済みの ID は何もしない。
+ * userId が null(タグ無し)の発言は無視する。
+ */
+export function requestAvatar(
+  userId: string | null,
+  fetchAvatars: typeof fetchUserAvatars = fetchUserAvatars,
+): void {
+  if (userId === null) return;
+  if (requestedIds.has(userId) || failedIds.has(userId)) return;
+
+  requestedIds.add(userId);
+  pendingIds.add(userId);
+  pendingFetchAvatars = fetchAvatars;
+  if (flushTimer === null) {
+    flushTimer = setTimeout(() => {
+      void flushPendingRequests();
+    }, AVATAR_BATCH_WINDOW_MS);
+  }
+}
+
+/** 溜まった ID をまとめて取得し、結果をキャッシュとストアへ反映する */
+async function flushPendingRequests(): Promise<void> {
+  flushTimer = null;
+  const ids = [...pendingIds];
+  pendingIds = new Set();
+  const fetchAvatars = pendingFetchAvatars;
+
+  const result = await fetchAvatars(ids);
+
+  if (result === null) {
+    // Helix 利用不可・一時的な失敗: 発言のたびに繰り返さないよう失敗として記録する。
+    // チャンネル切り替え時の clearAvatarLoadFailures で再試行できるようになる
+    for (const id of ids) {
+      requestedIds.delete(id);
+      failedIds.add(id);
+    }
+    return;
+  }
+
+  // レスポンスに含まれない ID(退会済みなど)は requestedIds に残り、アバターなしとして確定する
+  for (const [id, url] of result) {
+    avatarCache.set(id, url);
+  }
+  // 上限を超えたぶんは古い発言者(挿入順の先頭)から捨て、再要求できるようにする
+  while (avatarCache.size > MAX_AVATAR_CACHE_ENTRIES) {
+    const oldestId = avatarCache.keys().next().value as string;
+    avatarCache.delete(oldestId);
+    requestedIds.delete(oldestId);
+  }
+  useAvatarStore.setState({ avatars: Object.fromEntries(avatarCache) });
+}
+
+/**
+ * 取得失敗の記録をクリアし、失敗した ID を再取得できるようにする。
+ * チャンネル切り替え(`connect()`)時に呼ぶ(取得済みのキャッシュは持ち越す)。
+ */
+export function clearAvatarLoadFailures(): void {
+  failedIds.clear();
+}
+
+/** テスト専用: モジュールスコープの状態を初期状態に戻す。各テストの afterEach で呼び出すこと */
+export function resetAvatarsForTests(): void {
+  if (flushTimer !== null) {
+    clearTimeout(flushTimer);
+    flushTimer = null;
+  }
+  avatarCache.clear();
+  requestedIds.clear();
+  failedIds.clear();
+  pendingIds = new Set();
+  pendingFetchAvatars = fetchUserAvatars;
+  useAvatarStore.setState({ avatars: {} });
+}

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -60,6 +60,15 @@ vi.mock("./cheermotes", async () => {
   };
 });
 
+// 発言者アバターの読み込みも実 API(Helix プロキシ)を呼ぶため、ストア連携だけをモックで検証する
+const mockRequestAvatar = vi.fn();
+const mockClearAvatarLoadFailures = vi.fn();
+
+vi.mock("./avatars", () => ({
+  requestAvatar: (userId: string | null) => mockRequestAvatar(userId),
+  clearAvatarLoadFailures: () => mockClearAvatarLoadFailures(),
+}));
+
 import { resetBotFilterStoreForTests, useBotFilterStore } from "./bot-filter";
 import { resetChatConnectionStoreForTests, subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
 
@@ -95,6 +104,8 @@ afterEach(() => {
   mockClearThirdPartyEmotes.mockClear();
   mockLoadCheermotes.mockClear();
   mockClearCheermotes.mockClear();
+  mockRequestAvatar.mockClear();
+  mockClearAvatarLoadFailures.mockClear();
   fakeThirdPartyEmoteMap = new Map();
   window.localStorage.clear();
 });
@@ -363,6 +374,33 @@ describe("Cheermote 一覧(Helix Cheermotes API)", () => {
     useChatConnectionStore.getState().connect("ZackRawrr");
 
     expect(mockClearCheermotes).toHaveBeenCalled();
+  });
+});
+
+describe("発言者アバター(Helix Get Users API)", () => {
+  it("privmsg 受信時に、発言者の user-id でアバターの取得を要求する", () => {
+    useChatConnectionStore.getState().connect("somechannel");
+    const message = createSampleMessage({ userId: "987654" });
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message });
+
+    expect(mockRequestAvatar).toHaveBeenCalledWith("987654");
+  });
+
+  it("bot 除外に一致する発言では、アバターの取得を要求しない", () => {
+    useBotFilterStore.getState().setPatterns(["streamelements"]);
+    useChatConnectionStore.getState().connect("somechannel");
+    const botMessage = createSampleMessage({ username: "streamelements", userId: "100135110" });
+
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "somechannel", message: botMessage });
+
+    expect(mockRequestAvatar).not.toHaveBeenCalled();
+  });
+
+  it("connect() を呼ぶと、アバター取得失敗の記録をクリアして再試行できるようにする", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(mockClearAvatarLoadFailures).toHaveBeenCalled();
   });
 });
 

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -29,6 +29,7 @@ import { mergeCheermotePositions } from "@/lib/twitch/cheermotes";
 import { mergeThirdPartyEmotePositions } from "@/lib/twitch/third-party-emotes";
 import { matchesBotFilter } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
+import { clearAvatarLoadFailures, requestAvatar } from "./avatars";
 import { clearStreamInfo, loadStreamInfo } from "./stream-info";
 import { clearThirdPartyEmotes, getThirdPartyEmoteMap, loadThirdPartyEmotes } from "./third-party-emotes";
 import { clearCheermotes, getCheermoteSet, loadCheermotes } from "./cheermotes";
@@ -71,6 +72,9 @@ function getClient(): TwitchIrcClient {
         }
         if (event.type !== "privmsg") return;
         if (isExcludedByBotFilter(event.message.username)) return;
+        // 発言者のアバター(プロフィール画像)を Helix からバッチで取得する(issue #60)。
+        // 取得完了までは avatars ストアに URL が無く、アバターなしで表示される
+        requestAvatar(event.message.userId);
         // 本文中の Cheermote(bits 付き発言)とサードパーティ emote 名(BTTV / FFZ / 7TV)を
         // 位置情報として合成してから保持・通知する。下流(描画・翻訳・Pick up)は
         // Twitch 公式 emote と同じ扱いで処理できる
@@ -108,6 +112,8 @@ export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
     clearThirdPartyEmotes();
     clearCheermotes();
     clearStreamInfo();
+    // アバターのキャッシュはユーザー固有のため持ち越すが、取得失敗の記録はクリアして再試行できるようにする
+    clearAvatarLoadFailures();
     const normalized = normalizeChannelName(channel);
     set({ messages: [], channel: normalized });
     // 配信情報(タイトル・カテゴリ。issue #54)はチャンネル名(user_login)だけで取得できるため、


### PR DESCRIPTION
## Summary

Helix の `GET /users` からプロフィール画像 URL を取得し、生IRC列の発言者にアバターを表示します。誰の発言かをひと目で判別しやすくします。

## 変更内容

- **アバター取得クライアント**(`src/lib/twitch/user-avatars.ts` 新規): 発言者 ID をプロキシ(`/api/twitch/users?id=`)経由でバッチ取得(1 リクエスト最大 100 件、超過分は分割)。全チャンク失敗時のみ null(Helix 利用不可)、一部失敗時は取得済みぶんを返す
- **アバターストア**(`src/store/avatars.ts` 新規):
  - 発言受信時の要求を 250ms のバッチ窓でまとめて取得
  - キャッシュはユーザー固有のためチャンネルをまたいで持ち越し、上限 500 件を LRU で管理(「アバターなし」の負のキャッシュも同じ上限)
  - Helix 利用不可(全面失敗)は利用不可フラグで記録してリクエスト連発を防ぎ、チャンネル切り替え時にクリアして再試行(世代フェンスで進行中バッチの失敗と競合しない)
- **chat-connection**(`src/store/chat-connection.ts`): privmsg 受信時(bot 除外後)にアバター取得を要求、`connect()` で失敗記録をクリア
- **生IRC列**(`src/app/page.tsx`): 発言行の表示名の前にアバターを表示。アバターの遅延反映で行の高さが変わっても追従スクロールが最下部を維持
- 未取得・取得失敗・Helix 利用不可時はアバターなしの現行表示のまま動作します

## テスト

- `npm run lint` / `npm run type-check` / `npm test`(602 件)/ `npm run build` すべて成功
- CodeRabbit はレートリミットのため `/code-review`(high)で代替実施。指摘 10 件のうち 9 件に対応、共通 fetch ヘルパー抽出(3ファイル横断)は別 issue 化

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH