### PR TITLE
refactor: Helix プロキシ呼び出しの共通ヘルパー抽出(fetch ラッパーと data 配列パースの重複解消)

### DIFF
--- a/src/lib/twitch/badges.test.ts
+++ b/src/lib/twitch/badges.test.ts
@@ -87,8 +87,10 @@ describe("fetchBadgeImageMap", () => {
 
     const map = await fetchBadgeImageMap("12345", fetchFn);
 
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/chat/badges/global");
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/chat/badges?broadcaster_id=12345");
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/chat/badges/global", { signal: undefined });
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/chat/badges?broadcaster_id=12345", {
+      signal: undefined,
+    });
     expect(map).toEqual(
       new Map([
         ["moderator/1", "https://cdn.example/global/moderator/1/2x.png"],

--- a/src/lib/twitch/badges.ts
+++ b/src/lib/twitch/badges.ts
@@ -16,6 +16,8 @@
  * - 画像は 2 倍サイズ(`image_url_2x`)を使う(高解像度ディスプレイでも約 18px 表示が滲まないように)
  */
 
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
 /** 「set_id/version → 画像 URL」の対応表 */
 export type BadgeImageMap = ReadonlyMap<string, string>;
 
@@ -26,9 +28,8 @@ export type BadgeImageMap = ReadonlyMap<string, string>;
  */
 export function parseBadgeImageMap(json: unknown): Map<string, string> {
   const map = new Map<string, string>();
-  if (typeof json !== "object" || json === null) return map;
-  const data = (json as Record<string, unknown>).data;
-  if (!Array.isArray(data)) return map;
+  const data = extractDataArray(json);
+  if (data === null) return map;
 
   for (const entry of data) {
     if (typeof entry !== "object" || entry === null) continue;
@@ -48,18 +49,18 @@ export function parseBadgeImageMap(json: unknown): Map<string, string> {
 }
 
 /** 1 エンドポイントぶんの対応表を取得する。取得できない場合は null */
-async function fetchSingleBadgeMap(path: string, fetchFn: typeof fetch): Promise<Map<string, string> | null> {
-  try {
-    const response = await fetchFn(path);
-    if (!response.ok) {
-      console.warn(`チャットバッジの取得に失敗しました(HTTP ${response.status})。バッジなしで表示します`);
-      return null;
-    }
-    return parseBadgeImageMap(await response.json());
-  } catch (error) {
-    console.warn("チャットバッジの取得に失敗しました。バッジなしで表示します", error);
-    return null;
-  }
+async function fetchSingleBadgeMap(
+  path: string,
+  params: URLSearchParams | undefined,
+  fetchFn: typeof fetch,
+): Promise<Map<string, string> | null> {
+  const json = await fetchHelixJson(path, {
+    params,
+    fetchFn,
+    failureLog: { subject: "チャットバッジ", fallback: "バッジなしで表示します" },
+  });
+  if (json === null) return null;
+  return parseBadgeImageMap(json);
 }
 
 /**
@@ -75,11 +76,8 @@ export async function fetchBadgeImageMap(
   fetchFn: typeof fetch = fetch,
 ): Promise<BadgeImageMap | null> {
   const [globalMap, channelMap] = await Promise.all([
-    fetchSingleBadgeMap("/api/twitch/chat/badges/global", fetchFn),
-    fetchSingleBadgeMap(
-      `/api/twitch/chat/badges?broadcaster_id=${encodeURIComponent(broadcasterId)}`,
-      fetchFn,
-    ),
+    fetchSingleBadgeMap("chat/badges/global", undefined, fetchFn),
+    fetchSingleBadgeMap("chat/badges", new URLSearchParams({ broadcaster_id: broadcasterId }), fetchFn),
   ]);
   if (globalMap === null && channelMap === null) return null;
 

--- a/src/lib/twitch/channel-search.test.ts
+++ b/src/lib/twitch/channel-search.test.ts
@@ -76,7 +76,7 @@ describe("fetchChannelSuggestions", () => {
     const suggestions = await fetchChannelSuggestions("ざっく らー", { fetchFn });
 
     expect(fetchFn).toHaveBeenCalledWith(
-      "/api/twitch/search/channels?query=%E3%81%96%E3%81%A3%E3%81%8F%20%E3%82%89%E3%83%BC&first=8",
+      "/api/twitch/search/channels?query=%E3%81%96%E3%81%A3%E3%81%8F+%E3%82%89%E3%83%BC&first=8",
       { signal: undefined },
     );
     expect(suggestions).toEqual([

--- a/src/lib/twitch/channel-search.ts
+++ b/src/lib/twitch/channel-search.ts
@@ -11,6 +11,8 @@
  *   null を返し、候補なし(現行の手入力だけの動作)にフォールバックする(意図した仕様)
  */
 
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
 /** チャンネル候補 1 件(Helix Search Channels API の 1 項目) */
 export interface ChannelSuggestion {
   /** 接続に使うログイン名(Helix の `broadcaster_login`) */
@@ -29,9 +31,8 @@ const SUGGESTION_LIMIT = 8;
  * 解析してチャンネル候補一覧を作る。API 側の仕様変更などで形式が想定と異なる項目は読み飛ばす。
  */
 export function parseChannelSuggestions(json: unknown): ChannelSuggestion[] {
-  if (typeof json !== "object" || json === null) return [];
-  const data = (json as Record<string, unknown>).data;
-  if (!Array.isArray(data)) return [];
+  const data = extractDataArray(json);
+  if (data === null) return [];
 
   const suggestions: ChannelSuggestion[] = [];
   for (const entry of data) {
@@ -64,15 +65,12 @@ export async function fetchChannelSuggestions(
   options: { signal?: AbortSignal; fetchFn?: typeof fetch } = {},
 ): Promise<ChannelSuggestion[] | null> {
   const { signal, fetchFn = fetch } = options;
-  try {
-    const response = await fetchFn(
-      `/api/twitch/search/channels?query=${encodeURIComponent(query)}&first=${SUGGESTION_LIMIT}`,
-      { signal },
-    );
-    if (!response.ok) return null;
-    return parseChannelSuggestions(await response.json());
-  } catch {
-    // 中断(AbortError)・ネットワークエラーのいずれも候補なしとして扱う
-    return null;
-  }
+  // failureLog を渡さない = 失敗しても console.warn しない(中断・ネットワークエラーを候補なしとして静かに扱う)
+  const json = await fetchHelixJson("search/channels", {
+    params: new URLSearchParams({ query, first: String(SUGGESTION_LIMIT) }),
+    fetchFn,
+    signal,
+  });
+  if (json === null) return null;
+  return parseChannelSuggestions(json);
 }

--- a/src/lib/twitch/cheermotes.test.ts
+++ b/src/lib/twitch/cheermotes.test.ts
@@ -244,7 +244,9 @@ describe("fetchCheermoteSet", () => {
 
     const set = await fetchCheermoteSet("552120296", fetchFn);
 
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/bits/cheermotes?broadcaster_id=552120296");
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/bits/cheermotes?broadcaster_id=552120296", {
+      signal: undefined,
+    });
     expect(set?.get("mycustom")).toEqual([
       { minBits: 100, imageUrl: "https://example.com/mycustom/100/2.gif" },
     ]);

--- a/src/lib/twitch/cheermotes.ts
+++ b/src/lib/twitch/cheermotes.ts
@@ -26,6 +26,7 @@
  * - 位置は Twitch の `emotes` タグと同じくコードポイント単位・end は inclusive
  */
 import type { EmotePosition } from "./irc-parser";
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
 
 /** Cheermote の 1 ティア(bits 数の閾値と、その段階の画像 URL) */
 export interface CheermoteTier {
@@ -204,9 +205,8 @@ function parseCheermoteTier(value: unknown): CheermoteTier | null {
  */
 export function parseCheermoteSet(json: unknown): CheermoteSet {
   const set = new Map<string, readonly CheermoteTier[]>();
-  if (typeof json !== "object" || json === null) return set;
-  const data = (json as Record<string, unknown>).data;
-  if (!Array.isArray(data)) return set;
+  const data = extractDataArray(json);
+  if (data === null) return set;
 
   for (const entry of data) {
     if (typeof entry !== "object" || entry === null) continue;
@@ -238,22 +238,17 @@ export async function fetchCheermoteSet(
   broadcasterId: string,
   fetchFn: typeof fetch = fetch,
 ): Promise<CheermoteSet | null> {
-  try {
-    const response = await fetchFn(
-      `/api/twitch/bits/cheermotes?broadcaster_id=${encodeURIComponent(broadcasterId)}`,
-    );
-    if (!response.ok) {
-      console.warn(`Cheermote 一覧の取得に失敗しました(HTTP ${response.status})。静的一覧を使います`);
-      return null;
-    }
-    const set = parseCheermoteSet(await response.json());
-    if (set.size === 0) {
-      console.warn("Cheermote 一覧のレスポンスを解析できませんでした。静的一覧を使います");
-      return null;
-    }
-    return set;
-  } catch (error) {
-    console.warn("Cheermote 一覧の取得に失敗しました。静的一覧を使います", error);
+  const json = await fetchHelixJson("bits/cheermotes", {
+    params: new URLSearchParams({ broadcaster_id: broadcasterId }),
+    fetchFn,
+    failureLog: { subject: "Cheermote 一覧", fallback: "静的一覧を使います" },
+  });
+  if (json === null) return null;
+
+  const set = parseCheermoteSet(json);
+  if (set.size === 0) {
+    console.warn("Cheermote 一覧のレスポンスを解析できませんでした。静的一覧を使います");
     return null;
   }
+  return set;
 }

--- a/src/lib/twitch/helix-proxy.test.ts
+++ b/src/lib/twitch/helix-proxy.test.ts
@@ -1,0 +1,155 @@
+/**
+ * src/lib/twitch/helix-proxy.ts(Helix プロキシ呼び出しの共通ヘルパー)のテスト。
+ *
+ * Helix プロキシ(`/api/twitch/`)への fetch ラッパー(HTTP エラー・ネットワークエラーを
+ * null に丸めて console.warn する制御フロー)と、`{data: [...]}` エンベロープの
+ * 前段パースを検証する。実際の API 呼び出しは行わず、フェイクの fetch を注入する。
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
+/** 指定した JSON を返す成功レスポンスのフェイク fetch を作る */
+function createFetchStub(json: unknown): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => json,
+  }) as unknown as typeof fetch;
+}
+
+/** 指定したステータスの失敗レスポンスのフェイク fetch を作る */
+function createErrorFetchStub(status: number): typeof fetch {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    json: async () => ({}),
+  }) as unknown as typeof fetch;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchHelixJson", () => {
+  it("プロキシのパスに /api/twitch/ を前置し、成功レスポンスの JSON を返す", async () => {
+    const fetchStub = createFetchStub({ data: [{ title: "作業配信" }] });
+
+    const json = await fetchHelixJson("streams", { fetchFn: fetchStub });
+
+    expect(fetchStub).toHaveBeenCalledWith("/api/twitch/streams", { signal: undefined });
+    expect(json).toEqual({ data: [{ title: "作業配信" }] });
+  });
+
+  it("params を渡すとクエリ文字列として付加する(繰り返しキーも保持する)", async () => {
+    const fetchStub = createFetchStub({ data: [] });
+    const params = new URLSearchParams();
+    params.append("id", "111");
+    params.append("id", "222");
+
+    await fetchHelixJson("users", { params, fetchFn: fetchStub });
+
+    expect(fetchStub).toHaveBeenCalledWith("/api/twitch/users?id=111&id=222", { signal: undefined });
+  });
+
+  it("params の値は URL エンコードされる", async () => {
+    const fetchStub = createFetchStub({ data: [] });
+    const params = new URLSearchParams({ query: "日本語 チャンネル" });
+
+    await fetchHelixJson("search/channels", { params, fetchFn: fetchStub });
+
+    expect(fetchStub).toHaveBeenCalledWith(
+      `/api/twitch/search/channels?query=${encodeURIComponent("日本語 チャンネル").replaceAll("%20", "+")}`,
+      { signal: undefined },
+    );
+  });
+
+  it("HTTP エラーの場合は null を返し、failureLog の文言で console.warn する", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchStub = createErrorFetchStub(503);
+
+    const json = await fetchHelixJson("streams", {
+      fetchFn: fetchStub,
+      failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
+    });
+
+    expect(json).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("配信情報の取得に失敗しました(HTTP 503)。文脈なしで動作します");
+  });
+
+  it("ネットワークエラーの場合は null を返し、failureLog の文言とエラーで console.warn する", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const networkError = new Error("ネットワーク断");
+    const fetchStub = vi.fn().mockRejectedValue(networkError) as unknown as typeof fetch;
+
+    const json = await fetchHelixJson("streams", {
+      fetchFn: fetchStub,
+      failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
+    });
+
+    expect(json).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith("配信情報の取得に失敗しました。文脈なしで動作します", networkError);
+  });
+
+  it("failureLog を渡さない場合は console.warn せずに null を返す(オートコンプリートなど静かに失敗したい用途)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    expect(await fetchHelixJson("search/channels", { fetchFn: createErrorFetchStub(429) })).toBeNull();
+    expect(
+      await fetchHelixJson("search/channels", {
+        fetchFn: vi.fn().mockRejectedValue(new Error("中断")) as unknown as typeof fetch,
+      }),
+    ).toBeNull();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("レスポンス本文の JSON 解析に失敗した場合も null を返す(制御フローは catch に合流する)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchStub = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("JSON ではない本文");
+      },
+    }) as unknown as typeof fetch;
+
+    const json = await fetchHelixJson("streams", {
+      fetchFn: fetchStub,
+      failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
+    });
+
+    expect(json).toBeNull();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("signal を fetch にそのまま渡す(オートコンプリートの中断用)", async () => {
+    const fetchStub = createFetchStub({ data: [] });
+    const controller = new AbortController();
+
+    await fetchHelixJson("search/channels", { fetchFn: fetchStub, signal: controller.signal });
+
+    expect(fetchStub).toHaveBeenCalledWith("/api/twitch/search/channels", { signal: controller.signal });
+  });
+});
+
+describe("extractDataArray", () => {
+  it("{data: [...]} エンベロープから data 配列を取り出す", () => {
+    expect(extractDataArray({ data: [{ id: "111" }, { id: "222" }] })).toEqual([
+      { id: "111" },
+      { id: "222" },
+    ]);
+  });
+
+  it("オブジェクトでない値(null・文字列)は null を返す", () => {
+    expect(extractDataArray(null)).toBeNull();
+    expect(extractDataArray("文字列のレスポンス")).toBeNull();
+  });
+
+  it("data が配列でない場合は null を返す", () => {
+    expect(extractDataArray({ data: "配列ではない" })).toBeNull();
+    expect(extractDataArray({})).toBeNull();
+  });
+
+  it("data が空配列の場合は空配列をそのまま返す(空判定は呼び出し側の責務)", () => {
+    expect(extractDataArray({ data: [] })).toEqual([]);
+  });
+});

--- a/src/lib/twitch/helix-proxy.ts
+++ b/src/lib/twitch/helix-proxy.ts
@@ -1,0 +1,81 @@
+/**
+ * Helix プロキシ(`/api/twitch/`)呼び出しの共通ヘルパー(issue #65)。
+ *
+ * Helix API を Next.js プロキシ経由で呼ぶ各クライアント
+ * (`stream-info.ts` / `cheermotes.ts` / `user-avatars.ts` / `channel-search.ts` / `badges.ts`)で
+ * 重複していた以下の 2 つの処理を共通化する。
+ *
+ * - fetch ラッパー(`fetchHelixJson`): `try / fetch / !response.ok → console.warn → null /
+ *   catch → null` の制御フロー。プロキシ契約の変更(例: 429 の `Retry-After` を尊重した
+ *   待機・再試行の導入)はこのヘルパーだけを修正すればよい
+ * - `{data: [...]}` エンベロープの前段パース(`extractDataArray`): オブジェクト判定 →
+ *   `.data` 取り出し → `Array.isArray` 判定
+ *
+ * 各クライアント固有のレスポンス解析(フィールドの型判定など)と、null 時の
+ * フォールバック方針(静的一覧・文脈なし動作など)は従来どおり各クライアントが担う。
+ */
+
+/** 取得失敗時に console.warn へ出す文言。省略した場合は警告を出さない(静かに失敗したい用途) */
+export interface HelixFailureLog {
+  /** 取得対象の名称(例: "配信情報")。「{subject}の取得に失敗しました」と整形される */
+  subject: string;
+  /** 失敗時のフォールバック動作の説明(例: "文脈なしで動作します") */
+  fallback: string;
+}
+
+/** fetchHelixJson のオプション */
+export interface FetchHelixJsonOptions {
+  /** クエリパラメータ。繰り返しキー(`id=111&id=222`)もそのまま保持される */
+  params?: URLSearchParams;
+  /** テストや呼び出し側から注入する fetch 実装(省略時はグローバルの fetch) */
+  fetchFn?: typeof fetch;
+  /** リクエストの中断用(オートコンプリートなど) */
+  signal?: AbortSignal;
+  /** 取得失敗時の console.warn 文言。省略した場合は警告を出さない */
+  failureLog?: HelixFailureLog;
+}
+
+/**
+ * Helix プロキシ(`/api/twitch/{path}`)から JSON を取得する。
+ *
+ * 取得できない場合は null を返す(呼び出し側が各自のフォールバックへ移る):
+ * - HTTP エラー(Helix 未設定の 503・レート制限・障害など)
+ * - ネットワークエラー・`signal` による中断(AbortError)・レスポンス本文の JSON 解析失敗
+ *
+ * `failureLog` を渡した場合のみ、失敗時に console.warn で文言を出す。
+ */
+export async function fetchHelixJson(
+  path: string,
+  options: FetchHelixJsonOptions = {},
+): Promise<unknown | null> {
+  const { params, fetchFn = fetch, signal, failureLog } = options;
+  const url = params === undefined ? `/api/twitch/${path}` : `/api/twitch/${path}?${params.toString()}`;
+  try {
+    const response = await fetchFn(url, { signal });
+    if (!response.ok) {
+      if (failureLog !== undefined) {
+        console.warn(
+          `${failureLog.subject}の取得に失敗しました(HTTP ${response.status})。${failureLog.fallback}`,
+        );
+      }
+      return null;
+    }
+    return await response.json();
+  } catch (error) {
+    if (failureLog !== undefined) {
+      console.warn(`${failureLog.subject}の取得に失敗しました。${failureLog.fallback}`, error);
+    }
+    return null;
+  }
+}
+
+/**
+ * Helix レスポンスの `{data: [...]}` エンベロープから data 配列を取り出す。
+ * オブジェクトでない・`data` が配列でない場合は null を返す。
+ * 空配列はそのまま返す(オフライン判定など、空の意味づけは呼び出し側の責務)。
+ */
+export function extractDataArray(json: unknown): readonly unknown[] | null {
+  if (typeof json !== "object" || json === null) return null;
+  const data = (json as Record<string, unknown>).data;
+  return Array.isArray(data) ? data : null;
+}

--- a/src/lib/twitch/stream-info.test.ts
+++ b/src/lib/twitch/stream-info.test.ts
@@ -75,7 +75,7 @@ describe("fetchStreamInfo", () => {
 
     const info = await fetchStreamInfo("zackrawrr", fetchFn);
 
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/streams?user_login=zackrawrr");
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/streams?user_login=zackrawrr", { signal: undefined });
     expect(info).toEqual({
       title: "Mythic raid progression! !drops",
       category: "World of Warcraft",

--- a/src/lib/twitch/stream-info.ts
+++ b/src/lib/twitch/stream-info.ts
@@ -14,6 +14,8 @@
  *   文脈なしで動作を続ける(意図したフォールバック)
  */
 
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
 /** 接続中チャンネルのライブ配信の情報。カテゴリ未設定の配信では category が空文字になる */
 export interface StreamInfo {
   /** 配信タイトル(Helix の `title`) */
@@ -33,9 +35,8 @@ export interface StreamInfo {
  * 配信者名(username・DisplayName)は取得できないフィールドだけを空文字として読み飛ばす。
  */
 export function parseStreamInfo(json: unknown): StreamInfo | null {
-  if (typeof json !== "object" || json === null) return null;
-  const data = (json as Record<string, unknown>).data;
-  if (!Array.isArray(data) || data.length === 0) return null;
+  const data = extractDataArray(json);
+  if (data === null || data.length === 0) return null;
 
   const first = data[0];
   if (typeof first !== "object" || first === null) return null;
@@ -63,15 +64,11 @@ export async function fetchStreamInfo(
   userLogin: string,
   fetchFn: typeof fetch = fetch,
 ): Promise<StreamInfo | null> {
-  try {
-    const response = await fetchFn(`/api/twitch/streams?user_login=${encodeURIComponent(userLogin)}`);
-    if (!response.ok) {
-      console.warn(`配信情報の取得に失敗しました(HTTP ${response.status})。文脈なしで動作します`);
-      return null;
-    }
-    return parseStreamInfo(await response.json());
-  } catch (error) {
-    console.warn("配信情報の取得に失敗しました。文脈なしで動作します", error);
-    return null;
-  }
+  const json = await fetchHelixJson("streams", {
+    params: new URLSearchParams({ user_login: userLogin }),
+    fetchFn,
+    failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
+  });
+  if (json === null) return null;
+  return parseStreamInfo(json);
 }

--- a/src/lib/twitch/user-avatars.test.ts
+++ b/src/lib/twitch/user-avatars.test.ts
@@ -56,7 +56,7 @@ describe("fetchUserAvatars", () => {
     const avatars = await fetchUserAvatars(["1234", "5678"], fetchFn);
 
     expect(fetchFn).toHaveBeenCalledTimes(1);
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/users?id=1234&id=5678");
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/users?id=1234&id=5678", { signal: undefined });
     expect(avatars).toEqual(
       new Map([
         ["1234", "https://cdn.example/taro.png"],
@@ -87,7 +87,7 @@ describe("fetchUserAvatars", () => {
 
     await fetchUserAvatars(["1234", "1234", "5678"], fetchFn);
 
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/users?id=1234&id=5678");
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/users?id=1234&id=5678", { signal: undefined });
   });
 
   it("ID が空の場合はリクエストせず空の対応表を返す", async () => {

--- a/src/lib/twitch/user-avatars.ts
+++ b/src/lib/twitch/user-avatars.ts
@@ -15,6 +15,8 @@
  *   (取得できたアバターを捨てない)
  */
 
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
 /** Helix の Get Users API の 1 リクエストで指定できる ID の上限 */
 const MAX_IDS_PER_REQUEST = 100;
 
@@ -25,9 +27,8 @@ const MAX_IDS_PER_REQUEST = 100;
  */
 export function parseUserAvatars(json: unknown): Map<string, string> {
   const avatars = new Map<string, string>();
-  if (typeof json !== "object" || json === null) return avatars;
-  const data = (json as Record<string, unknown>).data;
-  if (!Array.isArray(data)) return avatars;
+  const data = extractDataArray(json);
+  if (data === null) return avatars;
 
   for (const entry of data) {
     if (typeof entry !== "object" || entry === null) continue;
@@ -60,22 +61,22 @@ export async function fetchUserAvatars(
 
   for (let start = 0; start < uniqueIds.length; start += MAX_IDS_PER_REQUEST) {
     const chunk = uniqueIds.slice(start, start + MAX_IDS_PER_REQUEST);
-    const query = chunk.map((id) => `id=${encodeURIComponent(id)}`).join("&");
-    try {
-      const response = await fetchFn(`/api/twitch/users?${query}`);
-      if (!response.ok) {
-        console.warn(`発言者アバターの取得に失敗しました(HTTP ${response.status})。アバターなしで表示します`);
-        // 取得済みのチャンクぶんは捨てない。1 件も取得できていなければ Helix 利用不可(null)
-        return anyChunkSucceeded ? avatars : null;
-      }
-      for (const [id, url] of parseUserAvatars(await response.json())) {
-        avatars.set(id, url);
-      }
-      anyChunkSucceeded = true;
-    } catch (error) {
-      console.warn("発言者アバターの取得に失敗しました。アバターなしで表示します", error);
+    const params = new URLSearchParams();
+    for (const id of chunk) params.append("id", id);
+
+    const json = await fetchHelixJson("users", {
+      params,
+      fetchFn,
+      failureLog: { subject: "発言者アバター", fallback: "アバターなしで表示します" },
+    });
+    if (json === null) {
+      // 取得済みのチャンクぶんは捨てない。1 件も取得できていなければ Helix 利用不可(null)
       return anyChunkSucceeded ? avatars : null;
     }
+    for (const [id, url] of parseUserAvatars(json)) {
+      avatars.set(id, url);
+    }
+    anyChunkSucceeded = true;
   }
   return avatars;
 }


### PR DESCRIPTION
## 概要

Helix プロキシ(`/api/twitch/`)経由の取得処理で 5 クライアントに重複していた制御フローを、共通ヘルパー `src/lib/twitch/helix-proxy.ts` に抽出しました。

## 変更内容

### 新規: `src/lib/twitch/helix-proxy.ts`

- `fetchHelixJson(path, options)` — `try / fetch / !response.ok → console.warn → null / catch → null` の fetch ラッパー。クエリは `URLSearchParams` で組み立て、`signal`(中断)と `failureLog`(失敗時の警告文言。省略時は警告なし)をオプションで受け取ります
- `extractDataArray(json)` — `{data: [...]}` エンベロープの前段パース(オブジェクト判定 → `.data` → `Array.isArray`)。空配列はそのまま返し、空の意味づけ(オフライン判定など)は呼び出し側の責務のままです

### 既存 5 クライアントの置き換え(振る舞いは不変)

- `src/lib/twitch/stream-info.ts`(`fetchStreamInfo` / `parseStreamInfo`)
- `src/lib/twitch/cheermotes.ts`(`fetchCheermoteSet` / `parseCheermoteSet`。解析 0 件時の警告は固有処理として維持)
- `src/lib/twitch/user-avatars.ts`(`fetchUserAvatars` / `parseUserAvatars`。チャンク分割と部分成功時の挙動は維持)
- `src/lib/twitch/channel-search.ts`(`fetchChannelSuggestions` / `parseChannelSuggestions`。従来どおり警告なしで静かに失敗)
- `src/lib/twitch/badges.ts`(`fetchSingleBadgeMap` / `parseBadgeImageMap`)

失敗時の `console.warn` 文言は `failureLog` オプションにより各クライアントの従来文言をそのまま維持しています。

### 挙動の軽微な変化(等価)

- クエリ組み立てを `URLSearchParams` に統一したため、スペースのエンコードが `%20` から `+` になります(クエリ文字列として等価。`channel-search.test.ts` の期待値を調整)
- 全クライアントが `fetch(url, { signal })` 形式で呼ぶようになったため、テストの `toHaveBeenCalledWith` に第 2 引数を追加

## 効果

プロキシ契約の変更(例: 429 の `Retry-After` を尊重した待機・再試行の導入)を `fetchHelixJson` の 1 箇所の修正で全クライアントに反映できます。

## テスト

- `helix-proxy.test.ts` を新規追加(12 テスト。TDD で先行作成)
- 既存テスト含め 47 ファイル / 655 テストすべて成功
- `npm run lint` / `npm run type-check` エラーなし

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH