### PR TITLE
fix: パイプライン停止時にLanguage Detectorのネイティブセッションを破棄する

### DIFF
--- a/src/lib/ai/detect-language.ts
+++ b/src/lib/ai/detect-language.ts
@@ -28,6 +28,8 @@ export interface DetectedLanguageCandidate {
 /** Language Detector のセッションが最低限備えるべきインターフェース */
 export interface LanguageDetectorLike {
   detect(input: string): Promise<DetectedLanguageCandidate[]>;
+  /** ネイティブセッションを解放する。パイプライン停止時に呼び、再起動のたびのリークを防ぐ(issue #78) */
+  destroy(): void;
 }
 
 /** 言語が判定できなかったときの BCP 47 タグ(Language Detector も同じ値を返す) */

--- a/src/store/auto-pipeline.test.ts
+++ b/src/store/auto-pipeline.test.ts
@@ -10,6 +10,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import type { EnvironmentDiagnosis } from "@/lib/ai/availability";
+import type { LanguageDetectorLike } from "@/lib/ai/detect-language";
 import { LowPriorityQueueOverflowError } from "@/lib/ai/session-pool";
 import { createAutoPipeline, MAX_WAITING_FOR_DIAGNOSIS } from "./auto-pipeline";
 import { createDeferred, createDeps, createDiagnosis, createMessage, flush } from "./pipeline-test-fixtures";
@@ -647,5 +648,84 @@ describe("createAutoPipeline: 停止時のセッションプール破棄(issue #
     expect(deps.createReversePool).not.toHaveBeenCalled();
     expect(dispose).not.toHaveBeenCalled();
     expect(reverseDispose).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * issue #78: パイプライン停止時に、生成済み(生成中を含む)の Language Detector の
+ * ネイティブセッションを destroy し、再起動のたびにリークさせないこと。
+ */
+describe("createAutoPipeline: 停止時の Language Detector 破棄(issue #78)", () => {
+  it("停止関数は発言処理で生成した Language Detector を destroy する", async () => {
+    const { deps, emit, detectorDestroy } = createDeps({ promptResults: [Promise.resolve("訳文")] });
+
+    const stop = start(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "gg chat" }));
+    await flush();
+
+    expect(detectorDestroy).not.toHaveBeenCalled();
+    stop();
+    await flush();
+
+    expect(detectorDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("停止関数はウォームアップで生成した Language Detector を destroy する", async () => {
+    const { deps, detectorDestroy } = createDeps();
+
+    const stop = start(deps);
+    await flush();
+    warmUpPipeline();
+    await flush();
+    stop();
+    await flush();
+
+    expect(detectorDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Language Detector の生成中に停止した場合、生成完了を待ってから destroy する", async () => {
+    const { deps, detectorDestroy, createDetector } = createDeps();
+    const deferred = createDeferred<LanguageDetectorLike>();
+    createDetector.mockReturnValueOnce(deferred.promise);
+
+    const stop = start(deps);
+    await flush();
+    // ウォームアップで Detector の生成を開始し、生成が完了しないうちに停止する
+    warmUpPipeline();
+    stop();
+    await flush();
+    expect(detectorDestroy).not.toHaveBeenCalled();
+
+    deferred.resolve({ detect: async () => [], destroy: detectorDestroy });
+    await flush();
+
+    expect(detectorDestroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("Language Detector を生成しないまま停止した場合、destroy のために新しく生成しない", async () => {
+    const { deps, detectorDestroy, createDetector } = createDeps();
+
+    const stop = start(deps);
+    await flush();
+    stop();
+    await flush();
+
+    expect(createDetector).not.toHaveBeenCalled();
+    expect(detectorDestroy).not.toHaveBeenCalled();
+  });
+
+  it("Language Detector の生成が失敗していた場合、destroy を呼ばず停止だけを完了する", async () => {
+    const { deps, detectorDestroy, createDetector } = createDeps();
+    createDetector.mockRejectedValueOnce(new Error("NotAllowedError: user activation is required"));
+
+    const stop = start(deps);
+    await flush();
+    warmUpPipeline();
+    await flush();
+    stop();
+    await flush();
+
+    expect(detectorDestroy).not.toHaveBeenCalled();
   });
 });

--- a/src/store/auto-pipeline.ts
+++ b/src/store/auto-pipeline.ts
@@ -370,6 +370,21 @@ export function createAutoPipeline<TDone extends object>(config: AutoPipelineCon
       // 破棄済みプールへの遅延ジョブは拒否されるが、controller.abort() 済みのため結果には反映されない
       forwardPool?.dispose();
       reversePool?.dispose();
+      // 生成済み(生成中を含む)の Language Detector のネイティブセッションを解放する(issue #78)。
+      // 生成中の場合は完了を待ってから destroy する(SessionPool.dispose() と同じ方針)。
+      // 生成失敗は getDetector が detectorPromise を捨てて呼び出し元へ通知済みのため、破棄対象が無く何もしない
+      detectorPromise?.then(
+        (detector) => {
+          try {
+            detector.destroy();
+          } catch (error) {
+            // destroy の失敗はネイティブセッションのリーク残存を意味するが、停止処理の呼び出し元
+            // (ホーム画面のアンマウント・再起動)には対処手段が無いため、警告として記録するに留める
+            console.warn("auto-pipeline: Language Detector の destroy に失敗しました", error);
+          }
+        },
+        () => {},
+      );
       if (activePipeline === handle) activePipeline = null;
     };
   }

--- a/src/store/pipeline-test-fixtures.ts
+++ b/src/store/pipeline-test-fixtures.ts
@@ -114,7 +114,9 @@ export function createDeps(
       { detectedLanguage: options.detectedLanguage ?? "en", confidence: 0.9 },
     ],
   );
-  const createDetector = vi.fn(async (): Promise<LanguageDetectorLike> => ({ detect }));
+  /** フェイクの Language Detector の destroy。停止時にネイティブセッションを破棄することを検証するために公開する */
+  const detectorDestroy = vi.fn();
+  const createDetector = vi.fn(async (): Promise<LanguageDetectorLike> => ({ detect, destroy: detectorDestroy }));
 
   const deps: AutoPipelineDeps = {
     diagnose: vi.fn(async () => createDiagnosis(options.ready ?? true)),
@@ -151,6 +153,7 @@ export function createDeps(
     reverseWarmUp,
     reverseDispose,
     detect,
+    detectorDestroy,
     createDetector,
     listeners,
   };


### PR DESCRIPTION
## Summary

issue #78 の対応です。言語設定の変更や配信情報の変化でauto-pipelineが再起動するたびに、`start()` が生成したネイティブのLanguageDetectorセッションが破棄されずページの寿命までリークしていた問題を修正します。

## 変更内容

- `src/lib/ai/detect-language.ts`: `LanguageDetectorLike` に `destroy()` を追加しました(実体の `LanguageDetector` は既に `destroy()` を持つため、`createBrowserLanguageDetector` の実装変更は不要です)
- `src/store/auto-pipeline.ts`: 停止関数で生成済み(生成中を含む)のDetectorを `destroy()` します。生成中の場合は完了を待ってから破棄します(`SessionPool.dispose()` と同じ方針)。生成失敗時は `getDetector` が `detectorPromise` を捨てて呼び出し元へ通知済みのため、何もしません
- `src/store/pipeline-test-fixtures.ts`: フェイクDetectorに `destroy` スパイ(`detectorDestroy`)を追加しました
- `src/store/auto-pipeline.test.ts`: 停止時のDetector破棄を検証するテスト5件を追加しました(発言処理で生成/ウォームアップで生成/生成中に停止/未生成のまま停止/生成失敗)

## テスト

- `npm test`: 751件すべて成功
- `npm run type-check` / `npm run lint` / `npm run build`: エラー・警告なし
- `coderabbit review --agent`: 指摘0件

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH