### PR TITLE
feat: チャンネル固有バッジを画像表示する(Helix /chat/badges)

### DIFF
--- a/src/app/api/twitch/[...path]/route.test.ts
+++ b/src/app/api/twitch/[...path]/route.test.ts
@@ -90,6 +90,20 @@ describe("GET /api/twitch/[...path]", () => {
     );
   });
 
+  it("チャットバッジ(chat/badges・chat/badges/global)も中継できる", async () => {
+    fetchMock.mockResolvedValue(helixResponse({ data: [] }));
+
+    const channelResponse = await callGet(["chat", "badges"], "?broadcaster_id=12345");
+    const globalResponse = await callGet(["chat", "badges", "global"]);
+
+    expect(channelResponse.status).toBe(200);
+    expect(globalResponse.status).toBe(200);
+    expect(fetchMock.mock.calls.map((call) => call[0])).toEqual([
+      "https://api.twitch.tv/helix/chat/badges?broadcaster_id=12345",
+      "https://api.twitch.tv/helix/chat/badges/global",
+    ]);
+  });
+
   it("許可リストにないエンドポイントは 404 を返し、Helix へ中継しない", async () => {
     const response = await callGet(["moderation", "banned"]);
 

--- a/src/app/api/twitch/[...path]/route.ts
+++ b/src/app/api/twitch/[...path]/route.ts
@@ -34,6 +34,8 @@ const ALLOWED_ENDPOINTS: ReadonlySet<string> = new Set([
   "channels",
   "bits/cheermotes",
   "chat/emotes",
+  "chat/badges",
+  "chat/badges/global",
 ]);
 
 /** エラーレスポンス(JSON)を組み立てる */

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -16,6 +16,7 @@ import { act, fireEvent, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
+import { resetBadgesForTests, useBadgeStore } from "@/store/badges";
 import { resetBotFilterStoreForTests, useBotFilterStore } from "@/store/bot-filter";
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetPickupStoreForTests, usePickupStore } from "@/store/pickups";
@@ -90,6 +91,7 @@ afterEach(() => {
   resetPromptApiStoreForTests();
   resetBotFilterStoreForTests();
   resetSettingsStoreForTests();
+  resetBadgesForTests();
   window.localStorage.clear();
 });
 
@@ -110,6 +112,46 @@ describe("Home(3カラム構成)", () => {
     const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
     expect(within(rawColumn).getByText("viewer_taro")).toBeInTheDocument();
     expect(within(rawColumn).getByText("gg no re chat")).toBeInTheDocument();
+  });
+
+  it("対応表にあるバッジを、生IRC列の発言行の表示名の前に画像で表示する", () => {
+    // モデレーターかつサブスク3ヶ月の発言者。サブスクバッジはチャンネル固有画像
+    useChatConnectionStore.setState({
+      messages: [
+        {
+          ...サンプル発言,
+          badges: [
+            { name: "moderator", version: "1" },
+            { name: "subscriber", version: "3" },
+          ],
+        },
+      ],
+    });
+    useBadgeStore.setState({
+      badgeImages: {
+        "moderator/1": "https://cdn.example/moderator/1/2x.png",
+        "subscriber/3": "https://cdn.example/channel/subscriber/3/2x.png",
+      },
+    });
+
+    render(<Home />);
+
+    const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
+    expect(rawColumn.querySelector('img[src="https://cdn.example/moderator/1/2x.png"]')).not.toBeNull();
+    expect(rawColumn.querySelector('img[src="https://cdn.example/channel/subscriber/3/2x.png"]')).not.toBeNull();
+  });
+
+  it("対応表に無いバッジ・対応表が未読み込み(Helix 利用不可)の場合は、バッジを表示せず現行どおり動作する", () => {
+    useChatConnectionStore.setState({
+      messages: [{ ...サンプル発言, badges: [{ name: "moderator", version: "1" }] }],
+    });
+    // 対応表は空(未読み込み・Helix 利用不可)
+
+    render(<Home />);
+
+    const rawColumn = screen.getByRole("region", { name: "Raw IRC" });
+    expect(within(rawColumn).getByText("viewer_taro")).toBeInTheDocument();
+    expect(rawColumn.querySelector('img[alt="moderator"]')).toBeNull();
   });
 
   it("翻訳列とPick up列は初期状態では見えており(ぼかし無し)、トグルでぼかせる", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -44,6 +44,7 @@ import { cn } from "@/lib/utils";
 import type { ConnectionState } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { buildEmoteImageUrl, splitMessageIntoSegments, type MessageSegment } from "@/lib/twitch/emotes";
+import { useBadgeStore } from "@/store/badges";
 import { hydrateBotFilterStore } from "@/store/bot-filter";
 import { useChatConnectionStore } from "@/store/chat-connection";
 import type { PipelineEntry } from "@/store/auto-pipeline";
@@ -521,9 +522,26 @@ function ChatMessageRow({ message }: { message: TwitchChatMessage }) {
     () => splitMessageIntoSegments(message.text, message.emotes),
     [message.text, message.emotes],
   );
+  // バッジ対応表(issue #61)。未読み込み・Helix 利用不可時は空で、バッジ非表示の現行表示になる
+  const badgeImages = useBadgeStore((state) => state.badgeImages);
 
   return (
     <Row message={message} blurred={false}>
+      {message.badges.map((badge) => {
+        const badgeImageUrl = badgeImages[`${badge.name}/${badge.version}`];
+        // 対応表に無いバッジ(未知の set_id など)は非表示のまま現行どおり動作する
+        if (badgeImageUrl === undefined) return null;
+        return (
+          // eslint-disable-next-line @next/next/no-img-element -- Twitch CDNの外部画像のためnext/imageのドメイン許可設定は不要な単純imgで表示する
+          <img
+            key={`${badge.name}/${badge.version}`}
+            src={badgeImageUrl}
+            alt={badge.name}
+            title={badge.name}
+            className="mr-1 inline-block h-[18px] w-[18px] align-text-bottom"
+          />
+        );
+      })}
       <span className="font-semibold" style={message.color ? { color: message.color } : undefined}>
         {message.displayName}
       </span>

--- a/src/lib/twitch/badges.test.ts
+++ b/src/lib/twitch/badges.test.ts
@@ -1,0 +1,132 @@
+/**
+ * src/lib/twitch/badges.ts(チャットバッジの画像 URL 対応表)のテスト。
+ *
+ * Helix の Chat Badges API(`GET /chat/badges/global` と `GET /chat/badges?broadcaster_id=`)の
+ * レスポンスを「set_id/version → 画像 URL」の対応表として解析する処理と、
+ * Next.js プロキシ経由でグローバル + チャンネル固有を取得してマージ
+ * (同じ set_id はチャンネル固有を優先)する処理を検証する。
+ * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fetchBadgeImageMap, parseBadgeImageMap } from "./badges";
+
+/** Helix Chat Badges API のグローバルバッジのレスポンス(検証に使う部分のみ) */
+const グローバルバッジJSON = {
+  data: [
+    {
+      set_id: "moderator",
+      versions: [{ id: "1", image_url_2x: "https://cdn.example/global/moderator/1/2x.png" }],
+    },
+    {
+      set_id: "subscriber",
+      versions: [
+        { id: "0", image_url_2x: "https://cdn.example/global/subscriber/0/2x.png" },
+        { id: "3", image_url_2x: "https://cdn.example/global/subscriber/3/2x.png" },
+      ],
+    },
+  ],
+};
+
+/** チャンネル固有バッジのレスポンス(サブスクバッジをチャンネル独自画像で上書きする) */
+const チャンネルバッジJSON = {
+  data: [
+    {
+      set_id: "subscriber",
+      versions: [{ id: "0", image_url_2x: "https://cdn.example/channel/subscriber/0/2x.png" }],
+    },
+  ],
+};
+
+describe("parseBadgeImageMap", () => {
+  it("レスポンスから「set_id/version → 画像 URL」の対応表を作る", () => {
+    expect(parseBadgeImageMap(グローバルバッジJSON)).toEqual(
+      new Map([
+        ["moderator/1", "https://cdn.example/global/moderator/1/2x.png"],
+        ["subscriber/0", "https://cdn.example/global/subscriber/0/2x.png"],
+        ["subscriber/3", "https://cdn.example/global/subscriber/3/2x.png"],
+      ]),
+    );
+  });
+
+  it("set_id・versions・画像 URL が無い項目・型が想定と異なる項目は読み飛ばす", () => {
+    const json = {
+      data: [
+        { versions: [{ id: "1", image_url_2x: "https://cdn.example/no-set-id.png" }] },
+        { set_id: "broken", versions: "配列でない" },
+        { set_id: "no-url", versions: [{ id: "1" }] },
+        { set_id: "vip", versions: [{ id: "1", image_url_2x: "https://cdn.example/vip/1/2x.png" }] },
+      ],
+    };
+    expect(parseBadgeImageMap(json)).toEqual(new Map([["vip/1", "https://cdn.example/vip/1/2x.png"]]));
+  });
+
+  it("data が配列でない・オブジェクトでない JSON は空の対応表を返す", () => {
+    expect(parseBadgeImageMap({ data: "壊れたレスポンス" })).toEqual(new Map());
+    expect(parseBadgeImageMap(null)).toEqual(new Map());
+  });
+});
+
+describe("fetchBadgeImageMap", () => {
+  /** URL に応じてグローバル・チャンネルのレスポンスを返すフェイク fetch */
+  function createFetchFn(
+    globalResult: { status: number; body: unknown } | Error,
+    channelResult: { status: number; body: unknown } | Error,
+  ) {
+    return vi.fn(async (input: RequestInfo | URL) => {
+      const result = String(input).includes("/chat/badges/global") ? globalResult : channelResult;
+      if (result instanceof Error) throw result;
+      return new Response(JSON.stringify(result.body), { status: result.status });
+    });
+  }
+
+  it("グローバルとチャンネル固有をマージし、同じ set_id/version はチャンネル固有を優先する", async () => {
+    const fetchFn = createFetchFn(
+      { status: 200, body: グローバルバッジJSON },
+      { status: 200, body: チャンネルバッジJSON },
+    );
+
+    const map = await fetchBadgeImageMap("12345", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/chat/badges/global");
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/chat/badges?broadcaster_id=12345");
+    expect(map).toEqual(
+      new Map([
+        ["moderator/1", "https://cdn.example/global/moderator/1/2x.png"],
+        // subscriber/0 はチャンネル固有画像で上書きされる
+        ["subscriber/0", "https://cdn.example/channel/subscriber/0/2x.png"],
+        ["subscriber/3", "https://cdn.example/global/subscriber/3/2x.png"],
+      ]),
+    );
+  });
+
+  it("チャンネル固有だけが取得できない場合は、グローバルだけの対応表を返す", async () => {
+    const fetchFn = createFetchFn(
+      { status: 200, body: グローバルバッジJSON },
+      { status: 500, body: { error: "server error" } },
+    );
+
+    const map = await fetchBadgeImageMap("12345", fetchFn);
+
+    expect(map).toEqual(parseBadgeImageMap(グローバルバッジJSON));
+  });
+
+  it("グローバルだけが取得できない場合は、チャンネル固有だけの対応表を返す", async () => {
+    const fetchFn = createFetchFn(new TypeError("network error"), {
+      status: 200,
+      body: チャンネルバッジJSON,
+    });
+
+    const map = await fetchBadgeImageMap("12345", fetchFn);
+
+    expect(map).toEqual(new Map([["subscriber/0", "https://cdn.example/channel/subscriber/0/2x.png"]]));
+  });
+
+  it("両方とも取得できない場合(Helix 未設定の 503 など)は null を返す", async () => {
+    const fetchFn = createFetchFn(
+      { status: 503, body: { error: "Helix API が設定されていません" } },
+      { status: 503, body: { error: "Helix API が設定されていません" } },
+    );
+
+    expect(await fetchBadgeImageMap("12345", fetchFn)).toBeNull();
+  });
+});

--- a/src/lib/twitch/badges.ts
+++ b/src/lib/twitch/badges.ts
@@ -1,0 +1,92 @@
+/**
+ * チャットバッジ(サブスク・モデレーター・VIP など)の画像 URL 対応表(issue #61)。
+ *
+ * Helix の Chat Badges API(`GET /chat/badges/global` と `GET /chat/badges?broadcaster_id=`)を
+ * Next.js プロキシ(`/api/twitch/`)経由で呼び、IRC の `badges` タグ
+ * (`TwitchChatMessage.badges` の `{name, version}`)を画像 URL に解決するための
+ * 「set_id/version → 画像 URL」対応表を作る。
+ * 特にサブスクバッジはチャンネル固有画像のため、Helix でしか解決できない。
+ * 読み込みの流れと保持は `src/store/badges.ts` が担う。
+ *
+ * - グローバルとチャンネル固有を並行取得してマージし、同じ set_id/version は
+ *   チャンネル固有を優先する(Twitch の仕様どおりチャンネル側が上書きする)
+ * - 片方だけ取得できない場合は取得できた側だけの対応表を返す。
+ *   両方とも取得できない場合(Helix 未設定の 503・障害・ネットワークエラー)は null を返し、
+ *   呼び出し側はバッジ非表示のまま現行どおり動作する(意図した仕様)
+ * - 画像は 2 倍サイズ(`image_url_2x`)を使う(高解像度ディスプレイでも約 18px 表示が滲まないように)
+ */
+
+/** 「set_id/version → 画像 URL」の対応表 */
+export type BadgeImageMap = ReadonlyMap<string, string>;
+
+/**
+ * Helix の Chat Badges API レスポンス(`{data: [{set_id, versions: [{id, image_url_2x}]}]}`)を
+ * 解析して「set_id/version → 画像 URL」の対応表を作る。
+ * API 側の仕様変更などで形式が想定と異なる項目は読み飛ばす。
+ */
+export function parseBadgeImageMap(json: unknown): Map<string, string> {
+  const map = new Map<string, string>();
+  if (typeof json !== "object" || json === null) return map;
+  const data = (json as Record<string, unknown>).data;
+  if (!Array.isArray(data)) return map;
+
+  for (const entry of data) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.set_id !== "string" || record.set_id === "") continue;
+    if (!Array.isArray(record.versions)) continue;
+
+    for (const version of record.versions) {
+      if (typeof version !== "object" || version === null) continue;
+      const versionRecord = version as Record<string, unknown>;
+      if (typeof versionRecord.id !== "string" || versionRecord.id === "") continue;
+      if (typeof versionRecord.image_url_2x !== "string" || versionRecord.image_url_2x === "") continue;
+      map.set(`${record.set_id}/${versionRecord.id}`, versionRecord.image_url_2x);
+    }
+  }
+  return map;
+}
+
+/** 1 エンドポイントぶんの対応表を取得する。取得できない場合は null */
+async function fetchSingleBadgeMap(path: string, fetchFn: typeof fetch): Promise<Map<string, string> | null> {
+  try {
+    const response = await fetchFn(path);
+    if (!response.ok) {
+      console.warn(`チャットバッジの取得に失敗しました(HTTP ${response.status})。バッジなしで表示します`);
+      return null;
+    }
+    return parseBadgeImageMap(await response.json());
+  } catch (error) {
+    console.warn("チャットバッジの取得に失敗しました。バッジなしで表示します", error);
+    return null;
+  }
+}
+
+/**
+ * Helix プロキシから、グローバルバッジと指定した配信者のチャンネル固有バッジを
+ * 並行取得してマージした対応表を返す。同じ set_id/version はチャンネル固有を優先する。
+ *
+ * 片方だけ取得できない場合は取得できた側だけの対応表を返す。
+ * 両方とも取得できない場合は null を返す(呼び出し側の `src/store/badges.ts` が
+ * 未読み込みのまま次の ROOMSTATE で再試行できるようにする。意図した仕様)。
+ */
+export async function fetchBadgeImageMap(
+  broadcasterId: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<BadgeImageMap | null> {
+  const [globalMap, channelMap] = await Promise.all([
+    fetchSingleBadgeMap("/api/twitch/chat/badges/global", fetchFn),
+    fetchSingleBadgeMap(
+      `/api/twitch/chat/badges?broadcaster_id=${encodeURIComponent(broadcasterId)}`,
+      fetchFn,
+    ),
+  ]);
+  if (globalMap === null && channelMap === null) return null;
+
+  // グローバルを先に入れ、チャンネル固有で上書きする(チャンネル固有優先)
+  const merged = new Map(globalMap ?? []);
+  for (const [key, url] of channelMap ?? []) {
+    merged.set(key, url);
+  }
+  return merged;
+}

--- a/src/store/badges.test.ts
+++ b/src/store/badges.test.ts
@@ -1,0 +1,103 @@
+/**
+ * src/store/badges.ts(チャットバッジ画像対応表の保持)のテスト。
+ *
+ * ROOMSTATE で判明した配信者の Twitch ID から Helix の Chat Badges API 経由で
+ * 「set_id/version → 画像 URL」の対応表(グローバル + チャンネル固有)を読み込み、
+ * 生IRC列の発言行が Zustand ストア経由で参照する流れと、
+ * チャンネル切り替え時のクリア・失敗時の再試行(`src/store/cheermotes.ts` と同じ方針)を検証する。
+ * 実際の API 呼び出しは行わず、フェイクの読み込み関数を注入する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { clearBadges, loadBadges, resetBadgesForTests, useBadgeStore } from "./badges";
+
+afterEach(() => {
+  resetBadgesForTests();
+});
+
+/** テスト用のバッジ画像対応表(モデレーターとチャンネル固有サブスクバッジ) */
+const FAKE_BADGE_IMAGE_MAP = new Map([
+  ["moderator/1", "https://cdn.example/moderator/1/2x.png"],
+  ["subscriber/0", "https://cdn.example/channel/subscriber/0/2x.png"],
+]);
+
+describe("loadBadges", () => {
+  it("未読み込みの間は空の対応表を返す", () => {
+    expect(useBadgeStore.getState().badgeImages).toEqual({});
+  });
+
+  it("読み込んだ対応表をストアで参照できる", async () => {
+    const fetchMap = vi.fn(async () => FAKE_BADGE_IMAGE_MAP);
+
+    await loadBadges("12345", fetchMap);
+
+    expect(fetchMap).toHaveBeenCalledWith("12345");
+    expect(useBadgeStore.getState().badgeImages).toEqual({
+      "moderator/1": "https://cdn.example/moderator/1/2x.png",
+      "subscriber/0": "https://cdn.example/channel/subscriber/0/2x.png",
+    });
+  });
+
+  it("同じ Twitch ID の2回目の読み込みは行わない(ROOMSTATE は再接続などで複数回届く)", async () => {
+    const fetchMap = vi.fn(async () => FAKE_BADGE_IMAGE_MAP);
+
+    await loadBadges("12345", fetchMap);
+    await loadBadges("12345", fetchMap);
+
+    expect(fetchMap).toHaveBeenCalledTimes(1);
+  });
+
+  it("読み込みに失敗(null = Helix 利用不可)した場合は空の対応表のまま、同じ ID で再試行できる", async () => {
+    const fetchMap = vi.fn(async () => null);
+
+    await loadBadges("12345", fetchMap);
+
+    expect(useBadgeStore.getState().badgeImages).toEqual({});
+
+    await loadBadges("12345", fetchMap);
+
+    expect(fetchMap).toHaveBeenCalledTimes(2);
+  });
+
+  it("読み込み完了前に clearBadges された場合は結果を破棄する(チャンネル切り替え)", async () => {
+    let resolveFetch: (map: Map<string, string> | null) => void = () => {};
+    const fetchMap = vi.fn(
+      () => new Promise<Map<string, string> | null>((resolve) => (resolveFetch = resolve)),
+    );
+
+    const loading = loadBadges("12345", fetchMap);
+    clearBadges();
+    resolveFetch(FAKE_BADGE_IMAGE_MAP);
+    await loading;
+
+    expect(useBadgeStore.getState().badgeImages).toEqual({});
+  });
+
+  it("別チャンネルの読み込みを新しく開始したら、遅れて届いた前チャンネルの結果で上書きしない", async () => {
+    let resolveFirst: (map: Map<string, string> | null) => void = () => {};
+    const firstFetch = vi.fn(
+      () => new Promise<Map<string, string> | null>((resolve) => (resolveFirst = resolve)),
+    );
+    const secondMap = new Map([["vip/1", "https://cdn.example/vip/1/2x.png"]]);
+    const secondFetch = vi.fn(async () => secondMap);
+
+    const firstLoading = loadBadges("11111", firstFetch);
+    clearBadges();
+    await loadBadges("22222", secondFetch);
+    resolveFirst(FAKE_BADGE_IMAGE_MAP);
+    await firstLoading;
+
+    expect(useBadgeStore.getState().badgeImages).toEqual({
+      "vip/1": "https://cdn.example/vip/1/2x.png",
+    });
+  });
+});
+
+describe("clearBadges", () => {
+  it("読み込み済みの対応表を破棄して未読み込み状態に戻す", async () => {
+    await loadBadges("12345", async () => FAKE_BADGE_IMAGE_MAP);
+
+    clearBadges();
+
+    expect(useBadgeStore.getState().badgeImages).toEqual({});
+  });
+});

--- a/src/store/badges.ts
+++ b/src/store/badges.ts
@@ -1,0 +1,71 @@
+/**
+ * チャットバッジ画像対応表(「set_id/version → 画像 URL」)を保持する Zustand ストア(issue #61)。
+ *
+ * `chat-connection.ts` が ROOMSTATE の `room-id`(配信者の Twitch ユーザー ID)を受け取った時点で
+ * `loadBadges` を呼び、Helix の Chat Badges API(`src/lib/twitch/badges.ts`)から
+ * グローバル + チャンネル固有の対応表を読み込む(`src/store/cheermotes.ts` と同じ方針)。
+ * 生IRC列(`src/app/page.tsx`)は発言行の `badges` タグを描画時に画像へ解決するため、
+ * 読み込み完了で行が再描画されるよう Zustand ストアで保持する。
+ *
+ * - Helix が利用できない場合(`fetchBadgeImageMap` が null)は空の対応表のまま
+ *   バッジ非表示で動作する(意図したフォールバック)。一時的な失敗の可能性があるため、
+ *   次の ROOMSTATE で再試行できるように未読み込み状態へ戻す
+ * - 同じ Twitch ID への読み込みは 1 回だけ行う(ROOMSTATE は再接続などで複数回届く)
+ * - チャンネル切り替え(`connect()`)時は `clearBadges` で対応表を破棄し、
+ *   読み込み途中だった前チャンネルの結果は世代番号の比較で捨てる
+ */
+import { create } from "zustand";
+import { fetchBadgeImageMap, type BadgeImageMap } from "@/lib/twitch/badges";
+
+interface BadgeState {
+  /** 「set_id/version → 画像 URL」の対応表。未読み込み・クリア直後・読み込み失敗時は空 */
+  badgeImages: Record<string, string>;
+}
+
+export const useBadgeStore = create<BadgeState>(() => ({ badgeImages: {} }));
+
+/** 読み込み済み(または読み込み中)の Twitch ユーザー ID。未読み込みなら null */
+let loadedRoomId: string | null = null;
+/** クリア・読み込み開始のたびに進める世代番号。読み込み完了時に世代が変わっていたら結果を破棄する */
+let generation = 0;
+
+/**
+ * 指定した配信者の Twitch ユーザー ID でバッジ対応表を読み込む。
+ * 同じ ID で読み込み済み(読み込み中を含む)の場合は何もしない。
+ * 読み込みに失敗した場合は空の対応表のまま、次の ROOMSTATE で再試行できる状態に戻す。
+ */
+export async function loadBadges(
+  roomId: string,
+  fetchMap: (broadcasterId: string) => Promise<BadgeImageMap | null> = fetchBadgeImageMap,
+): Promise<void> {
+  if (loadedRoomId === roomId) return;
+  loadedRoomId = roomId;
+  // 世代番号を進めてから控える。別チャンネルの読み込みを新しく開始した時点で
+  // 進行中の古い読み込みを無効化し、遅れて届いた結果による上書きを防ぐ
+  const requestGeneration = ++generation;
+
+  const map = await fetchMap(roomId);
+
+  // 読み込み中にチャンネルが切り替わっていたら(クリア済みなら)、前チャンネルの結果は捨てる
+  if (generation !== requestGeneration) return;
+
+  if (map === null) {
+    // Helix 利用不可・一時的な失敗: バッジ非表示のまま、次の ROOMSTATE で再試行できるようにする
+    loadedRoomId = null;
+    return;
+  }
+
+  useBadgeStore.setState({ badgeImages: Object.fromEntries(map) });
+}
+
+/** 対応表を破棄して未読み込み状態にする。チャンネル切り替え時に呼ぶ */
+export function clearBadges(): void {
+  generation += 1;
+  loadedRoomId = null;
+  useBadgeStore.setState({ badgeImages: {} });
+}
+
+/** テスト専用: モジュールスコープの状態を初期状態に戻す。各テストの afterEach で呼び出すこと */
+export function resetBadgesForTests(): void {
+  clearBadges();
+}

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -60,6 +60,15 @@ vi.mock("./cheermotes", async () => {
   };
 });
 
+// チャットバッジ対応表の読み込みも実 API(Helix プロキシ)を呼ぶため、ストア連携だけをモックで検証する
+const mockLoadBadges = vi.fn();
+const mockClearBadges = vi.fn();
+
+vi.mock("./badges", () => ({
+  loadBadges: (roomId: string) => mockLoadBadges(roomId),
+  clearBadges: () => mockClearBadges(),
+}));
+
 import { resetBotFilterStoreForTests, useBotFilterStore } from "./bot-filter";
 import { resetChatConnectionStoreForTests, subscribeToChatMessages, useChatConnectionStore } from "./chat-connection";
 
@@ -95,6 +104,8 @@ afterEach(() => {
   mockClearThirdPartyEmotes.mockClear();
   mockLoadCheermotes.mockClear();
   mockClearCheermotes.mockClear();
+  mockLoadBadges.mockClear();
+  mockClearBadges.mockClear();
   fakeThirdPartyEmoteMap = new Map();
   window.localStorage.clear();
 });
@@ -363,6 +374,52 @@ describe("Cheermote 一覧(Helix Cheermotes API)", () => {
     useChatConnectionStore.getState().connect("ZackRawrr");
 
     expect(mockClearCheermotes).toHaveBeenCalled();
+  });
+});
+
+describe("チャットバッジ(Helix Chat Badges API)", () => {
+  it("roomstate イベントを受信すると、room-id を使ってバッジ対応表の読み込みを開始する", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onEvent({
+      type: "roomstate",
+      channel: "zackrawrr",
+      state: {
+        emoteOnly: false,
+        followersOnlyMinutes: null,
+        r9k: false,
+        slowSeconds: 0,
+        subsOnly: false,
+        roomId: "552120296",
+      },
+    });
+
+    expect(mockLoadBadges).toHaveBeenCalledWith("552120296");
+  });
+
+  it("room-id が無い roomstate では読み込みを開始しない", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    capturedCallbacks?.onEvent({
+      type: "roomstate",
+      channel: "zackrawrr",
+      state: {
+        emoteOnly: false,
+        followersOnlyMinutes: null,
+        r9k: false,
+        slowSeconds: 0,
+        subsOnly: false,
+        roomId: null,
+      },
+    });
+
+    expect(mockLoadBadges).not.toHaveBeenCalled();
+  });
+
+  it("connect() を呼ぶと、前のチャンネルのバッジ対応表をクリアする", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(mockClearBadges).toHaveBeenCalled();
   });
 });
 

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -29,6 +29,7 @@ import { mergeCheermotePositions } from "@/lib/twitch/cheermotes";
 import { mergeThirdPartyEmotePositions } from "@/lib/twitch/third-party-emotes";
 import { matchesBotFilter } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
+import { clearBadges, loadBadges } from "./badges";
 import { clearStreamInfo, loadStreamInfo } from "./stream-info";
 import { clearThirdPartyEmotes, getThirdPartyEmoteMap, loadThirdPartyEmotes } from "./third-party-emotes";
 import { clearCheermotes, getCheermoteSet, loadCheermotes } from "./cheermotes";
@@ -62,10 +63,11 @@ function getClient(): TwitchIrcClient {
       onEvent: (event) => {
         if (event.type === "roomstate") {
           // room-id(配信者の Twitch ユーザー ID)が判明した時点で
-          // サードパーティ emote と Cheermote 一覧(Helix)を読み込む
+          // サードパーティ emote と Cheermote 一覧・チャットバッジ対応表(Helix)を読み込む
           if (event.state.roomId !== null) {
             void loadThirdPartyEmotes(event.state.roomId);
             void loadCheermotes(event.state.roomId);
+            void loadBadges(event.state.roomId);
           }
           return;
         }
@@ -107,6 +109,7 @@ export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
     // (emote と Cheermote は ROOMSTATE 受信後に再読み込みされる)
     clearThirdPartyEmotes();
     clearCheermotes();
+    clearBadges();
     clearStreamInfo();
     const normalized = normalizeChannelName(channel);
     set({ messages: [], channel: normalized });


### PR DESCRIPTION
## Summary

Helix の `GET /chat/badges?broadcaster_id=` と `GET /chat/badges/global` からバッジ画像 URL を取得し、発言者のバッジ(サブスク・モデレーター・VIP など)を生IRC列に画像で表示します。特にサブスクバッジはチャンネル固有画像のため Helix でしか解決できません。

## 変更内容

- **Helix プロキシ**(`src/app/api/twitch/[...path]/route.ts`): `ALLOWED_ENDPOINTS` に `chat/badges` と `chat/badges/global` を追加
- **バッジクライアント**(`src/lib/twitch/badges.ts` 新規): グローバルとチャンネル固有を並行取得し「set_id/version → 画像 URL(2x)」の対応表にマージ(同じ set_id/version はチャンネル固有を優先)。片方だけ失敗した場合は取得できた側を返し、両方失敗時のみ null(Helix 利用不可)
- **バッジストア**(`src/store/badges.ts` 新規): ROOMSTATE の `room-id` を契機に読み込み、チャンネル切り替え時にクリア。失敗時は次の ROOMSTATE で再試行(`src/store/cheermotes.ts` と同じ方針)。描画時解決のため Zustand ストアで保持
- **chat-connection**(`src/store/chat-connection.ts`): ROOMSTATE で `loadBadges`、`connect()` で `clearBadges`
- **生IRC列**(`src/app/page.tsx`): 発言行の `badges` タグを画像に解決して表示名の前に表示
- 対応表に無いバッジ・Helix 利用不可(503 など)時はバッジ非表示のまま現行どおり動作します

## テスト

- `npm run lint` / `npm run type-check` / `npm test`(596 件)/ `npm run build` すべて成功
- CodeRabbit レビュー実施(指摘 0 件)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH