### PR TITLE
SessionPoolにベースセッションの破棄APIを追加し、プール差し替え時のセッションリークを解消する

### DIFF
--- a/src/lib/ai/session-pool.test.ts
+++ b/src/lib/ai/session-pool.test.ts
@@ -12,6 +12,7 @@ import {
   createPromptJobQueue,
   createSessionPool,
   LowPriorityQueueOverflowError,
+  SessionPoolDisposedError,
   type PromptJobQueue,
   type PromptSessionLike,
 } from "./session-pool";
@@ -446,6 +447,62 @@ describe("createSessionPool: dispose(issue #75)", () => {
     pool.dispose();
 
     await expect(pool.warmUp()).rejects.toThrow(/disposed/);
+  });
+
+  it("dispose() 後の enqueue は SessionPoolDisposedError で拒否され、呼び出し側が判別できる", async () => {
+    const pool = createPool(async () => createFakeSession([], "base"));
+    await pool.warmUp();
+    pool.dispose();
+
+    await expect(pool.enqueue("high", async () => "x")).rejects.toBeInstanceOf(SessionPoolDisposedError);
+  });
+
+  it("ベースセッションの clone() 実行中に dispose() しても、clone 完了を待ってから destroy する(clone 中の破棄レースを防ぐ)", async () => {
+    const cloneDeferred = createDeferred<PromptSessionLike>();
+    const cloneSession: PromptSessionLike = {
+      prompt: async () => "cloned response",
+      clone: async () => cloneSession,
+      destroy: vi.fn(),
+    };
+    const baseSession: PromptSessionLike = {
+      prompt: async () => "base response",
+      clone: () => cloneDeferred.promise,
+      destroy: vi.fn(),
+    };
+    const pool = createPool(async () => baseSession);
+
+    const pJob = pool.enqueue("high", (session) => session.prompt("hello"));
+    await flushMicrotasks(); // ジョブが clone() の完了待ちに入るまで進める
+
+    pool.dispose();
+    await flushMicrotasks();
+    expect(baseSession.destroy).not.toHaveBeenCalled(); // clone 完了前は destroy しない
+
+    cloneDeferred.resolve(cloneSession);
+    expect(await pJob).toBe("cloned response");
+    expect(baseSession.destroy).toHaveBeenCalledTimes(1); // clone 完了後に destroy する
+  });
+
+  it("ベースセッションの destroy() が失敗した場合は握りつぶさず console.warn で記録する", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const baseSession: PromptSessionLike = {
+        prompt: async () => "",
+        clone: async () => baseSession,
+        destroy: () => {
+          throw new Error("destroy failed");
+        },
+      };
+      const pool = createPool(async () => baseSession);
+      await pool.warmUp();
+
+      pool.dispose();
+      await flushMicrotasks();
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it("実行中のジョブはクローンセッションで動作しているため、dispose() 後も完了できる", async () => {

--- a/src/lib/ai/session-pool.test.ts
+++ b/src/lib/ai/session-pool.test.ts
@@ -371,3 +371,100 @@ describe("createSessionPool: 複数プールでのキュー共有(issue #23)", (
     expect(await pTranslate2).toBe("translate2");
   });
 });
+
+/**
+ * issue #75: プール差し替え・パイプライン停止時に、ウォームアップ済みのベースセッション
+ * (Gemini Nano のネイティブセッション)がページの寿命までリークしないよう破棄する API。
+ */
+describe("createSessionPool: dispose(issue #75)", () => {
+  it("dispose() は生成済みのベースセッションを destroy する", async () => {
+    const log: string[] = [];
+    const baseSession = createFakeSession(log, "base");
+    const pool = createPool(async () => baseSession);
+    await pool.warmUp();
+
+    pool.dispose();
+    await flushMicrotasks();
+
+    expect(baseSession.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() は冪等で、2回呼んでも destroy は1回しか呼ばれない", async () => {
+    const log: string[] = [];
+    const baseSession = createFakeSession(log, "base");
+    const pool = createPool(async () => baseSession);
+    await pool.warmUp();
+
+    pool.dispose();
+    pool.dispose();
+    await flushMicrotasks();
+
+    expect(baseSession.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("ベースセッションが未生成のまま dispose() しても、生成を試みない", async () => {
+    const createBaseSession = vi.fn(async () => createFakeSession([], "base"));
+    const pool = createPool(createBaseSession);
+
+    pool.dispose();
+    await flushMicrotasks();
+
+    expect(createBaseSession).not.toHaveBeenCalled();
+  });
+
+  it("ベースセッションの生成中に dispose() した場合、生成完了後に destroy する", async () => {
+    const log: string[] = [];
+    const baseSession = createFakeSession(log, "base");
+    const deferred = createDeferred<PromptSessionLike>();
+    const pool = createPool(() => deferred.promise);
+
+    const warmUpPromise = pool.warmUp();
+    pool.dispose();
+    deferred.resolve(baseSession);
+    await warmUpPromise;
+    await flushMicrotasks();
+
+    expect(baseSession.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() 後の enqueue は拒否され、ベースセッションを再生成しない(Fail-Fast)", async () => {
+    const log: string[] = [];
+    const createBaseSession = vi.fn(async () => createFakeSession(log, "base"));
+    const pool = createPool(createBaseSession);
+    await pool.warmUp();
+    pool.dispose();
+
+    const run = vi.fn(async () => "should not run");
+    await expect(pool.enqueue("high", run)).rejects.toThrow(/disposed/);
+
+    expect(run).not.toHaveBeenCalled();
+    expect(createBaseSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispose() 後の warmUp() は拒否される(Fail-Fast)", async () => {
+    const pool = createPool(async () => createFakeSession([], "base"));
+    pool.dispose();
+
+    await expect(pool.warmUp()).rejects.toThrow(/disposed/);
+  });
+
+  it("実行中のジョブはクローンセッションで動作しているため、dispose() 後も完了できる", async () => {
+    const log: string[] = [];
+    const baseSession = createFakeSession(log, "base");
+    const pool = createPool(async () => baseSession);
+    const blocker = createDeferred<string>();
+
+    const pJob = pool.enqueue("high", async (session) => {
+      const text = await session.prompt("hello");
+      await blocker.promise;
+      return text;
+    });
+    await flushMicrotasks();
+
+    pool.dispose();
+    blocker.resolve("released");
+
+    expect(await pJob).toBe("response from base-clone1");
+    expect(baseSession.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/ai/session-pool.ts
+++ b/src/lib/ai/session-pool.ts
@@ -70,6 +70,14 @@ export interface SessionPool {
    * ベースセッションを先に作っておく用途に使う。生成に失敗した場合は例外をそのまま投げる。
    */
   warmUp(): Promise<void>;
+  /**
+   * 生成済み(生成中を含む)のベースセッションを `destroy()` し、Gemini Nano のネイティブセッションを
+   * 解放する。プールの差し替え・パイプラインの停止時に呼ぶこと(issue #75)。
+   * - 冪等であり、2回以上呼んでも安全
+   * - 呼び出し後の `enqueue` / `warmUp` はベースセッションを再生成せず拒否する(Fail-Fast)。
+   *   実行中のジョブはクローンセッションで動作しているため影響を受けない
+   */
+  dispose(): void;
 }
 
 const DEFAULT_MAX_LOW_PRIORITY_QUEUE_LENGTH = 20;
@@ -187,8 +195,14 @@ export function createPromptJobQueue(options: PromptJobQueueOptions = {}): Promp
 
 export function createSessionPool(deps: SessionPoolDeps): SessionPool {
   let baseSessionPromise: Promise<PromptSessionLike> | null = null;
+  /** dispose() 済みか。破棄後にベースセッションを再生成して再リークさせないためのフラグ */
+  let disposed = false;
 
   function getBaseSession(): Promise<PromptSessionLike> {
+    if (disposed) {
+      // このメッセージは failed の理由として画面に表示され得るため、UIの言語(英語)で書く
+      return Promise.reject(new Error("This session pool has already been disposed"));
+    }
     if (!baseSessionPromise) {
       baseSessionPromise = deps.createBaseSession().catch((error: unknown) => {
         // 生成に失敗したら次回 enqueue 時に再試行できるようキャッシュを捨てる
@@ -202,6 +216,17 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
   return {
     async warmUp() {
       await getBaseSession();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      const promise = baseSessionPromise;
+      baseSessionPromise = null;
+      // 生成中でも、完了を待ってから destroy する(生成そのものは中断できないため)。
+      // 生成失敗時は破棄する対象が無いので何もしない
+      if (promise) {
+        promise.then((session) => session.destroy()).catch(() => {});
+      }
     },
     enqueue<T>(priority: JobPriority, run: (session: PromptSessionLike) => Promise<T>, signal?: AbortSignal): Promise<T> {
       // ベースセッションの生成・クローンもキューの中で行い、`LanguageModel.create()` を含めて直列にする

--- a/src/lib/ai/session-pool.ts
+++ b/src/lib/ai/session-pool.ts
@@ -74,8 +74,10 @@ export interface SessionPool {
    * 生成済み(生成中を含む)のベースセッションを `destroy()` し、Gemini Nano のネイティブセッションを
    * 解放する。プールの差し替え・パイプラインの停止時に呼ぶこと(issue #75)。
    * - 冪等であり、2回以上呼んでも安全
-   * - 呼び出し後の `enqueue` / `warmUp` はベースセッションを再生成せず拒否する(Fail-Fast)。
-   *   実行中のジョブはクローンセッションで動作しているため影響を受けない
+   * - 呼び出し後の `enqueue` / `warmUp` はベースセッションを再生成せず
+   *   `SessionPoolDisposedError` で拒否する(Fail-Fast)
+   * - 実行中のジョブは影響を受けない。クローン中(`clone()` 実行中)の場合は
+   *   クローン完了を待ってからベースセッションを destroy する
    */
   dispose(): void;
 }
@@ -90,6 +92,19 @@ export class LowPriorityQueueOverflowError extends Error {
   constructor() {
     super("低優先度キューの上限に達したため、このジョブは破棄されました");
     this.name = "LowPriorityQueueOverflowError";
+  }
+}
+
+/**
+ * dispose() 済みのプールに enqueue / warmUp した際のエラー。
+ * 呼び出し側(manual-pickups など)が `instanceof` で判別し、
+ * 内部文言ではなく利用者向けの失敗理由に差し替えられるようにする(issue #75)。
+ */
+export class SessionPoolDisposedError extends Error {
+  constructor() {
+    // failed の理由として画面に表示され得るため、UIの言語(英語)で書く
+    super("This session pool has already been disposed");
+    this.name = "SessionPoolDisposedError";
   }
 }
 
@@ -197,11 +212,32 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
   let baseSessionPromise: Promise<PromptSessionLike> | null = null;
   /** dispose() 済みか。破棄後にベースセッションを再生成して再リークさせないためのフラグ */
   let disposed = false;
+  /** `clone()` 実行中のジョブ数。直列キューのため実質 0 か 1 */
+  let cloningCount = 0;
+  /** dispose() 時に clone() 実行中だった場合の destroy 待ちベースセッション */
+  let pendingDestroySession: PromptSessionLike | null = null;
+
+  /**
+   * destroy 待ちのベースセッションを、clone() 実行中のジョブがいなければ destroy する。
+   * clone() の途中で destroy すると clone() がブラウザ内部のエラーで失敗するため、
+   * dispose() と clone() 完了の両方からこの関数を呼び、後に到達した方が破棄を実行する
+   */
+  function destroyPendingBaseSessionIfIdle(): void {
+    if (!pendingDestroySession || cloningCount > 0) return;
+    const session = pendingDestroySession;
+    pendingDestroySession = null;
+    try {
+      session.destroy();
+    } catch (error) {
+      // destroy の失敗はネイティブセッションのリーク残存を意味するが、dispose の呼び出し元
+      // (パイプラインの停止処理など)を巻き込まないよう、例外にせず警告として記録する
+      console.warn("SessionPool: ベースセッションの destroy に失敗しました", error);
+    }
+  }
 
   function getBaseSession(): Promise<PromptSessionLike> {
     if (disposed) {
-      // このメッセージは failed の理由として画面に表示され得るため、UIの言語(英語)で書く
-      return Promise.reject(new Error("This session pool has already been disposed"));
+      return Promise.reject(new SessionPoolDisposedError());
     }
     if (!baseSessionPromise) {
       baseSessionPromise = deps.createBaseSession().catch((error: unknown) => {
@@ -223,10 +259,15 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
       const promise = baseSessionPromise;
       baseSessionPromise = null;
       // 生成中でも、完了を待ってから destroy する(生成そのものは中断できないため)。
-      // 生成失敗時は破棄する対象が無いので何もしない
-      if (promise) {
-        promise.then((session) => session.destroy()).catch(() => {});
-      }
+      // 拒否ハンドラは「生成失敗 = 破棄する対象が無い」場合専用で、destroy の失敗は
+      // destroyPendingBaseSessionIfIdle が警告として記録する(暗黙に握りつぶさない)
+      void promise?.then(
+        (session) => {
+          pendingDestroySession = session;
+          destroyPendingBaseSessionIfIdle();
+        },
+        () => {},
+      );
     },
     enqueue<T>(priority: JobPriority, run: (session: PromptSessionLike) => Promise<T>, signal?: AbortSignal): Promise<T> {
       // ベースセッションの生成・クローンもキューの中で行い、`LanguageModel.create()` を含めて直列にする
@@ -234,7 +275,15 @@ export function createSessionPool(deps: SessionPoolDeps): SessionPool {
         priority,
         async () => {
           const baseSession = await getBaseSession();
-          const jobSession = await baseSession.clone();
+          // clone() の途中で dispose() がベースセッションを destroy しないよう、clone 中を数えて破棄を遅延させる
+          cloningCount += 1;
+          let jobSession: PromptSessionLike;
+          try {
+            jobSession = await baseSession.clone();
+          } finally {
+            cloningCount -= 1;
+            destroyPendingBaseSessionIfIdle();
+          }
           try {
             return await run(jobSession);
           } finally {

--- a/src/store/auto-pipeline.test.ts
+++ b/src/store/auto-pipeline.test.ts
@@ -600,3 +600,52 @@ describe("createAutoPipeline().resetForTests", () => {
     expect(useStore.getState().entries).toEqual({});
   });
 });
+
+/**
+ * issue #75: パイプライン停止時に、生成済みのセッションプール(ウォームアップ済みベースセッション)を
+ * dispose し、Gemini Nano のネイティブセッションをリークさせないこと。
+ */
+describe("createAutoPipeline: 停止時のセッションプール破棄(issue #75)", () => {
+  it("停止関数はウォームアップで生成した順方向・逆方向プールを dispose する", async () => {
+    const { deps, dispose, reverseDispose } = createDeps();
+
+    const stop = start(deps);
+    await flush();
+    warmUpPipeline();
+    await flush();
+
+    expect(dispose).not.toHaveBeenCalled();
+    expect(reverseDispose).not.toHaveBeenCalled();
+    stop();
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(reverseDispose).toHaveBeenCalledTimes(1);
+  });
+
+  it("発言処理で生成した順方向プールだけを dispose し、未生成の逆方向プールは作らない", async () => {
+    const { deps, emit, dispose, reverseDispose } = createDeps({ promptResults: [Promise.resolve("訳文")] });
+
+    const stop = start(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "gg chat" }));
+    await flush();
+    stop();
+
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(reverseDispose).not.toHaveBeenCalled();
+    expect(deps.createReversePool).not.toHaveBeenCalled();
+  });
+
+  it("プールを一度も生成しないまま停止した場合、dispose のために新しくプールを作らない", async () => {
+    const { deps, dispose, reverseDispose } = createDeps();
+
+    const stop = start(deps);
+    await flush();
+    stop();
+
+    expect(deps.createPool).not.toHaveBeenCalled();
+    expect(deps.createReversePool).not.toHaveBeenCalled();
+    expect(dispose).not.toHaveBeenCalled();
+    expect(reverseDispose).not.toHaveBeenCalled();
+  });
+});

--- a/src/store/auto-pipeline.ts
+++ b/src/store/auto-pipeline.ts
@@ -366,6 +366,10 @@ export function createAutoPipeline<TDone extends object>(config: AutoPipelineCon
     return () => {
       unsubscribe();
       controller.abort();
+      // 生成済みプールのベースセッション(Gemini Nano のネイティブセッション)を解放する(issue #75)。
+      // 破棄済みプールへの遅延ジョブは拒否されるが、controller.abort() 済みのため結果には反映されない
+      forwardPool?.dispose();
+      reversePool?.dispose();
       if (activePipeline === handle) activePipeline = null;
     };
   }

--- a/src/store/manual-pickups.test.ts
+++ b/src/store/manual-pickups.test.ts
@@ -6,7 +6,7 @@
  * 意味の生成(LLM 呼び出し)と Prompt API の利用可否はフェイクを注入する。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { PromptSessionLike } from "@/lib/ai/session-pool";
+import { SessionPoolDisposedError, type PromptSessionLike } from "@/lib/ai/session-pool";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
 import {
   addManualPickup,
@@ -16,6 +16,7 @@ import {
   useManualPickupStore,
   type ManualPickupDeps,
 } from "./manual-pickups";
+import { flush } from "./pipeline-test-fixtures";
 import { resetPromptApiStoreForTests, usePromptApiStore } from "./prompt-api";
 import { resetSettingsStoreForTests, useSettingsStore } from "./settings";
 
@@ -266,6 +267,24 @@ describe("manual-pickups ストア", () => {
     expect(useManualPickupStore.getState().entries).toEqual({});
   });
 
+  it("プール差し替えで破棄されたジョブは、内部文言ではなく再試行を促す理由の failed になる(issue #75)", async () => {
+    const deps = createDeps({
+      generateMeaning: vi.fn(async () => {
+        throw new SessionPoolDisposedError();
+      }),
+    });
+
+    await addManualPickup("msg-1", "gg", "gg chat", deps);
+
+    expect(useManualPickupStore.getState().entries["msg-1"]).toEqual([
+      {
+        status: "failed",
+        term: "gg",
+        reason: "Cancelled because the settings or stream context changed. Select the term again to retry.",
+      },
+    ]);
+  });
+
   it("clearManualPickups で全発言の手動Pick upを破棄する", async () => {
     const deps = createDeps();
     await addManualPickup("msg-1", "no re", "gg no re chat", deps);
@@ -283,13 +302,6 @@ describe("manual-pickups ストア", () => {
  * デフォルト依存(deps 省略)で getDefineTermPool を経由させるため、define-term をモックしている。
  */
 describe("getDefineTermPool: プール差し替え時の破棄(issue #75)", () => {
-  /** ウォームアップ(ベースセッション生成)や dispose の destroy 呼び出しが落ち着くまでフラッシュする */
-  async function flushMicrotasks(times = 10) {
-    for (let i = 0; i < times; i++) {
-      await Promise.resolve();
-    }
-  }
-
   /** デフォルト依存が参照する設定ストア・Prompt API ストアを「利用可能」な状態にする */
   function setUpDefaultDepsEnvironment() {
     useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS }, hydrated: true });
@@ -307,7 +319,7 @@ describe("getDefineTermPool: プール差し替え時の破棄(issue #75)", () =
 
     await addManualPickup("msg-1", "gg", "gg chat");
     await addManualPickup("msg-2", "poggers", "poggers wow");
-    await flushMicrotasks();
+    await flush();
 
     expect(defineTermMockState.createdBaseSessions).toHaveLength(1);
     expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(0);
@@ -316,25 +328,36 @@ describe("getDefineTermPool: プール差し替え時の破棄(issue #75)", () =
   it("設定が変わって新しいプールを作るとき、旧プールのベースセッションを destroy する", async () => {
     setUpDefaultDepsEnvironment();
     await addManualPickup("msg-1", "gg", "gg chat");
-    await flushMicrotasks();
+    await flush();
     expect(defineTermMockState.createdBaseSessions).toHaveLength(1);
 
     useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS, explainLang: "es" }, hydrated: true });
     await addManualPickup("msg-2", "poggers", "poggers wow");
-    await flushMicrotasks();
+    await flush();
 
     expect(defineTermMockState.createdBaseSessions).toHaveLength(2);
     expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(1); // 旧プールは破棄する
     expect(defineTermMockState.createdBaseSessions[1].destroyCount).toBe(0); // 新プールは使い続ける
   });
 
+  it("clearManualPickups はキャッシュ中のプールのベースセッションを破棄する(チャンネル切替時のリーク防止)", async () => {
+    setUpDefaultDepsEnvironment();
+    await addManualPickup("msg-1", "gg", "gg chat");
+    await flush();
+
+    clearManualPickups();
+    await flush();
+
+    expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(1);
+  });
+
   it("resetManualPickupStoreForTests はキャッシュ中のプールのベースセッションを破棄する", async () => {
     setUpDefaultDepsEnvironment();
     await addManualPickup("msg-1", "gg", "gg chat");
-    await flushMicrotasks();
+    await flush();
 
     resetManualPickupStoreForTests();
-    await flushMicrotasks();
+    await flush();
 
     expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(1);
   });

--- a/src/store/manual-pickups.test.ts
+++ b/src/store/manual-pickups.test.ts
@@ -6,6 +6,8 @@
  * 意味の生成(LLM 呼び出し)と Prompt API の利用可否はフェイクを注入する。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PromptSessionLike } from "@/lib/ai/session-pool";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
 import {
   addManualPickup,
   clearManualPickups,
@@ -14,6 +16,35 @@ import {
   useManualPickupStore,
   type ManualPickupDeps,
 } from "./manual-pickups";
+import { resetPromptApiStoreForTests, usePromptApiStore } from "./prompt-api";
+import { resetSettingsStoreForTests, useSettingsStore } from "./settings";
+
+/**
+ * getDefineTermPool(セッションプールの差し替え)を検証するために define-term をモックする(issue #75)。
+ * デフォルト依存(deps を省略した呼び出し)だけがこのモックに到達し、
+ * ManualPickupDeps を注入する既存テストの経路には影響しない。
+ */
+const defineTermMockState = vi.hoisted(() => {
+  /** createDefineTermBaseSessionFactory が生成したフェイクのベースセッションの破棄記録(生成順) */
+  const createdBaseSessions: Array<{ destroyCount: number }> = [];
+  return { createdBaseSessions };
+});
+
+vi.mock("@/lib/ai/define-term", () => ({
+  createDefineTermBaseSessionFactory: () => async (): Promise<PromptSessionLike> => {
+    const tracker = { destroyCount: 0 };
+    defineTermMockState.createdBaseSessions.push(tracker);
+    const session: PromptSessionLike = {
+      prompt: async () => "モックの応答",
+      clone: async () => session,
+      destroy: () => {
+        tracker.destroyCount += 1;
+      },
+    };
+    return session;
+  },
+  defineTerm: async () => ({ meaning: "モックが生成した意味" }),
+}));
 
 function createDeps(overrides: Partial<ManualPickupDeps> = {}): ManualPickupDeps {
   return {
@@ -243,5 +274,68 @@ describe("manual-pickups ストア", () => {
     clearManualPickups();
 
     expect(useManualPickupStore.getState().entries).toEqual({});
+  });
+});
+
+/**
+ * issue #75: 設定・配信情報の変化でセッションプールを差し替えるとき、旧プールのウォームアップ済み
+ * ベースセッション(Gemini Nano のネイティブセッション)を破棄し、リークさせないこと。
+ * デフォルト依存(deps 省略)で getDefineTermPool を経由させるため、define-term をモックしている。
+ */
+describe("getDefineTermPool: プール差し替え時の破棄(issue #75)", () => {
+  /** ウォームアップ(ベースセッション生成)や dispose の destroy 呼び出しが落ち着くまでフラッシュする */
+  async function flushMicrotasks(times = 10) {
+    for (let i = 0; i < times; i++) {
+      await Promise.resolve();
+    }
+  }
+
+  /** デフォルト依存が参照する設定ストア・Prompt API ストアを「利用可能」な状態にする */
+  function setUpDefaultDepsEnvironment() {
+    useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS }, hydrated: true });
+    usePromptApiStore.setState({ status: { status: "ready" } });
+  }
+
+  afterEach(() => {
+    defineTermMockState.createdBaseSessions.length = 0;
+    resetSettingsStoreForTests();
+    resetPromptApiStoreForTests();
+  });
+
+  it("設定が同じ間はプールを使い回し、ベースセッションを破棄しない", async () => {
+    setUpDefaultDepsEnvironment();
+
+    await addManualPickup("msg-1", "gg", "gg chat");
+    await addManualPickup("msg-2", "poggers", "poggers wow");
+    await flushMicrotasks();
+
+    expect(defineTermMockState.createdBaseSessions).toHaveLength(1);
+    expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(0);
+  });
+
+  it("設定が変わって新しいプールを作るとき、旧プールのベースセッションを destroy する", async () => {
+    setUpDefaultDepsEnvironment();
+    await addManualPickup("msg-1", "gg", "gg chat");
+    await flushMicrotasks();
+    expect(defineTermMockState.createdBaseSessions).toHaveLength(1);
+
+    useSettingsStore.setState({ settings: { ...DEFAULT_SETTINGS, explainLang: "es" }, hydrated: true });
+    await addManualPickup("msg-2", "poggers", "poggers wow");
+    await flushMicrotasks();
+
+    expect(defineTermMockState.createdBaseSessions).toHaveLength(2);
+    expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(1); // 旧プールは破棄する
+    expect(defineTermMockState.createdBaseSessions[1].destroyCount).toBe(0); // 新プールは使い続ける
+  });
+
+  it("resetManualPickupStoreForTests はキャッシュ中のプールのベースセッションを破棄する", async () => {
+    setUpDefaultDepsEnvironment();
+    await addManualPickup("msg-1", "gg", "gg chat");
+    await flushMicrotasks();
+
+    resetManualPickupStoreForTests();
+    await flushMicrotasks();
+
+    expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(1);
   });
 });

--- a/src/store/manual-pickups.ts
+++ b/src/store/manual-pickups.ts
@@ -16,7 +16,7 @@
  */
 import { create } from "zustand";
 import { createDefineTermBaseSessionFactory, defineTerm } from "@/lib/ai/define-term";
-import { createSessionPool, type SessionPool } from "@/lib/ai/session-pool";
+import { createSessionPool, SessionPoolDisposedError, type SessionPool } from "@/lib/ai/session-pool";
 import { sharedPromptJobQueue } from "./auto-pipeline";
 import { normalizePickupTerm } from "./hidden-pickups";
 import { usePromptApiStore, type PromptApiStatus } from "./prompt-api";
@@ -50,6 +50,16 @@ export interface ManualPickupDeps {
  */
 let cachedPool: { key: string; pool: SessionPool } | null = null;
 
+/**
+ * キャッシュ中のプールを破棄して捨てる。「捨てる前に必ず dispose する」という不変条件を
+ * 1箇所に集約し、旧プールのウォームアップ済みベースセッション(Gemini Nano のネイティブ
+ * セッション)をリークさせない(issue #75)。プールが無ければ何もしない
+ */
+function disposeCachedPool(): void {
+  cachedPool?.pool.dispose();
+  cachedPool = null;
+}
+
 function getDefineTermPool(): SessionPool {
   const { hydrated, settings } = useSettingsStore.getState();
   // 手動Pick upはユーザー操作起点のため通常は復元済みだが、呼び出し順の誤りを暗黙に隠さない(Fail-Fast)。
@@ -60,9 +70,9 @@ function getDefineTermPool(): SessionPool {
   // 構造ごと JSON にして比較する(設定・配信情報はどちらも小さな平坦オブジェクト)
   const key = JSON.stringify([settings, streamInfo]);
   if (cachedPool === null || cachedPool.key !== key) {
-    // 旧プールのウォームアップ済みベースセッションを破棄し、Gemini Nano のネイティブセッションを
-    // リークさせない(issue #75)。旧プールに残っていたジョブは破棄済みエラーで failed になる
-    cachedPool?.pool.dispose();
+    // 旧プールに残っていたジョブは SessionPoolDisposedError で failed になり、
+    // addManualPickup が再試行を促す理由に差し替える
+    disposeCachedPool();
     cachedPool = {
       key,
       pool: createSessionPool({
@@ -178,12 +188,16 @@ export async function addManualPickup(
     const meaning = await deps.generateMeaning(trimmed, messageText, controller.signal);
     replaceEntry(messageId, trimmed, { status: "done", term: trimmed, meaning });
   } catch (error) {
-    // 削除・クリアによる中断はエントリ自体が消えているため、replaceEntry のガードで何も反映されない
-    replaceEntry(messageId, trimmed, {
-      status: "failed",
-      term: trimmed,
-      reason: error instanceof Error ? error.message : String(error),
-    });
+    // 削除・クリアによる中断はエントリ自体が消えているため、replaceEntry のガードで何も反映されない。
+    // プール差し替え(設定変更・配信情報の更新)で破棄されたジョブは、内部文言ではなく
+    // 再試行(語句の再選択)を促す理由に差し替える(issue #75)
+    const reason =
+      error instanceof SessionPoolDisposedError
+        ? "Cancelled because the settings or stream context changed. Select the term again to retry."
+        : error instanceof Error
+          ? error.message
+          : String(error);
+    replaceEntry(messageId, trimmed, { status: "failed", term: trimmed, reason });
   } finally {
     pendingControllers.delete(pendingKey(messageId, trimmed));
   }
@@ -213,13 +227,15 @@ export function removeManualPickup(messageId: string, term: string): void {
 /** 手動Pick upをすべて破棄する。チャンネル切り替え時(`chat-connection.ts` の connect())に呼ぶ */
 export function clearManualPickups(): void {
   abortAllPendingGenerations();
+  // チャンネル切替後は配信情報が変わりプールキーが二度と一致しないため、ここで破棄しないと
+  // 旧チャンネルのベースセッションがページの寿命までリークし得る(issue #75)
+  disposeCachedPool();
   useManualPickupStore.setState({ entries: {} });
 }
 
 /** テスト専用: ストアとセッションプールのキャッシュを初期状態に戻す。各テストの afterEach で呼び出すこと */
 export function resetManualPickupStoreForTests(): void {
   abortAllPendingGenerations();
-  cachedPool?.pool.dispose();
-  cachedPool = null;
+  disposeCachedPool();
   useManualPickupStore.setState({ entries: {} });
 }

--- a/src/store/manual-pickups.ts
+++ b/src/store/manual-pickups.ts
@@ -60,6 +60,9 @@ function getDefineTermPool(): SessionPool {
   // 構造ごと JSON にして比較する(設定・配信情報はどちらも小さな平坦オブジェクト)
   const key = JSON.stringify([settings, streamInfo]);
   if (cachedPool === null || cachedPool.key !== key) {
+    // 旧プールのウォームアップ済みベースセッションを破棄し、Gemini Nano のネイティブセッションを
+    // リークさせない(issue #75)。旧プールに残っていたジョブは破棄済みエラーで failed になる
+    cachedPool?.pool.dispose();
     cachedPool = {
       key,
       pool: createSessionPool({
@@ -216,6 +219,7 @@ export function clearManualPickups(): void {
 /** テスト専用: ストアとセッションプールのキャッシュを初期状態に戻す。各テストの afterEach で呼び出すこと */
 export function resetManualPickupStoreForTests(): void {
   abortAllPendingGenerations();
+  cachedPool?.pool.dispose();
   cachedPool = null;
   useManualPickupStore.setState({ entries: {} });
 }

--- a/src/store/pipeline-test-fixtures.ts
+++ b/src/store/pipeline-test-fixtures.ts
@@ -92,7 +92,8 @@ export function createDeps(
     return run({ prompt });
   });
   const warmUp = vi.fn(async () => {});
-  const pool = { enqueue, warmUp } as unknown as SessionPool;
+  const dispose = vi.fn();
+  const pool = { enqueue, warmUp, dispose } as unknown as SessionPool;
 
   /** 逆方向ジョブ用のフェイクセッションの prompt。順方向と分けて検証できるようにする */
   const reversePrompt = vi.fn((): Promise<string> => {
@@ -104,7 +105,8 @@ export function createDeps(
     return run({ prompt: reversePrompt });
   });
   const reverseWarmUp = vi.fn(async () => {});
-  const reversePool = { enqueue: reverseEnqueue, warmUp: reverseWarmUp } as unknown as SessionPool;
+  const reverseDispose = vi.fn();
+  const reversePool = { enqueue: reverseEnqueue, warmUp: reverseWarmUp, dispose: reverseDispose } as unknown as SessionPool;
 
   /** フェイクの Language Detector。判定に渡された本文を検証するために公開する */
   const detect = vi.fn(
@@ -143,9 +145,11 @@ export function createDeps(
     enqueue,
     prompt,
     warmUp,
+    dispose,
     reverseEnqueue,
     reversePrompt,
     reverseWarmUp,
+    reverseDispose,
     detect,
     createDetector,
     listeners,


### PR DESCRIPTION
## Summary

issue #75 の対応として、`SessionPool` にベースセッションの破棄API `dispose()` を追加し、プール差し替え・パイプライン停止・チャンネル切替の各経路で Gemini Nano のネイティブセッションがページの寿命までリークする問題を解消します。

### 変更内容

- **`src/lib/ai/session-pool.ts`**: `SessionPool.dispose()` を追加
  - 生成済み・生成中のベースセッションを `destroy()`(生成中は完了を待ってから破棄)
  - 冪等。dispose 後の `enqueue` / `warmUp` は再生成せず `SessionPoolDisposedError` で拒否(Fail-Fast)
  - `clone()` 実行中は clone 完了を待ってから destroy し、clone 途中の破棄レースを防止
  - `destroy()` の失敗は握りつぶさず `console.warn` で記録
- **`src/store/auto-pipeline.ts`**: 停止関数で順方向・逆方向プールを `dispose()`(未生成なら何もしない)
- **`src/store/manual-pickups.ts`**:
  - 「捨てる前に必ず dispose する」を `disposeCachedPool()` に集約し、キー変更時(`getDefineTermPool`)・チャンネル切替時(`clearManualPickups`)・テストリセット時に破棄
  - プール差し替えで破棄されたジョブの failed 理由を、内部文言ではなく再試行(語句の再選択)を促す文言に差し替え

### テスト

- `session-pool.test.ts`: dispose の基本動作・冪等性・未生成/生成中/実行中の各タイミング・dispose 後の Fail-Fast・cloneレース・destroy失敗時の警告(10件)
- `auto-pipeline.test.ts`: 停止時の順方向/逆方向プールの破棄・未生成プールを作らないこと(3件)
- `manual-pickups.test.ts`: キー変更/クリア/リセット時の破棄・破棄済みエラーの理由差し替え(5件)

746テスト・Lint・型チェック・ビルドすべてパス。

### コードレビューについて

CodeRabbitはレートリミットのため `/code-review`(high)で代替実施。指摘8件のうち6件を本PRで対応済み。残り2件の扱い:

- **Language Detector のリーク(同一クラスの別リーク)**: インターフェース変更を含む4ファイル超の独立作業のため #78 としてissue化
- **`vi.mock("@/lib/ai/define-term")` が過剰との指摘**: プール生成を注入可能にするには `ManualPickupDeps`(UI向けの注入シーム)へプール管理の詳細を漏らす設計変更が必要なため見送り。モックはデフォルト依存経由のテストのみが到達し、既存テストの経路には影響しない旨をコメントに明記済み

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH