### PR TITLE
Pick up語句削除後のフォーカス管理とスクリーンリーダー通知を追加する

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -21,6 +21,7 @@ import { resetBadgesForTests, useBadgeStore } from "@/store/badges";
 import { resetBotFilterStoreForTests, useBotFilterStore } from "@/store/bot-filter";
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetHiddenPickupStoreForTests } from "@/store/hidden-pickups";
+import { resetPickupAnnouncementStoreForTests } from "@/store/pickup-announcements";
 import { resetManualPickupStoreForTests, useManualPickupStore } from "@/store/manual-pickups";
 import { resetPickupStoreForTests, usePickupStore } from "@/store/pickups";
 import { resetPromptApiStoreForTests, usePromptApiStore } from "@/store/prompt-api";
@@ -109,6 +110,7 @@ afterEach(() => {
   resetTranslationStoreForTests();
   resetPickupStoreForTests();
   resetHiddenPickupStoreForTests();
+  resetPickupAnnouncementStoreForTests();
   resetManualPickupStoreForTests();
   resetPromptApiStoreForTests();
   resetBotFilterStoreForTests();
@@ -549,6 +551,84 @@ describe("Home(Pick up列)", () => {
 
     expect(within(pickupColumn).queryByText("gg")).not.toBeInTheDocument();
     expect(within(pickupColumn).getByText("None")).toBeInTheDocument();
+  });
+
+
+  it("語句を削除すると、同じ発言の次の語句の削除ボタンへフォーカスが移る", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: {
+        "msg-1": {
+          status: "done",
+          terms: [
+            { term: "gg", meaning: "good game の略、お疲れ" },
+            { term: "no re", meaning: "再戦なし" },
+          ],
+        },
+      },
+    });
+
+    render(<Home />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Remove "gg"' }));
+
+    expect(within(pickupColumn).getByRole("button", { name: 'Remove "no re"' })).toHaveFocus();
+  });
+
+  it("末尾の語句を削除すると、同じ発言の前の語句の削除ボタンへフォーカスが移る", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: {
+        "msg-1": {
+          status: "done",
+          terms: [
+            { term: "gg", meaning: "good game の略、お疲れ" },
+            { term: "no re", meaning: "再戦なし" },
+          ],
+        },
+      },
+    });
+
+    render(<Home />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Remove "no re"' }));
+
+    expect(within(pickupColumn).getByRole("button", { name: 'Remove "gg"' })).toHaveFocus();
+  });
+
+  it("最後の語句を削除すると、行コンテナへフォーカスが移る", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: { "msg-1": { status: "done", terms: [{ term: "gg", meaning: "お疲れ" }] } },
+    });
+
+    render(<Home />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    const row = within(pickupColumn).getByRole("listitem");
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Remove "gg"' }));
+
+    expect(row).toHaveFocus();
+  });
+
+  it('語句を削除すると、スクリーンリーダー向けの通知リージョンに「Removed "<語句>"」が表示される', async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: { "msg-1": { status: "done", terms: [{ term: "gg", meaning: "お疲れ" }] } },
+    });
+
+    render(<Home />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Remove "gg"' }));
+
+    expect(screen.getByRole("status", { name: "Pick up updates" })).toHaveTextContent('Removed "gg"');
   });
 
   it("パイプライン再起動でエントリが再生成されても、削除した語句は表示されない", async () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,6 +58,7 @@ import { hydrateBotFilterStore } from "@/store/bot-filter";
 import { useChatConnectionStore } from "@/store/chat-connection";
 import type { PipelineEntry } from "@/store/auto-pipeline";
 import { hidePickupTerm, isPickupTermHidden, useHiddenPickupStore } from "@/store/hidden-pickups";
+import { announcePickupRemoval, usePickupAnnouncementStore } from "@/store/pickup-announcements";
 import { addManualPickup, removeManualPickup, useManualPickupStore } from "@/store/manual-pickups";
 import { startPickupPipeline, usePickupStore, warmUpPickupPipeline, type PickupDone } from "@/store/pickups";
 import { usePromptApiStore, type PromptApiStatus } from "@/store/prompt-api";
@@ -316,6 +317,7 @@ export default function Home() {
         </div>
       </ScrollArea>
       <ManualPickupOverlay onPickup={handleManualPickup} />
+      <PickupRemovalAnnouncement />
     </div>
   );
 }
@@ -435,6 +437,9 @@ function Row({
     <div
       role="listitem"
       data-message-id={message.id ?? undefined}
+      // Pick up列で行内の削除ボタンをすべて消したとき、フォーカスの退避先になる(issue #73)。
+      // tabIndex={-1} は Tab 順序には入れず、プログラムからのフォーカスだけを受け付ける
+      tabIndex={-1}
       // ぼかしは「自力で読む練習」のために中身を隠す機能なので、視覚だけでなくフォーカス・
       // 読み上げの対象からも外す(Pick up列の削除ボタンが不可視のまま操作できたり、
       // スクリーンリーダーで語句が漏れたりしないように)
@@ -565,13 +570,50 @@ function PickupTermRow({
           variant="ghost"
           size="icon-xs"
           aria-label={`Remove "${term}"`}
+          data-pickup-remove
           className="ml-1 align-middle opacity-0 group-hover/term:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100"
-          onClick={onRemove}
+          onClick={(event) => handleRemoveClick(event, term, onRemove)}
         >
           <XIcon />
         </Button>
       </dt>
       {children}
+    </div>
+  );
+}
+
+/**
+ * Pick up列の削除ボタンが押されたときの共通処理(issue #73)。
+ * 押されたボタン自身は unmount されてフォーカスが body に落ちるため、削除前に同じ発言の行
+ * (`role="listitem"`)内の削除ボタン一覧から次(無ければ前)のボタンを探し、削除後にそこへ
+ * フォーカスを移す。どちらも無ければ行コンテナ(tabIndex={-1})へ退避し、Tab 移動が
+ * ページ先頭からやり直しになるのを防ぐ。あわせてスクリーンリーダーへ削除を通知する。
+ * 移動先のボタン・行コンテナの DOM ノードは削除後も同一のまま残るため、削除前に取得した
+ * 参照へそのままフォーカスしてよい。
+ */
+function handleRemoveClick(event: React.MouseEvent<HTMLButtonElement>, term: string, onRemove: () => void): void {
+  const row = event.currentTarget.closest<HTMLElement>('[role="listitem"]');
+  const buttons = row === null ? [] : Array.from(row.querySelectorAll<HTMLElement>("[data-pickup-remove]"));
+  const index = buttons.indexOf(event.currentTarget);
+  const focusTarget = buttons[index + 1] ?? buttons[index - 1] ?? row;
+  onRemove();
+  announcePickupRemoval(term);
+  focusTarget?.focus();
+}
+
+/**
+ * Pick up語句の削除をスクリーンリーダーへ通知する常設の aria-live リージョン(issue #73)。
+ * `role="status"`(polite)の視覚非表示要素として置き、pickup-announcements ストアの
+ * メッセージを表示する。同じ語句を連続で削除してもテキストの変化として検知されるよう、
+ * 通知番号(seq)の偶奇で不可視のノーブレークスペースを付け替える。
+ */
+function PickupRemovalAnnouncement() {
+  const { message, seq } = usePickupAnnouncementStore();
+  return (
+    // 接続状態の role="status" と区別できるよう、リージョンに名前を付ける
+    <div role="status" aria-label="Pick up updates" className="sr-only">
+      {message}
+      {seq % 2 === 1 ? "\u00A0" : ""}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -571,7 +571,7 @@ function PickupTermRow({
           size="icon-xs"
           aria-label={`Remove "${term}"`}
           data-pickup-remove
-          className="ml-1 align-middle opacity-0 group-hover/term:opacity-100 focus-visible:opacity-100 pointer-coarse:opacity-100"
+          className="ml-1 align-middle opacity-0 group-hover/term:opacity-100 focus:opacity-100 pointer-coarse:opacity-100"
           onClick={(event) => handleRemoveClick(event, term, onRemove)}
         >
           <XIcon />

--- a/src/store/pickup-announcements.test.ts
+++ b/src/store/pickup-announcements.test.ts
@@ -1,0 +1,44 @@
+/**
+ * src/store/pickup-announcements.ts(Pick up語句削除のスクリーンリーダー通知ストア)のテスト。
+ *
+ * 削除された語句が「Removed "<語句>"」の形でメッセージになること、
+ * 同じ語句を連続で削除しても aria-live が変化を検知できるよう通知番号(seq)が
+ * 単調増加すること、テスト用リセットで初期状態に戻ることを検証する(issue #73)。
+ */
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  announcePickupRemoval,
+  resetPickupAnnouncementStoreForTests,
+  usePickupAnnouncementStore,
+} from "./pickup-announcements";
+
+afterEach(() => {
+  resetPickupAnnouncementStoreForTests();
+});
+
+describe("announcePickupRemoval", () => {
+  it('削除した語句を「Removed "<語句>"」のメッセージとして保持する', () => {
+    announcePickupRemoval("gg");
+    expect(usePickupAnnouncementStore.getState().message).toBe('Removed "gg"');
+  });
+
+  it("同じ語句を連続で削除しても通知番号(seq)が増え、通知の変化として区別できる", () => {
+    announcePickupRemoval("gg");
+    const 一回目 = usePickupAnnouncementStore.getState().seq;
+    announcePickupRemoval("gg");
+    const 二回目 = usePickupAnnouncementStore.getState().seq;
+    expect(二回目).toBeGreaterThan(一回目);
+  });
+
+  it("初期状態ではメッセージが空で、何も通知しない", () => {
+    expect(usePickupAnnouncementStore.getState().message).toBe("");
+    expect(usePickupAnnouncementStore.getState().seq).toBe(0);
+  });
+
+  it("テスト用リセットで初期状態に戻る", () => {
+    announcePickupRemoval("gg");
+    resetPickupAnnouncementStoreForTests();
+    expect(usePickupAnnouncementStore.getState().message).toBe("");
+    expect(usePickupAnnouncementStore.getState().seq).toBe(0);
+  });
+});

--- a/src/store/pickup-announcements.ts
+++ b/src/store/pickup-announcements.ts
@@ -1,0 +1,32 @@
+/**
+ * Pick up列で語句を削除したことをスクリーンリーダーへ通知するための、モジュールスコープのストア。
+ *
+ * 削除ボタン(`page.tsx` の PickupTermRow)は押されると自身が unmount されるため、
+ * ボタン側では読み上げできない。代わりにホーム画面が常設する polite な aria-live リージョン
+ * (`page.tsx` の PickupRemovalAnnouncement)がこのストアを購読し、削除のたびに
+ * 「Removed "<語句>"」を表示してスクリーンリーダーに通知する(issue #73)。
+ *
+ * 同じ語句を連続で削除するとメッセージ文字列が変わらず、aria-live が変化を検知できないため、
+ * 通知のたびに単調増加する通知番号(seq)を併せて保持する。表示側は seq の偶奇で
+ * 不可視の文字を付け替え、DOM のテキスト変化を保証する。
+ */
+import { create } from "zustand";
+
+interface PickupAnnouncementState {
+  /** スクリーンリーダーへ通知するメッセージ。初期状態は空で何も通知しない */
+  message: string;
+  /** 通知のたびに増える通知番号。同一メッセージの連続通知を DOM の変化として区別するために使う */
+  seq: number;
+}
+
+export const usePickupAnnouncementStore = create<PickupAnnouncementState>(() => ({ message: "", seq: 0 }));
+
+/** 語句の削除をスクリーンリーダーへ通知する。自動抽出分・手動Pick up分の削除ボタンの両方から呼ぶ */
+export function announcePickupRemoval(term: string): void {
+  usePickupAnnouncementStore.setState((state) => ({ message: `Removed "${term}"`, seq: state.seq + 1 }));
+}
+
+/** テスト専用: ストアを初期状態に戻す。各テストの afterEach で呼び出すこと */
+export function resetPickupAnnouncementStoreForTests(): void {
+  usePickupAnnouncementStore.setState({ message: "", seq: 0 });
+}


### PR DESCRIPTION
## Summary

issue #73 で指摘された、Pick up列の語句削除ボタン(`PickupTermRow`)のアクセシビリティ残課題2点に対応します。

### フォーカス管理

- 削除ボタンを押すとボタン自身が unmount されてフォーカスが `document.body` に落ち、Tab 移動がページ先頭からやり直しになる問題を修正しました
- 削除前に同じ発言の行(`role="listitem"`)内の削除ボタン一覧を取得し、削除後に次(無ければ前)の削除ボタンへフォーカスを移します(`src/app/page.tsx` の `handleRemoveClick`)
- 行内の削除ボタンがすべて無くなった場合は、行コンテナ(`Row` に `tabIndex={-1}` を追加)へフォーカスを退避します
- マウスクリックでの削除後にフォーカスを受けたボタンが不可視のままにならないよう、表示条件を `focus-visible` から `focus` に変更しました(CodeRabbit指摘対応)

### スクリーンリーダー通知

- polite な aria-live リージョン(`role="status"` + `sr-only`)をホーム画面に常設し、削除のたびに `Removed "<語句>"` を通知します(`PickupRemovalAnnouncement`)
- 通知メッセージは新設の `src/store/pickup-announcements.ts` ストアが保持します。同じ語句を連続で削除してもテキスト変化として検知されるよう、通知番号(seq)の偶奇で不可視のノーブレークスペースを付け替えます
- 自動抽出分(`PickupTerms`)・手動Pick up分(`ManualPickupTerms`)の両方の削除ボタンが同じ処理を通ります

## Test plan

- `src/store/pickup-announcements.test.ts`(新規4件): メッセージ形式・seq の単調増加・初期状態・リセット
- `src/app/page.test.tsx`(追加4件): 次のボタンへのフォーカス移動・前のボタンへのフォーカス移動・最後の語句削除時の行コンテナへの退避・通知リージョンへの表示
- Lint / 型チェック / 全テスト(728件)/ ビルド すべて成功
- CodeRabbitレビュー実施済み(指摘1件に対応済み)

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH