### PR TITLE
feat: bot除外設定に配信者自身の発言を非表示にするトグルを追加する

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -789,10 +789,27 @@ describe("Home(bot除外設定)", () => {
     await user.click(within(dialog).getByRole("button", { name: "Save" }));
 
     expect(useBotFilterStore.getState().patterns).toEqual(["streamelements", "*bot"]);
-    expect(JSON.parse(window.localStorage.getItem("chat-sensei:bot-filter") ?? "null")).toEqual([
-      "streamelements",
-      "*bot",
-    ]);
+    expect(JSON.parse(window.localStorage.getItem("chat-sensei:bot-filter") ?? "null")).toEqual({
+      patterns: ["streamelements", "*bot"],
+      excludeBroadcaster: false,
+    });
+  });
+
+  it("配信者自身の発言を隠すトグルを切り替えて保存すると、ストアと LocalStorage に反映される", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    await user.click(screen.getByRole("button", { name: "Bot filter" }));
+    const dialog = await screen.findByRole("dialog", { name: "Bot filter" });
+    const toggle = within(dialog).getByRole("switch", { name: "Hide the streamer's own messages" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+    await user.click(toggle);
+    await user.click(within(dialog).getByRole("button", { name: "Save" }));
+
+    expect(useBotFilterStore.getState().excludeBroadcaster).toBe(true);
+    expect(JSON.parse(window.localStorage.getItem("chat-sensei:bot-filter") ?? "null")).toMatchObject({
+      excludeBroadcaster: true,
+    });
   });
 
   it("マウント時に LocalStorage から除外パターンを復元する", () => {

--- a/src/components/bot-filter-dialog.tsx
+++ b/src/components/bot-filter-dialog.tsx
@@ -4,8 +4,10 @@
  * 生IRC列の見出しに置いたアイコンボタンから開き、チャット欄から除外する bot の
  * ユーザー名パターンを1行1件で編集する。`*` はワイルドカードで、配信者ごとに
  * 個別アカウントで運用される翻訳bot(`*trans`)などを一括で除外できる。
+ * 配信者アカウントで bot 的なコメント(定型文・アラート等)を流す配信者も多いため、
+ * 記述欄の上のトグルで配信者自身の発言をまとめて非表示にできる。
  *
- * 保存すると `useBotFilterStore.setPatterns` が LocalStorage へ永続化し、
+ * 保存すると `useBotFilterStore.setBotFilter` が LocalStorage へ永続化し、
  * `chat-connection.ts` が表示中の発言からも一致するものを取り除く。
  * 復元時に保存データが壊れていた場合(`wasCorrupted`)は、デフォルトに戻した旨をここで利用者に伝える。
  */
@@ -25,30 +27,37 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import { formatBotFilterPatterns, parseBotFilterPatterns } from "@/lib/bot-filter";
 import { useBotFilterStore } from "@/store/bot-filter";
 
 const DIALOG_TITLE = "Bot filter";
 const TEXTAREA_ID = "bot-filter-patterns";
+const BROADCASTER_SWITCH_ID = "bot-filter-exclude-broadcaster";
 const TEXTAREA_ROWS = 10;
 
 export function BotFilterDialog() {
   const patterns = useBotFilterStore((state) => state.patterns);
+  const excludeBroadcaster = useBotFilterStore((state) => state.excludeBroadcaster);
   const wasCorrupted = useBotFilterStore((state) => state.wasCorrupted);
-  const setPatterns = useBotFilterStore((state) => state.setPatterns);
+  const setBotFilter = useBotFilterStore((state) => state.setBotFilter);
 
   const [open, setOpen] = useState(false);
   const [draft, setDraft] = useState("");
+  const [draftExcludeBroadcaster, setDraftExcludeBroadcaster] = useState(false);
 
   const handleOpenChange = (nextOpen: boolean) => {
     // 開くたびにストアの現在値から下書きを作り直す(前回の未保存の編集を持ち越さない)
-    if (nextOpen) setDraft(formatBotFilterPatterns(patterns));
+    if (nextOpen) {
+      setDraft(formatBotFilterPatterns(patterns));
+      setDraftExcludeBroadcaster(excludeBroadcaster);
+    }
     setOpen(nextOpen);
   };
 
   const handleSave = () => {
-    setPatterns(parseBotFilterPatterns(draft));
+    setBotFilter({ patterns: parseBotFilterPatterns(draft), excludeBroadcaster: draftExcludeBroadcaster });
     setOpen(false);
   };
 
@@ -70,6 +79,14 @@ export function BotFilterDialog() {
             Your saved settings were corrupted and have been reset to the defaults. Save again to clear this notice.
           </p>
         )}
+        <div className="flex items-center justify-between gap-2">
+          <Label htmlFor={BROADCASTER_SWITCH_ID}>Hide the streamer&apos;s own messages</Label>
+          <Switch
+            id={BROADCASTER_SWITCH_ID}
+            checked={draftExcludeBroadcaster}
+            onCheckedChange={(checked) => setDraftExcludeBroadcaster(checked)}
+          />
+        </div>
         <div className="flex flex-col gap-1.5">
           <Label htmlFor={TEXTAREA_ID}>Usernames to hide</Label>
           <Textarea

--- a/src/lib/bot-filter.test.ts
+++ b/src/lib/bot-filter.test.ts
@@ -8,12 +8,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 import {
   BOT_FILTER_STORAGE_KEY,
+  DEFAULT_BOT_FILTER_CONFIG,
   DEFAULT_BOT_FILTER_PATTERNS,
   formatBotFilterPatterns,
-  loadBotFilterPatterns,
+  isExcludedFromChat,
+  loadBotFilterConfig,
   matchesBotFilter,
   parseBotFilterPatterns,
-  saveBotFilterPatterns,
+  saveBotFilterConfig,
 } from "./bot-filter";
 
 afterEach(() => {
@@ -91,28 +93,68 @@ describe("DEFAULT_BOT_FILTER_PATTERNS", () => {
   });
 });
 
-describe("loadBotFilterPatterns / saveBotFilterPatterns", () => {
-  it("保存されたデータが無い場合はデフォルトのパターンを返す", () => {
-    expect(loadBotFilterPatterns()).toEqual({ patterns: DEFAULT_BOT_FILTER_PATTERNS, wasCorrupted: false });
+describe("loadBotFilterConfig / saveBotFilterConfig", () => {
+  it("保存されたデータが無い場合はデフォルト設定を返す", () => {
+    expect(loadBotFilterConfig()).toEqual({ config: DEFAULT_BOT_FILTER_CONFIG, wasCorrupted: false });
   });
 
-  it("保存したパターンをそのまま復元する(空配列 = すべて除外しない、も保存できる)", () => {
-    saveBotFilterPatterns(["nightbot", "*trans"]);
-    expect(loadBotFilterPatterns()).toEqual({ patterns: ["nightbot", "*trans"], wasCorrupted: false });
+  it("保存した設定をそのまま復元する(空配列 = すべて除外しない、も保存できる)", () => {
+    saveBotFilterConfig({ patterns: ["nightbot", "*trans"], excludeBroadcaster: true });
+    expect(loadBotFilterConfig()).toEqual({
+      config: { patterns: ["nightbot", "*trans"], excludeBroadcaster: true },
+      wasCorrupted: false,
+    });
 
-    saveBotFilterPatterns([]);
-    expect(loadBotFilterPatterns()).toEqual({ patterns: [], wasCorrupted: false });
+    saveBotFilterConfig({ patterns: [], excludeBroadcaster: false });
+    expect(loadBotFilterConfig()).toEqual({
+      config: { patterns: [], excludeBroadcaster: false },
+      wasCorrupted: false,
+    });
+  });
+
+  it("旧形式(文字列配列のみ)の保存データは、配信者除外オフとして復元する", () => {
+    window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, JSON.stringify(["nightbot", "*trans"]));
+
+    expect(loadBotFilterConfig()).toEqual({
+      config: { patterns: ["nightbot", "*trans"], excludeBroadcaster: false },
+      wasCorrupted: false,
+    });
   });
 
   it("JSONとして壊れたデータの場合はデフォルトに戻し、壊れていたことを伝える", () => {
     window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, "{ これはJSONではない");
 
-    expect(loadBotFilterPatterns()).toEqual({ patterns: DEFAULT_BOT_FILTER_PATTERNS, wasCorrupted: true });
+    expect(loadBotFilterConfig()).toEqual({ config: DEFAULT_BOT_FILTER_CONFIG, wasCorrupted: true });
   });
 
-  it("文字列配列以外が保存されている場合はデフォルトに戻し、壊れていたことを伝える", () => {
+  it("スキーマに合わないデータが保存されている場合はデフォルトに戻し、壊れていたことを伝える", () => {
     window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, JSON.stringify({ patterns: "nightbot" }));
 
-    expect(loadBotFilterPatterns()).toEqual({ patterns: DEFAULT_BOT_FILTER_PATTERNS, wasCorrupted: true });
+    expect(loadBotFilterConfig()).toEqual({ config: DEFAULT_BOT_FILTER_CONFIG, wasCorrupted: true });
+  });
+});
+
+describe("isExcludedFromChat", () => {
+  const config = { patterns: ["nightbot"], excludeBroadcaster: true };
+
+  it("配信者除外がオンなら、接続中チャンネル名と同じユーザー名(= 配信者自身)の発言を除外する", () => {
+    expect(isExcludedFromChat("zackrawrr", "zackrawrr", config)).toBe(true);
+  });
+
+  it("配信者の判定でもユーザー名の大文字小文字は区別しない", () => {
+    expect(isExcludedFromChat("ZackRawrr", "zackrawrr", config)).toBe(true);
+  });
+
+  it("配信者除外がオフなら、配信者自身の発言は除外しない", () => {
+    expect(isExcludedFromChat("zackrawrr", "zackrawrr", { patterns: [], excludeBroadcaster: false })).toBe(false);
+  });
+
+  it("未接続(channel が null)の場合は、配信者除外では除外しない", () => {
+    expect(isExcludedFromChat("zackrawrr", null, config)).toBe(false);
+  });
+
+  it("除外パターンに一致するユーザー名は、配信者除外の設定に関わらず除外する", () => {
+    expect(isExcludedFromChat("nightbot", "zackrawrr", config)).toBe(true);
+    expect(isExcludedFromChat("viewer_taro", "zackrawrr", config)).toBe(false);
   });
 });

--- a/src/lib/bot-filter.ts
+++ b/src/lib/bot-filter.ts
@@ -4,8 +4,12 @@
  * - パターンは Twitch のログイン名(小文字)に対して照合する。`*` は任意の文字列に一致する
  *   ワイルドカードで、配信者ごとに個別のアカウントで運用される翻訳bot(`*trans`)や
  *   `*bot` のような命名の bot を一括で除外できる。`*` を含まないパターンは完全一致
- * - 設定は LocalStorage に文字列配列としてのみ永続化する(chat-sensei はサーバー不要の
- *   クライアントサイド専用アプリ)。保存データが壊れている場合は暗黙に補正せず、
+ * - パターンに加えて、配信者(broadcaster)自身の発言を除外するトグル(`excludeBroadcaster`)を持つ。
+ *   配信者アカウントで bot 的なコメント(定型文・アラート等)を流す配信者が多いため、
+ *   接続中チャンネル名(= 配信者のログイン名)との一致で除外できるようにする
+ * - 設定は LocalStorage に `{ patterns, excludeBroadcaster }` のオブジェクトとして永続化する
+ *   (chat-sensei はサーバー不要のクライアントサイド専用アプリ)。旧形式(文字列配列のみ)の
+ *   保存データは配信者除外オフとして復元する。保存データが壊れている場合は暗黙に補正せず、
  *   デフォルトへ戻したうえで `wasCorrupted: true` を返して呼び出し元が利用者に伝えられるようにする
  *   (CLAUDE.md の Fail-Fast 方針。`settings.ts` と同じ規約)
  */
@@ -36,11 +40,30 @@ export const DEFAULT_BOT_FILTER_PATTERNS: readonly string[] = [
   "commanderroot",
 ];
 
-const botFilterPatternsSchema = z.array(z.string());
+/** 旧形式の保存データ(パターンの文字列配列のみ。excludeBroadcaster 追加前) */
+const legacyBotFilterPatternsSchema = z.array(z.string());
 
-export interface LoadBotFilterPatternsResult {
+const botFilterConfigSchema = z.object({
+  patterns: z.array(z.string()),
+  excludeBroadcaster: z.boolean(),
+});
+
+/** bot除外設定の全体(除外パターン + 配信者自身を除外するか) */
+export interface BotFilterConfig {
+  /** 除外するユーザー名パターン(`*` ワイルドカード可、小文字) */
   patterns: readonly string[];
-  /** 保存されていた値が壊れていた(JSON不正・文字列配列でない)ため、デフォルトに戻した場合 true */
+  /** 接続中チャンネルの配信者自身の発言も除外するか */
+  excludeBroadcaster: boolean;
+}
+
+export const DEFAULT_BOT_FILTER_CONFIG: BotFilterConfig = {
+  patterns: DEFAULT_BOT_FILTER_PATTERNS,
+  excludeBroadcaster: false,
+};
+
+export interface LoadBotFilterConfigResult {
+  config: BotFilterConfig;
+  /** 保存されていた値が壊れていた(JSON不正・スキーマ不一致)ため、デフォルトに戻した場合 true */
   wasCorrupted: boolean;
 }
 
@@ -77,31 +100,50 @@ export function matchesBotFilter(username: string, patterns: readonly string[]):
   return patterns.some((pattern) => patternToRegExp(pattern).test(username));
 }
 
+/**
+ * 発言をチャット欄から除外すべきか。除外パターンとの一致に加え、配信者除外がオンの場合は
+ * 接続中チャンネル名(= 配信者のログイン名。小文字)との一致でも除外する。
+ * 未接続(channel が null)の間は配信者除外では除外しない。
+ */
+export function isExcludedFromChat(username: string, channel: string | null, config: BotFilterConfig): boolean {
+  if (config.excludeBroadcaster && channel !== null && username.toLowerCase() === channel.toLowerCase()) {
+    return true;
+  }
+  return matchesBotFilter(username, config.patterns);
+}
+
 function ensureBrowserEnvironment(): void {
   if (typeof window === "undefined") {
     throw new Error("bot-filter.ts の保存・復元関数はブラウザ環境でのみ呼び出せます(SSR中に呼び出さないでください)");
   }
 }
 
-/** LocalStorage から除外パターンを読み込む。無い場合はデフォルト、壊れている場合はデフォルト + wasCorrupted を返す */
-export function loadBotFilterPatterns(): LoadBotFilterPatternsResult {
+/** LocalStorage からbot除外設定を読み込む。無い場合はデフォルト、壊れている場合はデフォルト + wasCorrupted を返す */
+export function loadBotFilterConfig(): LoadBotFilterConfigResult {
   ensureBrowserEnvironment();
 
   const raw = window.localStorage.getItem(BOT_FILTER_STORAGE_KEY);
   if (raw === null) {
-    return { patterns: DEFAULT_BOT_FILTER_PATTERNS, wasCorrupted: false };
+    return { config: DEFAULT_BOT_FILTER_CONFIG, wasCorrupted: false };
   }
 
   try {
-    const patterns = botFilterPatternsSchema.parse(JSON.parse(raw));
-    return { patterns, wasCorrupted: false };
+    const parsed: unknown = JSON.parse(raw);
+    // 旧形式(パターンの文字列配列のみ)は、配信者除外オフとして新形式へ移行する
+    if (Array.isArray(parsed)) {
+      return {
+        config: { patterns: legacyBotFilterPatternsSchema.parse(parsed), excludeBroadcaster: false },
+        wasCorrupted: false,
+      };
+    }
+    return { config: botFilterConfigSchema.parse(parsed), wasCorrupted: false };
   } catch {
-    return { patterns: DEFAULT_BOT_FILTER_PATTERNS, wasCorrupted: true };
+    return { config: DEFAULT_BOT_FILTER_CONFIG, wasCorrupted: true };
   }
 }
 
-/** 除外パターンを LocalStorage に保存する。空配列(すべて除外しない)も保存できる */
-export function saveBotFilterPatterns(patterns: readonly string[]): void {
+/** bot除外設定を LocalStorage に保存する。空のパターン配列(すべて除外しない)も保存できる */
+export function saveBotFilterConfig(config: BotFilterConfig): void {
   ensureBrowserEnvironment();
-  window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, JSON.stringify(botFilterPatternsSchema.parse(patterns)));
+  window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, JSON.stringify(botFilterConfigSchema.parse(config)));
 }

--- a/src/store/bot-filter.test.ts
+++ b/src/store/bot-filter.test.ts
@@ -10,7 +10,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   BOT_FILTER_STORAGE_KEY,
   DEFAULT_BOT_FILTER_PATTERNS,
-  loadBotFilterPatterns,
+  loadBotFilterConfig,
 } from "@/lib/bot-filter";
 import {
   hydrateBotFilterStore,
@@ -34,8 +34,21 @@ describe("hydrateBotFilterStore", () => {
     hydrateBotFilterStore();
 
     expect(useBotFilterStore.getState().patterns).toEqual(["*trans"]);
+    expect(useBotFilterStore.getState().excludeBroadcaster).toBe(false);
     expect(useBotFilterStore.getState().hydrated).toBe(true);
     expect(useBotFilterStore.getState().wasCorrupted).toBe(false);
+  });
+
+  it("新形式(配信者除外オン)の保存データも復元する", () => {
+    window.localStorage.setItem(
+      BOT_FILTER_STORAGE_KEY,
+      JSON.stringify({ patterns: ["*trans"], excludeBroadcaster: true }),
+    );
+
+    hydrateBotFilterStore();
+
+    expect(useBotFilterStore.getState().patterns).toEqual(["*trans"]);
+    expect(useBotFilterStore.getState().excludeBroadcaster).toBe(true);
   });
 
   it("保存データが無ければデフォルトのパターンになる", () => {
@@ -64,14 +77,36 @@ describe("hydrateBotFilterStore", () => {
   });
 });
 
+describe("setBotFilter", () => {
+  it("パターンと配信者除外の両方を更新し、LocalStorage にも保存する", () => {
+    hydrateBotFilterStore();
+
+    useBotFilterStore.getState().setBotFilter({ patterns: ["nightbot"], excludeBroadcaster: true });
+
+    expect(useBotFilterStore.getState().patterns).toEqual(["nightbot"]);
+    expect(useBotFilterStore.getState().excludeBroadcaster).toBe(true);
+    expect(loadBotFilterConfig().config).toEqual({ patterns: ["nightbot"], excludeBroadcaster: true });
+  });
+});
+
 describe("setPatterns", () => {
+  it("配信者除外の設定は変えずに、パターンだけを更新する", () => {
+    hydrateBotFilterStore();
+    useBotFilterStore.getState().setBotFilter({ patterns: [], excludeBroadcaster: true });
+
+    useBotFilterStore.getState().setPatterns(["nightbot"]);
+
+    expect(useBotFilterStore.getState().patterns).toEqual(["nightbot"]);
+    expect(useBotFilterStore.getState().excludeBroadcaster).toBe(true);
+  });
+
   it("ストアを更新し、LocalStorage にも保存する", () => {
     hydrateBotFilterStore();
 
     useBotFilterStore.getState().setPatterns(["nightbot", "*trans"]);
 
     expect(useBotFilterStore.getState().patterns).toEqual(["nightbot", "*trans"]);
-    expect(loadBotFilterPatterns().patterns).toEqual(["nightbot", "*trans"]);
+    expect(loadBotFilterConfig().config.patterns).toEqual(["nightbot", "*trans"]);
   });
 
   it("保存に成功したら wasCorrupted を false に戻す(壊れていたデータは正常な値で上書きされたため)", () => {
@@ -88,8 +123,15 @@ describe("isExcludedByBotFilter", () => {
   it("未復元なら先に LocalStorage から復元してから判定する", () => {
     window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, JSON.stringify(["*trans"]));
 
-    expect(isExcludedByBotFilter("yuki_trans")).toBe(true);
-    expect(isExcludedByBotFilter("viewer_taro")).toBe(false);
+    expect(isExcludedByBotFilter("yuki_trans", null)).toBe(true);
+    expect(isExcludedByBotFilter("viewer_taro", null)).toBe(false);
     expect(useBotFilterStore.getState().hydrated).toBe(true);
+  });
+
+  it("配信者除外がオンなら、チャンネル名と同じユーザー名を除外する", () => {
+    window.localStorage.setItem(BOT_FILTER_STORAGE_KEY, JSON.stringify({ patterns: [], excludeBroadcaster: true }));
+
+    expect(isExcludedByBotFilter("zackrawrr", "zackrawrr")).toBe(true);
+    expect(isExcludedByBotFilter("viewer_taro", "zackrawrr")).toBe(false);
   });
 });

--- a/src/store/bot-filter.ts
+++ b/src/store/bot-filter.ts
@@ -1,55 +1,83 @@
 /**
- * チャット欄から除外する bot のユーザー名パターンを保持する、モジュールスコープのストア。
+ * チャット欄から除外する bot のユーザー名パターンと、配信者自身の発言を除外するトグルを保持する、
+ * モジュールスコープのストア。
  *
- * パターンの正本は LocalStorage(`lib/bot-filter.ts`)だが、発言を受信するたびに
+ * 設定の正本は LocalStorage(`lib/bot-filter.ts`)だが、発言を受信するたびに
  * LocalStorage を読むのは無駄なので、Zustand ストアにキャッシュして参照する。
  *
  * SSR 中(Next.js のプリレンダリング)に LocalStorage へ触れないよう、ストアの初期値は
  * 空にしておき、ブラウザ側で `hydrateBotFilterStore()` を呼んだときに初めて復元する。
- * 復元は1度だけ行い、以後の変更は `setPatterns` 経由でストアと LocalStorage の両方へ書き込む。
+ * 復元は1度だけ行い、以後の変更は `setBotFilter` / `setPatterns` 経由でストアと LocalStorage の両方へ書き込む。
  *
  * 受信した発言への適用(除外)は `chat-connection.ts` が担う(依存方向は chat-connection → bot-filter)。
  */
 import { create } from "zustand";
-import { loadBotFilterPatterns, matchesBotFilter, saveBotFilterPatterns } from "@/lib/bot-filter";
+import {
+  type BotFilterConfig,
+  isExcludedFromChat,
+  loadBotFilterConfig,
+  saveBotFilterConfig,
+} from "@/lib/bot-filter";
 
 interface BotFilterState {
   /** 除外するユーザー名パターン(`*` ワイルドカード可、小文字) */
   patterns: readonly string[];
+  /** 接続中チャンネルの配信者自身の発言も除外するか */
+  excludeBroadcaster: boolean;
   /** LocalStorage からの復元が済んでいるか */
   hydrated: boolean;
   /** 復元時に保存データが壊れていて、デフォルトに戻したか(設定画面で利用者に伝える) */
   wasCorrupted: boolean;
-  /** パターンを更新し、LocalStorage にも保存する */
+  /** bot除外設定(パターン + 配信者除外)をまとめて更新し、LocalStorage にも保存する */
+  setBotFilter: (config: BotFilterConfig) => void;
+  /** 配信者除外の設定は変えずに、パターンだけを更新する(`setBotFilter` の簡易版) */
   setPatterns: (patterns: readonly string[]) => void;
 }
 
-export const useBotFilterStore = create<BotFilterState>((set) => ({
+export const useBotFilterStore = create<BotFilterState>((set, get) => ({
   patterns: [],
+  excludeBroadcaster: false,
   hydrated: false,
   wasCorrupted: false,
-  setPatterns: (patterns) => {
-    saveBotFilterPatterns(patterns);
+  setBotFilter: (config) => {
+    saveBotFilterConfig(config);
     // 保存に成功した時点で LocalStorage は正常な値になっているため、壊れていた印は下ろす。
     // ストアが正本の値を持った状態になるので、復元済み扱いにする
-    set({ patterns, wasCorrupted: false, hydrated: true });
+    set({
+      patterns: config.patterns,
+      excludeBroadcaster: config.excludeBroadcaster,
+      wasCorrupted: false,
+      hydrated: true,
+    });
+  },
+  setPatterns: (patterns) => {
+    get().setBotFilter({ patterns, excludeBroadcaster: get().excludeBroadcaster });
   },
 }));
 
-/** LocalStorage から除外パターンを復元する。既に復元済みなら何もしない(ブラウザ環境でのみ呼ぶこと) */
+/** LocalStorage からbot除外設定を復元する。既に復元済みなら何もしない(ブラウザ環境でのみ呼ぶこと) */
 export function hydrateBotFilterStore(): void {
   if (useBotFilterStore.getState().hydrated) return;
-  const { patterns, wasCorrupted } = loadBotFilterPatterns();
-  useBotFilterStore.setState({ patterns, wasCorrupted, hydrated: true });
+  const { config, wasCorrupted } = loadBotFilterConfig();
+  useBotFilterStore.setState({
+    patterns: config.patterns,
+    excludeBroadcaster: config.excludeBroadcaster,
+    wasCorrupted,
+    hydrated: true,
+  });
 }
 
-/** ユーザー名が現在の除外パターンに一致するか。未復元なら先に復元する */
-export function isExcludedByBotFilter(username: string): boolean {
+/**
+ * ユーザー名を現在のbot除外設定で除外すべきか。未復元なら先に復元する。
+ * `channel` は接続中チャンネル名(= 配信者のログイン名。未接続なら null)で、配信者除外の判定に使う。
+ */
+export function isExcludedByBotFilter(username: string, channel: string | null): boolean {
   hydrateBotFilterStore();
-  return matchesBotFilter(username, useBotFilterStore.getState().patterns);
+  const { patterns, excludeBroadcaster } = useBotFilterStore.getState();
+  return isExcludedFromChat(username, channel, { patterns, excludeBroadcaster });
 }
 
 /** テスト専用: ストアを初期状態(未復元)に戻す。各テストの beforeEach で呼び出すこと */
 export function resetBotFilterStoreForTests(): void {
-  useBotFilterStore.setState({ patterns: [], hydrated: false, wasCorrupted: false });
+  useBotFilterStore.setState({ patterns: [], excludeBroadcaster: false, hydrated: false, wasCorrupted: false });
 }

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -349,6 +349,37 @@ describe("bot除外", () => {
 
     expect(useChatConnectionStore.getState().messages).toEqual([humanMessage]);
   });
+
+  it("配信者除外がオンなら、接続中チャンネルの配信者自身の発言は流れない", () => {
+    useBotFilterStore.getState().setBotFilter({ patterns: [], excludeBroadcaster: true });
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const listener = vi.fn();
+    subscribeToChatMessages(listener);
+
+    capturedCallbacks?.onEvent({
+      type: "privmsg",
+      channel: "zackrawrr",
+      message: createSampleMessage({ id: "streamer-1", username: "zackrawrr", displayName: "ZackRawrr" }),
+    });
+    const humanMessage = createSampleMessage({ id: "human-1", username: "viewer_taro" });
+    capturedCallbacks?.onEvent({ type: "privmsg", channel: "zackrawrr", message: humanMessage });
+
+    expect(useChatConnectionStore.getState().messages).toEqual([humanMessage]);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(humanMessage);
+  });
+
+  it("配信者除外をオンに変更すると、表示中の配信者自身の発言も取り除かれる", () => {
+    useBotFilterStore.getState().setBotFilter({ patterns: [], excludeBroadcaster: false });
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    const streamerMessage = createSampleMessage({ id: "streamer-1", username: "zackrawrr" });
+    const humanMessage = createSampleMessage({ id: "human-1", username: "viewer_taro" });
+    useChatConnectionStore.setState({ messages: [streamerMessage, humanMessage] });
+
+    useBotFilterStore.getState().setBotFilter({ patterns: [], excludeBroadcaster: true });
+
+    expect(useChatConnectionStore.getState().messages).toEqual([humanMessage]);
+  });
 });
 
 describe("Cheering Emote(Cheermote)", () => {

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -27,7 +27,7 @@ import {
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { mergeCheermotePositions } from "@/lib/twitch/cheermotes";
 import { mergeThirdPartyEmotePositions } from "@/lib/twitch/third-party-emotes";
-import { matchesBotFilter } from "@/lib/bot-filter";
+import { isExcludedFromChat } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
 import { clearAvatarLoadFailures, requestAvatar } from "./avatars";
 import { clearBadges, loadBadges } from "./badges";
@@ -75,7 +75,7 @@ function getClient(): TwitchIrcClient {
           return;
         }
         if (event.type !== "privmsg") return;
-        if (isExcludedByBotFilter(event.message.username)) return;
+        if (isExcludedByBotFilter(event.message.username, useChatConnectionStore.getState().channel)) return;
         // 発言者のアバター(プロフィール画像)を Helix からバッチで取得する(issue #60)。
         // 取得完了までは avatars ストアに URL が無く、アバターなしで表示される
         requestAvatar(event.message.userId);
@@ -138,11 +138,12 @@ export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
   },
 }));
 
-// 除外パターンの変更を、既に表示中の発言にも遡って適用する
+// 除外設定(パターン・配信者除外)の変更を、既に表示中の発言にも遡って適用する
 useBotFilterStore.subscribe((state, prevState) => {
-  if (state.patterns === prevState.patterns) return;
+  if (state.patterns === prevState.patterns && state.excludeBroadcaster === prevState.excludeBroadcaster) return;
   useChatConnectionStore.setState((prev) => {
-    const messages = prev.messages.filter((message) => !matchesBotFilter(message.username, state.patterns));
+    const config = { patterns: state.patterns, excludeBroadcaster: state.excludeBroadcaster };
+    const messages = prev.messages.filter((message) => !isExcludedFromChat(message.username, prev.channel, config));
     return messages.length === prev.messages.length ? prev : { messages };
   });
 });


### PR DESCRIPTION
## Summary

botアカウントだけでなく、配信者アカウント自身でbot的コメント(定型文・アラート等)を流す配信者が多いため、Bot filterダイアログの記述欄の上に「Hide the streamer's own messages」トグルを追加します。オンにすると、接続中チャンネル名(= 配信者のログイン名)と一致するユーザー名の発言をチャット欄から除外します。

## 変更内容

- `src/lib/bot-filter.ts`: 保存形式を `{ patterns, excludeBroadcaster }` のオブジェクトに拡張。旧形式(文字列配列のみ)の保存データは配信者除外オフとして移行する(`settings.ts` の `llmProvider` 移行と同じ規約)。除外判定 `isExcludedFromChat(username, channel, config)` を追加
- `src/store/bot-filter.ts`: `excludeBroadcaster` をストアに追加し、`setBotFilter(config)` でパターンと合わせて永続化。`isExcludedByBotFilter` は接続中チャンネル名を受け取る形に変更
- `src/store/chat-connection.ts`: 受信時の除外判定に接続中チャンネルを渡し、トグル変更時は表示中の発言にも遡って適用
- `src/components/bot-filter-dialog.tsx`: 記述欄の上に Switch を追加(UIは英語)

## Test plan

- [x] `npm test` 764件パス(lib/store/chat-connection/pageの各テストに配信者除外のケースを追加)
- [x] `npm run lint` / `npm run type-check` / `npm run build` すべてクリーン
- [x] CodeRabbitレビュー実行(指摘0件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH