### PR TITLE
接続中はTwitch配信embedと配信者情報を表示するレイアウトに再構成する

### DIFF
--- a/src/app/api/twitch/[...path]/route.test.ts
+++ b/src/app/api/twitch/[...path]/route.test.ts
@@ -114,6 +114,16 @@ describe("GET /api/twitch/[...path]", () => {
     ]);
   });
 
+  it("ゲーム情報(games)も中継できる(ボックスアート取得用)", async () => {
+    fetchMock.mockResolvedValue(helixResponse({ data: [] }));
+
+    const response = await callGet(["games"], "?id=18122");
+
+    expect(response.status).toBe(200);
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe("https://api.twitch.tv/helix/games?id=18122");
+  });
+
   it("許可リストにないエンドポイントは 404 を返し、Helix へ中継しない", async () => {
     const response = await callGet(["moderation", "banned"]);
 

--- a/src/app/api/twitch/[...path]/route.ts
+++ b/src/app/api/twitch/[...path]/route.ts
@@ -31,6 +31,7 @@ const HELIX_BASE_URL = "https://api.twitch.tv/helix";
 const ALLOWED_ENDPOINTS: ReadonlySet<string> = new Set([
   "users",
   "streams",
+  "games",
   "channels",
   "bits/cheermotes",
   "chat/emotes",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,9 +29,10 @@ export default function RootLayout({
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col">
+      {/* 接続中の画面(embed + 3カラム)をビューポート1ページに収めるため、高さを固定して内部スクロールに任せる */}
+      <body className="flex h-dvh flex-col overflow-hidden">
         <SiteHeader />
-        <main className="flex flex-1 flex-col">{children}</main>
+        <main className="flex min-h-0 flex-1 flex-col">{children}</main>
       </body>
     </html>
   );

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -103,6 +103,9 @@ beforeEach(() => {
   mockStopPickupPipeline.mockClear();
   mockWarmUpPickupPipeline.mockClear();
   mockAddManualPickup.mockClear();
+  // 多くのテストは接続中(embed + 3カラム)の画面を検証するため、既定で接続済み(open)にする。
+  // 未接続の接続画面を検証するテストは、テスト内で idle / closed に戻す
+  useChatConnectionStore.setState({ connectionState: "open", channel: "example" });
 });
 
 afterEach(() => {
@@ -241,8 +244,8 @@ describe("Home(3カラム構成)", () => {
 
   it("「接続する」クリック(ユーザー操作)の延長で翻訳・Pick upのセッションをウォームアップする(モデルDLにユーザー操作が必要なため)", async () =>  {
     const user = userEvent.setup();
-    // 実際の IRC 接続(WebSocket)は行わない
-    useChatConnectionStore.setState({ connect: vi.fn() });
+    // 未接続の接続画面から操作する。実際の IRC 接続(WebSocket)は行わない
+    useChatConnectionStore.setState({ connectionState: "idle", channel: null, connect: vi.fn() });
     render(<Home />);
 
     await user.type(screen.getByLabelText("Channel"), "example");
@@ -861,16 +864,10 @@ describe("Home(Prompt API の利用可否)", () => {
 });
 
 describe("Home(設定ダイアログ)", () => {
-  it("接続フォームの横にある設定ボタンから設定ダイアログを開ける(言語設定は含まない)", async () => {
-    const user = userEvent.setup();
+  it("設定ダイアログはヘッダー(SiteHeader)へ移したため、ページ内には設定ボタンを置かない", () => {
     render(<Home />);
 
-    await user.click(screen.getByRole("button", { name: "Settings" }));
-
-    const dialog = await screen.findByRole("dialog", { name: "Settings" });
-    // 言語設定(学ぶ言語・解説言語)は接続フォーム横の常時表示セレクトで行うため、ここには置かない
-    expect(within(dialog).queryByLabelText("Learning language")).not.toBeInTheDocument();
-    expect(within(dialog).queryByLabelText("Explanation language")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Settings" })).not.toBeInTheDocument();
   });
 
   it("マウント時に LocalStorage から言語設定を復元してから、パイプラインを開始する", () => {
@@ -885,21 +882,21 @@ describe("Home(設定ダイアログ)", () => {
 });
 
 describe("Home(言語ペアの設定)", () => {
-  it("接続フォームと同じ並びに、学ぶ言語・解説言語のセレクトを現在の設定値で常時表示する", () => {
-    window.localStorage.setItem("chat-sensei:settings", JSON.stringify({ learningLang: "es", explainLang: "en" }));
+  it("言語ペアのセレクトはヘッダー(SiteHeader)へ移したため、ページ内には置かない", () => {
     render(<Home />);
 
-    // ダイアログを開かなくてもファーストビューで言語ペアが見える
-    expect(screen.getByRole("combobox", { name: "Learning language" })).toHaveValue("es");
-    expect(screen.getByRole("combobox", { name: "Explanation language" })).toHaveValue("en");
+    expect(screen.queryByRole("combobox", { name: "Learning language" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox", { name: "Explanation language" })).not.toBeInTheDocument();
   });
 
-  it("学ぶ言語を変更すると、翻訳・Pick up のパイプラインを停止して新しい設定で開始し直す", async () => {
-    const user = userEvent.setup();
+  it("学ぶ言語を変更すると、翻訳・Pick up のパイプラインを停止して新しい設定で開始し直す", () => {
     render(<Home />);
     expect(mockStartTranslationPipeline).toHaveBeenCalledTimes(1);
 
-    await user.selectOptions(screen.getByRole("combobox", { name: "Learning language" }), "de");
+    // 言語ペアのセレクトはヘッダーへ移したため、設定変更はストア経由で注入する
+    act(() => {
+      useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, learningLang: "de" });
+    });
 
     expect(mockStopPipeline).toHaveBeenCalledTimes(1);
     expect(mockStopPickupPipeline).toHaveBeenCalledTimes(1);
@@ -907,26 +904,17 @@ describe("Home(言語ペアの設定)", () => {
     expect(mockStartPickupPipeline).toHaveBeenCalledTimes(2);
   });
 
-  it("解説言語を変更すると、翻訳・Pick up のパイプラインを停止して新しい設定で開始し直す", async () => {
-    const user = userEvent.setup();
+  it("解説言語を変更すると、翻訳・Pick up のパイプラインを停止して新しい設定で開始し直す", () => {
     render(<Home />);
 
-    await user.selectOptions(screen.getByRole("combobox", { name: "Explanation language" }), "fr");
+    act(() => {
+      useSettingsStore.getState().setSettings({ ...DEFAULT_SETTINGS, explainLang: "fr" });
+    });
 
     expect(mockStopPipeline).toHaveBeenCalledTimes(1);
     expect(mockStopPickupPipeline).toHaveBeenCalledTimes(1);
     expect(mockStartTranslationPipeline).toHaveBeenCalledTimes(2);
     expect(mockStartPickupPipeline).toHaveBeenCalledTimes(2);
-  });
-
-  it("学ぶ言語に解説言語と同じ言語を選ぶと両者を入れ替えて保存し、パイプラインを再起動する", async () => {
-    const user = userEvent.setup();
-    render(<Home />);
-
-    await user.selectOptions(screen.getByRole("combobox", { name: "Learning language" }), "ja");
-
-    expect(useSettingsStore.getState().settings).toEqual({ ...DEFAULT_SETTINGS, learningLang: "ja", explainLang: "en" });
-    expect(mockStartTranslationPipeline).toHaveBeenCalledTimes(2);
   });
 
   it("列見出しには言語設定のダイアログを置かない(接続フォーム横のセレクトに一本化)", () => {
@@ -1052,5 +1040,66 @@ describe("Home(手動Pick up。issue #72)", () => {
     await user.click(screen.getByRole("button", { name: "Pick up" }));
 
     expect(mockAddManualPickup).toHaveBeenCalledWith("msg-1", "no re", "gg no re chat");
+  });
+});
+
+describe("Home(未接続の接続画面)", () => {
+  beforeEach(() => {
+    useChatConnectionStore.setState({ connectionState: "idle", channel: null });
+  });
+
+  it("チャンネル入力と Connect ボタンの接続画面を表示し、3カラムと配信embedは表示しない", () => {
+    render(<Home />);
+
+    expect(screen.getByLabelText("Channel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Raw IRC" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Translation" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Pick up" })).not.toBeInTheDocument();
+    expect(screen.queryByTitle(/Twitch player/)).not.toBeInTheDocument();
+  });
+
+  it("接続状態(Status)を表示する", () => {
+    render(<Home />);
+
+    expect(screen.getByText("Status:")).toBeInTheDocument();
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+
+  it("切断(closed)後も接続画面に戻る", () => {
+    useChatConnectionStore.setState({ connectionState: "closed" });
+
+    render(<Home />);
+
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    expect(screen.queryByRole("region", { name: "Raw IRC" })).not.toBeInTheDocument();
+  });
+});
+
+describe("Home(接続中の配信embedと配信者情報)", () => {
+  it("接続中は接続中チャンネルの配信embed(Twitchプレイヤーのiframe)を表示する", () => {
+    render(<Home />);
+
+    expect(screen.getByTitle("Twitch player: example")).toBeInTheDocument();
+  });
+
+  it("接続中は配信者情報パネル(Stream info)を表示し、チャンネル入力・Connect ボタンは表示しない", () => {
+    render(<Home />);
+
+    expect(screen.getByRole("complementary", { name: "Stream info" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Channel")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
+  });
+
+  it("配信者情報パネルの Disconnect ボタンから切断できる", async () => {
+    const user = userEvent.setup();
+    const disconnectMock = vi.fn();
+    useChatConnectionStore.setState({ disconnect: disconnectMock });
+
+    render(<Home />);
+
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,11 @@
 /**
- * ホームページ(/) = 3カラムのチャット閲覧画面。
+ * ホームページ(/)。接続状態で画面が切り替わる。
+ *
+ * - 未接続(idle / closed): 画面中央にチャンネル入力と Connect ボタンの接続画面を表示する
+ * - 接続中(connecting / open / reconnecting): 上半分に配信embed(TwitchEmbedPlayer)と
+ *   配信者情報パネル(StreamInfoPanel)、下半分に3カラムのチャット閲覧領域を表示する。
+ *   全体がビューポート1ページに収まり(レイアウト側で高さを固定)、3カラム領域は
+ *   発言数に関わらず最初から下半分の全域を占める(スクロールは3カラム領域の内部で行う)
  *
  * Twitch チャンネル名を入力して匿名接続し、流れてくる発言を3列で表示する。
  *
@@ -17,9 +23,8 @@
  * 生IRC列の見出しには、新着発言に合わせてスクロール領域を最下部へ送り続ける追従トグル(FollowToggle。
  * 初期状態はオンで、利用者が上へスクロールして最下部から離れると自動でオフになる)と、
  * bot除外設定(BotFilterDialog)を開くアイコンを置く。
- * 言語ペア(学ぶ言語 / 解説言語)は接続フォームと同じ並びに常時表示するセレクト
- * (LanguagePairSelect)で切り替える。ファーストビューで「どのチャンネルに接続して、
- * 何の言語をどの言語で学んでいるか」が見えるようにするため、ダイアログではなくインラインに置く。除外パターンは
+ * 言語ペア(学ぶ言語 / 解説言語)のセレクトと設定ダイアログは、接続前後のどちらの画面でも
+ * 触れるようヘッダー(SiteHeader)に常時表示する(このページには置かない)。除外パターンは
  * bot-filter ストアが LocalStorage から復元し、chat-connection ストアが受信時に適用する。
  * 接続状態・受信済み発言はモジュールスコープのストア(chat-connection.ts)が、
  * 翻訳結果は translations ストアが、抽出結果は pickups ストアが保持し、
@@ -29,7 +34,6 @@
  * Pick up列の各語句はユーザーが削除でき、
  * 削除した語句は hidden-pickups ストアが保持して表示時に除外する(issue #71)。Prompt API の利用可否は両列で共通の
  * prompt-api ストアを参照し、利用不可の理由は翻訳列・Pick up列それぞれの見出し下に表示する。
- * 接続フォームの横には設定ダイアログ(SettingsDialog。環境診断と設定の初期化)を開くアイコンを置く。
  * 言語設定は settings ストアが LocalStorage から復元し、パイプラインは復元後に開始する。言語設定が変わると
  * 両パイプラインを停止して新しい設定で開始し直す(生成済みの翻訳・Pick up は破棄され、表示中の発言は再生成される。
  * ただし削除した語句の非表示集合は破棄されないため、再生成後も削除は維持される)。
@@ -43,8 +47,8 @@ import { ChevronsDownIcon, EyeIcon, EyeOffIcon, XIcon } from "lucide-react";
 import { BotFilterDialog } from "@/components/bot-filter-dialog";
 import { ManualPickupOverlay, MESSAGE_TEXT_ATTRIBUTE, RAW_IRC_COLUMN_NAME } from "@/components/manual-pickup";
 import { ChannelAutocompleteInput } from "@/components/channel-autocomplete";
-import { LanguagePairSelect } from "@/components/language-pair-select";
-import { SettingsDialog } from "@/components/settings-dialog";
+import { CONNECTION_STATE_LABEL, StreamInfoPanel } from "@/components/stream-info-panel";
+import { TwitchEmbedPlayer } from "@/components/twitch-embed-player";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -70,14 +74,6 @@ import {
   warmUpTranslationPipeline,
   type TranslationDone,
 } from "@/store/translations";
-
-const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
-  idle: "Idle",
-  connecting: "Connecting...",
-  open: "Connected",
-  reconnecting: "Reconnecting...",
-  closed: "Disconnected",
-};
 
 /** 翻訳列・Pick up 列の行に表示する状態文言。列ごとに動詞が異なるため文言一式で受け取る */
 interface PipelineCellLabels {
@@ -117,8 +113,8 @@ export default function Home() {
   const [channelInput, setChannelInput] = useState("");
   const connectionState = useChatConnectionStore((state) => state.connectionState);
   const messages = useChatConnectionStore((state) => state.messages);
+  const channel = useChatConnectionStore((state) => state.channel);
   const connect = useChatConnectionStore((state) => state.connect);
-  const disconnect = useChatConnectionStore((state) => state.disconnect);
 
   // 翻訳列・Pick up列のぼかし。初期状態はどちらも見える(自力で読みたいときに利用者がぼかす)
   const [translationBlurred, setTranslationBlurred] = useState(false);
@@ -216,43 +212,50 @@ export default function Home() {
   }, []);
 
   return (
-    <div className="flex w-full flex-1 flex-col gap-4 p-6">
-      <div className="flex flex-wrap items-end gap-4">
-        <div className="flex flex-col gap-1.5">
-          <Label htmlFor="channel-input">Channel</Label>
-          <div className="flex items-center gap-2">
-            <ChannelAutocompleteInput
-              id="channel-input"
-              placeholder="e.g. zackrawrr"
-              value={channelInput}
-              onValueChange={setChannelInput}
-              disabled={connected}
-            />
-            {connected ? (
-              <Button onClick={disconnect} variant="outline">
-                Disconnect
-              </Button>
-            ) : (
+    <div className="flex min-h-0 w-full flex-1 flex-col gap-4 p-4">
+      {!connected ? (
+        // 未接続: 画面中央の接続画面(3カラム・配信embedは表示しない)
+        <div className="flex flex-1 items-center justify-center">
+          <div className="flex w-full max-w-sm flex-col gap-1.5">
+            <Label htmlFor="channel-input">Channel</Label>
+            <div className="flex items-center gap-2">
+              <ChannelAutocompleteInput
+                id="channel-input"
+                placeholder="e.g. zackrawrr"
+                value={channelInput}
+                onValueChange={setChannelInput}
+              />
               <Button onClick={handleConnect} disabled={channelInput.trim().length === 0}>
                 Connect
               </Button>
-            )}
-            <SettingsDialog />
+            </div>
+            <p className="text-xs text-muted-foreground" role="status">
+              Status: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
+            </p>
           </div>
-          <p className="text-xs text-muted-foreground" role="status">
-            Status: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
-          </p>
         </div>
-        {/* ファーストビューで言語ペアが見えるよう、接続フォームと同じ並びに常時表示する */}
-        <LanguagePairSelect />
-      </div>
+      ) : (
+        <>
+          {/* 上半分: 配信embed + 配信者情報パネル */}
+          <div className="flex min-h-0 flex-1 gap-4">
+            {channel !== null && (
+              // iframe(TwitchEmbedPlayer)は幅基準(aspect-video w-full)のため、
+              // 高さ基準のラッパーで「上半分の高さいっぱいの16:9」に切り出す
+              <div className="aspect-video h-full min-w-0">
+                <TwitchEmbedPlayer channel={channel} />
+              </div>
+            )}
+            <StreamInfoPanel />
+          </div>
 
-      <ScrollArea className="h-[70vh]" viewportRef={scrollViewportRef}>
-        <div
-          className="grid grid-cols-3 gap-4"
-          // 見出し1行 + 発言数ぶんの行。各列は subgrid でこの行トラックを共有する
-          style={{ gridTemplateRows: `auto repeat(${messages.length}, auto)` }}
-        >
+          {/* 下半分: 3カラムのチャット閲覧領域(発言数に関わらず最初から全域を占め、内部でスクロールする) */}
+          <ScrollArea className="min-h-0 flex-1" viewportRef={scrollViewportRef}>
+            <div
+              className="grid min-h-full grid-cols-3 gap-4"
+              // 見出し1行 + 発言数ぶんの行 + 余白吸収の1fr行(発言が少なくても列が下半分の全域に伸びる)。
+              // 各列は subgrid でこの行トラックを共有する
+              style={{ gridTemplateRows: `auto repeat(${messages.length}, auto) 1fr` }}
+            >
           <Column
             title="Raw IRC"
             blurred={false}
@@ -314,8 +317,10 @@ export default function Home() {
               ))}
             </div>
           </Column>
-        </div>
-      </ScrollArea>
+            </div>
+          </ScrollArea>
+        </>
+      )}
       <ManualPickupOverlay onPickup={handleManualPickup} />
       <PickupRemovalAnnouncement />
     </div>

--- a/src/components/language-pair-select.test.tsx
+++ b/src/components/language-pair-select.test.tsx
@@ -36,6 +36,17 @@ describe("LanguagePairSelect", () => {
     expect(screen.getByRole("combobox", { name: "Explanation language" })).toHaveValue("en");
   });
 
+  it("compact 指定時はラベルを視覚的に隠す(sr-only)が、アクセシブル名としては保持する(ヘッダー配置用)", () => {
+    hydrateSettingsStore();
+
+    render(<LanguagePairSelect compact />);
+
+    const learningSelect = screen.getByRole("combobox", { name: "Learning language" });
+    expect(learningSelect).toBeInTheDocument();
+    expect(screen.getByText("Learning language")).toHaveClass("sr-only");
+    expect(screen.getByText("Explanation language")).toHaveClass("sr-only");
+  });
+
   it("ストアが未復元の間はセレクトを無効化する(復元前にデフォルト値で保存してしまう事故を防ぐ)", () => {
     render(<LanguagePairSelect />);
 

--- a/src/components/language-pair-select.tsx
+++ b/src/components/language-pair-select.tsx
@@ -27,8 +27,12 @@ const languageSchema = z.enum(SUPPORTED_LANGUAGES);
 
 const SELECT_CLASS_NAME = "h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30";
 
-/** 学ぶ言語・解説言語の2つのセレクト。接続フォームと同じ並びに置く想定 */
-export function LanguagePairSelect() {
+/**
+ * 学ぶ言語・解説言語の2つのセレクト。
+ * `compact` を指定するとラベルを視覚的に隠し(sr-only)、ヘッダーなど 高さの限られた場所に置ける
+ * (アクセシブル名としてのラベルは保持する)。
+ */
+export function LanguagePairSelect({ compact = false }: { compact?: boolean } = {}) {
   const settings = useSettingsStore((state) => state.settings);
   const hydrated = useSettingsStore((state) => state.hydrated);
   const setSettings = useSettingsStore((state) => state.setSettings);
@@ -52,7 +56,9 @@ export function LanguagePairSelect() {
   return (
     <div className="flex items-end gap-3">
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor={LEARNING_SELECT_ID}>Learning language</Label>
+        <Label htmlFor={LEARNING_SELECT_ID} className={compact ? "sr-only" : undefined}>
+          Learning language
+        </Label>
         <LanguageSelect
           id={LEARNING_SELECT_ID}
           value={settings.learningLang}
@@ -61,7 +67,9 @@ export function LanguagePairSelect() {
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor={EXPLANATION_SELECT_ID}>Explanation language</Label>
+        <Label htmlFor={EXPLANATION_SELECT_ID} className={compact ? "sr-only" : undefined}>
+          Explanation language
+        </Label>
         <LanguageSelect
           id={EXPLANATION_SELECT_ID}
           value={settings.explainLang}

--- a/src/components/site-header.test.tsx
+++ b/src/components/site-header.test.tsx
@@ -1,11 +1,24 @@
 /**
  * src/components/site-header.tsx のテスト。
  *
- * 全ページ共通ヘッダーが、アプリ名をホームへのリンクとして描画することを検証する。
+ * 全ページ共通ヘッダーが、アプリ名をホームへのリンクとして描画し、
+ * 右側に言語ペアのセレクト(コンパクト表示)と設定ダイアログのトリガーを
+ * 表示することを検証する(接続前後のどちらでも設定に触れるようにするため)。
+ * 設定ダイアログの環境診断(`runBrowserDiagnosis`)はブラウザ API に触れるためモックする。
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { resetSettingsStoreForTests } from "@/store/settings";
 import { SiteHeader } from "./site-header";
+
+vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
+  runBrowserDiagnosis: () => new Promise(() => {}),
+}));
+
+afterEach(() => {
+  resetSettingsStoreForTests();
+  window.localStorage.clear();
+});
 
 describe("SiteHeader", () => {
   it("アプリ名(chat-sensei)をホームへのリンクとして表示する", () => {
@@ -13,5 +26,18 @@ describe("SiteHeader", () => {
 
     const homeLink = screen.getByRole("link", { name: "chat-sensei" });
     expect(homeLink).toHaveAttribute("href", "/");
+  });
+
+  it("ヘッダー右側に言語ペアのセレクト(学ぶ言語 / 解説言語)を表示する", () => {
+    render(<SiteHeader />);
+
+    expect(screen.getByRole("combobox", { name: "Learning language" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Explanation language" })).toBeInTheDocument();
+  });
+
+  it("ヘッダー右側に設定ダイアログを開くボタンを表示する", () => {
+    render(<SiteHeader />);
+
+    expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
   });
 });

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,18 +1,26 @@
 /**
  * 全ページ共通のヘッダー。
  *
- * 現時点ではホーム(/)のみが存在するため、アプリ名のリンクだけを表示する。
- * 画面が増えた際にここへナビゲーションを追加する。
+ * 左側にアプリ名のリンク、右側に言語ペアのセレクト(コンパクト表示)と
+ * 設定ダイアログのトリガーを表示する。言語設定・アプリ設定は接続前後の
+ * どちらの画面(接続フォーム / embed + 3カラム)でも変更したくなるため、
+ * 画面の状態に依存しないヘッダーに常時置く。
  */
 import Link from "next/link";
+import { LanguagePairSelect } from "@/components/language-pair-select";
+import { SettingsDialog } from "@/components/settings-dialog";
 
 export function SiteHeader() {
   return (
     <header className="border-b bg-background">
-      <nav className="mx-auto flex w-full items-center justify-between px-6 py-3">
+      <nav className="mx-auto flex w-full items-center justify-between gap-4 px-6 py-2">
         <Link href="/" className="font-heading text-lg font-semibold">
           chat-sensei
         </Link>
+        <div className="flex items-center gap-2">
+          <LanguagePairSelect compact />
+          <SettingsDialog />
+        </div>
       </nav>
     </header>
   );

--- a/src/components/stream-info-panel.test.tsx
+++ b/src/components/stream-info-panel.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * src/components/stream-info-panel.tsx(接続中の配信者情報パネル)のテスト。
+ *
+ * 接続中の画面上半分で配信embedの横に置くパネルが、次を表示することを検証する。
+ *
+ * - 配信者の表示名(配信情報が無い間は接続中のチャンネル名で代用)
+ * - 配信者のアバター(avatars ストアに取得済みの場合のみ)と、アバター取得の要求
+ * - 配信タイトル・カテゴリ(ボックスアート画像はゲームIDから取得できた場合のみ)
+ * - 同時視聴者数(取得できた場合のみ)
+ * - 接続状態と Disconnect ボタン
+ *
+ * 配信情報・アバターは各ストアの state を直接書き換えて注入し、
+ * ボックスアート取得(`fetchGameBoxArtUrl`)とアバター取得要求(`requestAvatar`)はモックする。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { StreamInfo } from "@/lib/twitch/stream-info";
+import { resetAvatarsForTests, useAvatarStore } from "@/store/avatars";
+import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
+import { resetStreamInfoForTests, useStreamInfoStore } from "@/store/stream-info";
+
+const mockFetchGameBoxArtUrl = vi.fn<(gameId: string) => Promise<string | null>>();
+
+vi.mock("@/lib/twitch/game-box-art", () => ({
+  fetchGameBoxArtUrl: (gameId: string) => mockFetchGameBoxArtUrl(gameId),
+}));
+
+const mockRequestAvatar = vi.fn();
+
+vi.mock("@/store/avatars", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/avatars")>()),
+  requestAvatar: (...args: unknown[]) => mockRequestAvatar(...args),
+}));
+
+import { StreamInfoPanel } from "./stream-info-panel";
+
+const サンプル配信情報: StreamInfo = {
+  title: "Mythic raid progression! !drops",
+  category: "World of Warcraft",
+  broadcasterId: "552120296",
+  broadcasterLogin: "zackrawrr",
+  broadcasterName: "ZackRawrr",
+  gameId: "18122",
+  viewerCount: 4321,
+};
+
+beforeEach(() => {
+  mockFetchGameBoxArtUrl.mockResolvedValue(null);
+  useChatConnectionStore.setState({ connectionState: "open", channel: "zackrawrr" });
+});
+
+afterEach(() => {
+  mockFetchGameBoxArtUrl.mockReset();
+  mockRequestAvatar.mockClear();
+  resetChatConnectionStoreForTests();
+  resetStreamInfoForTests();
+  resetAvatarsForTests();
+});
+
+describe("StreamInfoPanel(配信情報あり)", () => {
+  beforeEach(() => {
+    useStreamInfoStore.setState({ streamInfo: サンプル配信情報 });
+  });
+
+  it("配信者の表示名・配信タイトル・カテゴリ名を表示する", () => {
+    render(<StreamInfoPanel />);
+
+    expect(screen.getByText("ZackRawrr")).toBeInTheDocument();
+    expect(screen.getByText("Mythic raid progression! !drops")).toBeInTheDocument();
+    expect(screen.getByText("World of Warcraft")).toBeInTheDocument();
+  });
+
+  it("同時視聴者数を桁区切りで表示する", () => {
+    render(<StreamInfoPanel />);
+
+    expect(screen.getByText("4,321 viewers")).toBeInTheDocument();
+  });
+
+  it("配信者のアバター取得を要求し、取得済みならアバター画像を表示する", () => {
+    useAvatarStore.setState({ avatars: { "552120296": "https://example.com/avatar.png" } });
+
+    const { container } = render(<StreamInfoPanel />);
+
+    expect(mockRequestAvatar).toHaveBeenCalledWith("552120296");
+    expect(container.querySelector('img[src="https://example.com/avatar.png"]')).not.toBeNull();
+  });
+
+  it("アバター未取得の間は、アバター画像なしで表示する", () => {
+    const { container } = render(<StreamInfoPanel />);
+
+    expect(container.querySelector('img[src="https://example.com/avatar.png"]')).toBeNull();
+  });
+
+  it("ゲームIDからボックスアートを取得できた場合、カテゴリの画像として表示する", async () => {
+    mockFetchGameBoxArtUrl.mockResolvedValue("https://static-cdn.jtvnw.net/ttv-boxart/18122-285x380.jpg");
+
+    render(<StreamInfoPanel />);
+
+    expect(mockFetchGameBoxArtUrl).toHaveBeenCalledWith("18122");
+    expect(await screen.findByRole("img", { name: "World of Warcraft" })).toHaveAttribute(
+      "src",
+      "https://static-cdn.jtvnw.net/ttv-boxart/18122-285x380.jpg",
+    );
+  });
+
+  it("ボックスアートを取得できない場合、カテゴリ名のテキストのみ表示する", async () => {
+    render(<StreamInfoPanel />);
+
+    // fetchGameBoxArtUrl の解決を待ってから、画像が無いことを確認する
+    await act(async () => {});
+    expect(screen.queryByRole("img", { name: "World of Warcraft" })).toBeNull();
+    expect(screen.getByText("World of Warcraft")).toBeInTheDocument();
+  });
+});
+
+describe("StreamInfoPanel(配信情報なし = オフライン・Helix 利用不可)", () => {
+  it("接続中のチャンネル名を表示し、タイトル・視聴者数は表示しない", () => {
+    render(<StreamInfoPanel />);
+
+    expect(screen.getByText("zackrawrr")).toBeInTheDocument();
+    expect(screen.queryByText(/viewers/)).toBeNull();
+  });
+
+  it("ゲームIDが無いためボックスアートの取得を要求しない", () => {
+    render(<StreamInfoPanel />);
+
+    expect(mockFetchGameBoxArtUrl).not.toHaveBeenCalled();
+  });
+});
+
+describe("StreamInfoPanel(接続状態と切断)", () => {
+  it("接続状態のラベルを表示する", () => {
+    useChatConnectionStore.setState({ connectionState: "reconnecting" });
+
+    render(<StreamInfoPanel />);
+
+    expect(screen.getByText(/Reconnecting/)).toBeInTheDocument();
+  });
+
+  it("Disconnect ボタンを押すと切断処理を呼ぶ", async () => {
+    const user = userEvent.setup();
+    const disconnectMock = vi.fn();
+    useChatConnectionStore.setState({ disconnect: disconnectMock });
+
+    render(<StreamInfoPanel />);
+
+    await user.click(screen.getByRole("button", { name: "Disconnect" }));
+
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/stream-info-panel.tsx
+++ b/src/components/stream-info-panel.tsx
@@ -1,0 +1,114 @@
+/**
+ * 接続中の画面上半分で配信embed(TwitchEmbedPlayer)の横に置く、配信者情報パネル。
+ *
+ * - 配信者のアバター(avatars ストア。未取得の間はアバターなし)と表示名
+ *   (配信情報が無い間 = オフライン・Helix 利用不可・読み込み中は、接続中のチャンネル名で代用)
+ * - 配信タイトル
+ * - 配信カテゴリ(ゲーム名)。ゲームIDからボックスアート画像を取得できた場合は画像も表示する
+ * - 同時視聴者数(Helix から取得できた場合のみ)
+ * - 接続状態のラベルと Disconnect ボタン
+ *
+ * 配信情報は stream-info ストア(接続時に読み込み済み)を購読して表示するだけで、
+ * このパネル自身は Helix を呼ばない(例外はボックスアート。ゲームIDが判明したときに
+ * `fetchGameBoxArtUrl` で取得し、取得できなければカテゴリ名のテキストのみで表示する)。
+ * 配信者のアバターは avatars ストアの共通バッチ取得(`requestAvatar`)へ要求する。
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { ConnectionState } from "@/lib/twitch/irc-client";
+import { fetchGameBoxArtUrl } from "@/lib/twitch/game-box-art";
+import { requestAvatar, useAvatarStore } from "@/store/avatars";
+import { useChatConnectionStore } from "@/store/chat-connection";
+import { useStreamInfoStore } from "@/store/stream-info";
+
+/** 接続状態の表示ラベル。接続フォーム(page.tsx)とこのパネルで共用する */
+export const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
+  idle: "Idle",
+  connecting: "Connecting...",
+  open: "Connected",
+  reconnecting: "Reconnecting...",
+  closed: "Disconnected",
+};
+
+/** 同時視聴者数の桁区切り表示(UI は英語のためロケールも en-US 固定) */
+const VIEWER_COUNT_FORMAT = new Intl.NumberFormat("en-US");
+
+export function StreamInfoPanel() {
+  const channel = useChatConnectionStore((state) => state.channel);
+  const connectionState = useChatConnectionStore((state) => state.connectionState);
+  const disconnect = useChatConnectionStore((state) => state.disconnect);
+  const streamInfo = useStreamInfoStore((state) => state.streamInfo);
+
+  // 配信者のアバター。発言者アバターと同じ共通バッチ(avatars ストア)へ取得を要求する
+  const broadcasterId = streamInfo?.broadcasterId ?? "";
+  const avatarUrl = useAvatarStore((state) => (broadcasterId === "" ? undefined : state.avatars[broadcasterId]));
+  useEffect(() => {
+    if (broadcasterId !== "") requestAvatar(broadcasterId);
+  }, [broadcasterId]);
+
+  // カテゴリのボックスアート。取得できない場合はカテゴリ名のテキストのみで表示する(意図したフォールバック)。
+  // 取得元の gameId と対にして保持し、チャンネル切り替えで gameId が変わった直後に
+  // 前のゲームのボックスアートを表示しない(描画時に gameId の一致で選別する)
+  const gameId = streamInfo?.gameId ?? "";
+  const [boxArt, setBoxArt] = useState<{ gameId: string; url: string | null } | null>(null);
+  useEffect(() => {
+    if (gameId === "") return;
+    // アンマウント・gameId 変更後に遅れて届いた結果で state を更新しない
+    let cancelled = false;
+    void fetchGameBoxArtUrl(gameId).then((url) => {
+      if (!cancelled) setBoxArt({ gameId, url });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [gameId]);
+  const boxArtUrl = boxArt !== null && boxArt.gameId === gameId ? boxArt.url : null;
+
+  // 配信情報が無い間(オフライン・Helix 利用不可・読み込み中)は接続中のチャンネル名で代用する
+  const displayName =
+    streamInfo !== null && streamInfo.broadcasterName !== "" ? streamInfo.broadcasterName : (channel ?? "");
+
+  return (
+    <aside aria-label="Stream info" className="flex min-w-0 flex-1 flex-col gap-3 rounded-xl border bg-card p-4">
+      <div className="flex items-center gap-3">
+        {avatarUrl !== undefined && (
+          // eslint-disable-next-line @next/next/no-img-element -- Twitch CDNの外部画像のためnext/imageのドメイン許可設定は不要な単純imgで表示する
+          <img
+            src={avatarUrl}
+            // 直後に表示名がテキストで続くため、アバターは装飾画像として扱う
+            alt=""
+            className="size-10 rounded-full"
+          />
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-semibold">{displayName}</p>
+          <p className="text-xs text-muted-foreground" role="status">
+            {CONNECTION_STATE_LABEL[connectionState]}
+          </p>
+        </div>
+        <Button onClick={disconnect} variant="outline" size="sm">
+          Disconnect
+        </Button>
+      </div>
+      {streamInfo !== null && (
+        <div className="flex min-h-0 flex-1 gap-3">
+          {boxArtUrl !== null && (
+            // eslint-disable-next-line @next/next/no-img-element -- Twitch CDNの外部画像のためnext/imageのドメイン許可設定は不要な単純imgで表示する
+            <img src={boxArtUrl} alt={streamInfo.category} className="h-24 w-18 rounded-md object-cover" />
+          )}
+          <div className="min-w-0 space-y-1">
+            <p className="text-sm break-words">{streamInfo.title}</p>
+            {streamInfo.category !== "" && <p className="text-sm text-muted-foreground">{streamInfo.category}</p>}
+            {streamInfo.viewerCount !== null && (
+              <p className="text-sm text-muted-foreground">
+                {VIEWER_COUNT_FORMAT.format(streamInfo.viewerCount)} viewers
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </aside>
+  );
+}

--- a/src/lib/twitch/game-box-art.test.ts
+++ b/src/lib/twitch/game-box-art.test.ts
@@ -1,0 +1,80 @@
+/**
+ * src/lib/twitch/game-box-art.ts(配信カテゴリのボックスアート URL 取得)のテスト。
+ *
+ * Helix の Get Games API(`GET /games?id=`)のレスポンスからボックスアート URL の
+ * テンプレート(`{width}x{height}` プレースホルダ付き)を解析し、表示サイズに解決する
+ * 処理と、Next.js プロキシ(`/api/twitch/games`)経由の取得を検証する。
+ * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import { fetchGameBoxArtUrl, parseGameBoxArtUrl } from "./game-box-art";
+
+/** Helix Get Games API のレスポンス(検証に使う部分のみ) */
+function createHelixGamesJson(overrides: Record<string, unknown> = {}): unknown {
+  return {
+    data: [
+      {
+        id: "18122",
+        name: "World of Warcraft",
+        box_art_url: "https://static-cdn.jtvnw.net/ttv-boxart/18122-{width}x{height}.jpg",
+        ...overrides,
+      },
+    ],
+  };
+}
+
+describe("parseGameBoxArtUrl", () => {
+  it("box_art_url の {width}x{height} プレースホルダを実サイズに解決した URL を返す", () => {
+    expect(parseGameBoxArtUrl(createHelixGamesJson())).toBe(
+      "https://static-cdn.jtvnw.net/ttv-boxart/18122-285x380.jpg",
+    );
+  });
+
+  it("data が空(未知のゲームID)の場合は null を返す", () => {
+    expect(parseGameBoxArtUrl({ data: [] })).toBeNull();
+  });
+
+  it("box_art_url が無い・型が違う・空文字の場合は null を返す", () => {
+    expect(parseGameBoxArtUrl(createHelixGamesJson({ box_art_url: undefined }))).toBeNull();
+    expect(parseGameBoxArtUrl(createHelixGamesJson({ box_art_url: 123 }))).toBeNull();
+    expect(parseGameBoxArtUrl(createHelixGamesJson({ box_art_url: "" }))).toBeNull();
+  });
+
+  it("形式が想定と異なるレスポンス(data が配列でない等)は null を返す", () => {
+    expect(parseGameBoxArtUrl(null)).toBeNull();
+    expect(parseGameBoxArtUrl({})).toBeNull();
+    expect(parseGameBoxArtUrl({ data: "not-an-array" })).toBeNull();
+  });
+});
+
+describe("fetchGameBoxArtUrl", () => {
+  it("Helix プロキシに id 付きで GET し、解決したボックスアート URL を返す", async () => {
+    const fetchFn = vi.fn(async () => Response.json(createHelixGamesJson()));
+
+    const url = await fetchGameBoxArtUrl("18122", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/games?id=18122", { signal: undefined });
+    expect(url).toBe("https://static-cdn.jtvnw.net/ttv-boxart/18122-285x380.jpg");
+  });
+
+  it("ゲームID が空文字の場合はリクエストせず null を返す(カテゴリ未設定の配信)", async () => {
+    const fetchFn = vi.fn();
+
+    expect(await fetchGameBoxArtUrl("", fetchFn)).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("HTTP エラー(503: Helix 未設定など)の場合は null を返す(ボックスアートなしで動作を続けるため)", async () => {
+    const fetchFn = vi.fn(async () => Response.json({ error: "Helix API が設定されていません" }, { status: 503 }));
+
+    expect(await fetchGameBoxArtUrl("18122", fetchFn)).toBeNull();
+  });
+
+  it("ネットワークエラーの場合は null を返す", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    expect(await fetchGameBoxArtUrl("18122", fetchFn)).toBeNull();
+  });
+});

--- a/src/lib/twitch/game-box-art.ts
+++ b/src/lib/twitch/game-box-art.ts
@@ -1,0 +1,57 @@
+/**
+ * 配信カテゴリ(ゲーム)のボックスアート URL の取得。
+ *
+ * Helix の Get Games API(`GET /games?id=`)を Next.js プロキシ(`/api/twitch/`)経由で呼び、
+ * 配信情報(`stream-info.ts`)の `gameId` からボックスアート画像の URL を取得する。
+ * 接続中の配信者情報パネル(`src/components/stream-info-panel.tsx`)でカテゴリ画像として表示する。
+ *
+ * Helix が返す `box_art_url` は `{width}x{height}` プレースホルダ付きのテンプレートのため、
+ * Twitch 標準のボックスアートサイズ(285x380)に解決してから返す。
+ *
+ * 取得できない場合は null を返し、ボックスアートなし(カテゴリ名のテキストのみ)で動作を続ける:
+ * - ゲームID が空文字(カテゴリ未設定の配信)
+ * - 未知のゲームID(`data` が空)・レスポンス形式が想定と異なる
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害・ネットワークエラー
+ */
+
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
+/** ボックスアートの取得サイズ。Twitch が標準的に使う 3:4 のサイズ */
+const BOX_ART_WIDTH = 285;
+const BOX_ART_HEIGHT = 380;
+
+/**
+ * Helix の Get Games API レスポンス(`{data: [{box_art_url, ...}]}`)を解析し、
+ * `{width}x{height}` プレースホルダを実サイズに解決したボックスアート URL を返す。
+ * `data` が空(未知のゲームID)・`box_art_url` が無い・型が違う・空文字の場合は null を返す。
+ */
+export function parseGameBoxArtUrl(json: unknown): string | null {
+  const data = extractDataArray(json);
+  if (data === null || data.length === 0) return null;
+
+  const first = data[0];
+  if (typeof first !== "object" || first === null) return null;
+  const boxArtUrl = (first as Record<string, unknown>).box_art_url;
+  if (typeof boxArtUrl !== "string" || boxArtUrl === "") return null;
+
+  return boxArtUrl.replace("{width}", String(BOX_ART_WIDTH)).replace("{height}", String(BOX_ART_HEIGHT));
+}
+
+/**
+ * Helix プロキシ(`/api/twitch/games`)から、指定したゲームID のボックスアート URL を取得する。
+ * 取得できない場合は null を返す(呼び出し側はボックスアートなしで動作を続ける。意図した仕様)。
+ */
+export async function fetchGameBoxArtUrl(
+  gameId: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<string | null> {
+  if (gameId === "") return null;
+
+  const json = await fetchHelixJson("games", {
+    params: new URLSearchParams({ id: gameId }),
+    fetchFn,
+    failureLog: { subject: "カテゴリのボックスアート", fallback: "カテゴリ名のみで表示します" },
+  });
+  if (json === null) return null;
+  return parseGameBoxArtUrl(json);
+}

--- a/src/lib/twitch/stream-info.test.ts
+++ b/src/lib/twitch/stream-info.test.ts
@@ -1,8 +1,8 @@
 /**
- * src/lib/twitch/stream-info.ts(配信タイトル・カテゴリの取得)のテスト。
+ * src/lib/twitch/stream-info.ts(配信タイトル・カテゴリなど配信情報の取得)のテスト。
  *
  * Helix の Get Streams API(`GET /streams?user_login=`)のレスポンスを
- * 配信情報(タイトル・カテゴリ)として解析する処理と、
+ * 配信情報(タイトル・カテゴリ・配信者情報・視聴者数)として解析する処理と、
  * Next.js プロキシ(`/api/twitch/streams`)経由の取得を検証する。
  * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
  */
@@ -14,25 +14,34 @@ function createHelixStreamsJson(overrides: Record<string, unknown> = {}): unknow
   return {
     data: [
       {
+        user_id: "552120296",
         user_login: "zackrawrr",
         user_name: "ZackRawrr",
         type: "live",
         title: "Mythic raid progression! !drops",
+        game_id: "18122",
         game_name: "World of Warcraft",
+        viewer_count: 4321,
         ...overrides,
       },
     ],
   };
 }
 
+/** 全フィールドが取得できたときの期待値 */
+const 期待する配信情報 = {
+  title: "Mythic raid progression! !drops",
+  category: "World of Warcraft",
+  broadcasterId: "552120296",
+  broadcasterLogin: "zackrawrr",
+  broadcasterName: "ZackRawrr",
+  gameId: "18122",
+  viewerCount: 4321,
+};
+
 describe("parseStreamInfo", () => {
-  it("ライブ配信のレスポンスからタイトル・カテゴリ・配信者名(username と DisplayName)を取り出す", () => {
-    expect(parseStreamInfo(createHelixStreamsJson())).toEqual({
-      title: "Mythic raid progression! !drops",
-      category: "World of Warcraft",
-      broadcasterLogin: "zackrawrr",
-      broadcasterName: "ZackRawrr",
-    });
+  it("ライブ配信のレスポンスからタイトル・カテゴリ・配信者情報(ID / username / DisplayName)・ゲームID・視聴者数を取り出す", () => {
+    expect(parseStreamInfo(createHelixStreamsJson())).toEqual(期待する配信情報);
   });
 
   it("data が空(オフライン)の場合は null を返す", () => {
@@ -41,19 +50,33 @@ describe("parseStreamInfo", () => {
 
   it("カテゴリ未設定(game_name が空文字)の場合はカテゴリを空文字として保持する", () => {
     expect(parseStreamInfo(createHelixStreamsJson({ game_name: "" }))).toEqual({
-      title: "Mythic raid progression! !drops",
+      ...期待する配信情報,
       category: "",
-      broadcasterLogin: "zackrawrr",
-      broadcasterName: "ZackRawrr",
     });
   });
 
   it("配信者名のフィールドが無い・型が違う場合は空文字として保持する(タイトル・カテゴリがあれば文脈は成立する)", () => {
-    expect(parseStreamInfo(createHelixStreamsJson({ user_login: undefined, user_name: 123 }))).toEqual({
-      title: "Mythic raid progression! !drops",
-      category: "World of Warcraft",
+    expect(
+      parseStreamInfo(createHelixStreamsJson({ user_id: undefined, user_login: undefined, user_name: 123 })),
+    ).toEqual({
+      ...期待する配信情報,
+      broadcasterId: "",
       broadcasterLogin: "",
       broadcasterName: "",
+    });
+  });
+
+  it("ゲームID が無い・型が違う場合は空文字として保持する(ボックスアートを表示しないだけ)", () => {
+    expect(parseStreamInfo(createHelixStreamsJson({ game_id: 18122 }))).toEqual({
+      ...期待する配信情報,
+      gameId: "",
+    });
+  });
+
+  it("視聴者数が無い・型が違う場合は null として保持する(視聴者数を表示しないだけ)", () => {
+    expect(parseStreamInfo(createHelixStreamsJson({ viewer_count: "many" }))).toEqual({
+      ...期待する配信情報,
+      viewerCount: null,
     });
   });
 
@@ -76,12 +99,7 @@ describe("fetchStreamInfo", () => {
     const info = await fetchStreamInfo("zackrawrr", fetchFn);
 
     expect(fetchFn).toHaveBeenCalledWith("/api/twitch/streams?user_login=zackrawrr", { signal: undefined });
-    expect(info).toEqual({
-      title: "Mythic raid progression! !drops",
-      category: "World of Warcraft",
-      broadcasterLogin: "zackrawrr",
-      broadcasterName: "ZackRawrr",
-    });
+    expect(info).toEqual(期待する配信情報);
   });
 
   it("オフライン(data が空)の場合は null を返す", async () => {

--- a/src/lib/twitch/stream-info.ts
+++ b/src/lib/twitch/stream-info.ts
@@ -22,17 +22,24 @@ export interface StreamInfo {
   title: string;
   /** 配信カテゴリ = ゲーム名(Helix の `game_name`) */
   category: string;
+  /** 配信者の Twitch ユーザー ID(Helix の `user_id`)。アバター取得に使う。取得できない場合は空文字 */
+  broadcasterId: string;
   /** 配信者の username(Helix の `user_login`)。取得できない場合は空文字 */
   broadcasterLogin: string;
   /** 配信者の表示名 = DisplayName(Helix の `user_name`。日本語名など)。取得できない場合は空文字 */
   broadcasterName: string;
+  /** 配信カテゴリのゲーム ID(Helix の `game_id`)。ボックスアート取得に使う。取得できない場合は空文字 */
+  gameId: string;
+  /** 同時視聴者数(Helix の `viewer_count`)。取得できない場合は null(表示しないだけ) */
+  viewerCount: number | null;
 }
 
 /**
- * Helix の Get Streams API レスポンス(`{data: [{title, game_name, user_login, user_name, ...}]}`)を
+ * Helix の Get Streams API レスポンス(`{data: [{title, game_name, user_id, user_login, user_name, game_id, viewer_count, ...}]}`)を
  * 解析して StreamInfo を作る。オフライン(`data` が空)・形式が想定と異なる場合・
  * タイトルとカテゴリの両方が空の場合(文脈として意味が無い)は null を返す。
- * 配信者名(username・DisplayName)は取得できないフィールドだけを空文字として読み飛ばす。
+ * 配信者情報(ID・username・DisplayName)・ゲーム ID は取得できないフィールドだけを空文字として、
+ * 視聴者数は null として読み飛ばす(いずれも表示しないだけで、文脈としては成立する)。
  */
 export function parseStreamInfo(json: unknown): StreamInfo | null {
   const data = extractDataArray(json);
@@ -46,9 +53,12 @@ export function parseStreamInfo(json: unknown): StreamInfo | null {
   const category = typeof record.game_name === "string" ? record.game_name : "";
   if (title === "" && category === "") return null;
 
+  const broadcasterId = typeof record.user_id === "string" ? record.user_id : "";
   const broadcasterLogin = typeof record.user_login === "string" ? record.user_login : "";
   const broadcasterName = typeof record.user_name === "string" ? record.user_name : "";
-  return { title, category, broadcasterLogin, broadcasterName };
+  const gameId = typeof record.game_id === "string" ? record.game_id : "";
+  const viewerCount = typeof record.viewer_count === "number" ? record.viewer_count : null;
+  return { title, category, broadcasterId, broadcasterLogin, broadcasterName, gameId, viewerCount };
 }
 
 /**

--- a/src/store/stream-info.test.ts
+++ b/src/store/stream-info.test.ts
@@ -24,8 +24,11 @@ afterEach(() => {
 const FAKE_STREAM_INFO: StreamInfo = {
   title: "Mythic raid progression! !drops",
   category: "World of Warcraft",
+  broadcasterId: "552120296",
   broadcasterLogin: "zackrawrr",
   broadcasterName: "ZackRawrr",
+  gameId: "18122",
+  viewerCount: 4321,
 };
 
 describe("loadStreamInfo", () => {
@@ -73,8 +76,11 @@ describe("loadStreamInfo", () => {
     resolveFirst({
       title: "古いチャンネルの配信",
       category: "Old Game",
+      broadcasterId: "999",
       broadcasterLogin: "oldchannel",
       broadcasterName: "OldChannel",
+      gameId: "111",
+      viewerCount: 10,
     });
     await firstLoading;
 


### PR DESCRIPTION
## Summary

接続状態に応じて画面を切り替えるレイアウトへ再構成しました。

- **未接続時**: 画面中央にチャンネル入力 + Connect ボタンの接続画面のみを表示します(3カラム・embedは非表示)
- **接続中**: 上半分に配信embed(`TwitchEmbedPlayer`)と配信者情報パネル(`StreamInfoPanel`)、下半分に3カラムのチャット閲覧領域を表示します
- 全体をビューポート1ページに収め(`layout.tsx` を `h-dvh` 固定)、3カラム領域は発言数に関わらず最初から下半分の全域を占めます(グリッド末尾に余白吸収の `1fr` 行を追加)
- 言語ペアのセレクト(ラベル `sr-only` のコンパクト表示)と設定ダイアログをヘッダー右側へ移動しました

## 配信者情報パネル(新規)

- 配信者のアバター(avatars ストアの共通バッチ取得を再利用)・表示名・接続状態・Disconnect ボタン
- 配信タイトル・カテゴリ(Get Games API からボックスアート画像を取得。`game-box-art.ts` 新規、Helix プロキシ許可リストに `games` を追加)・同時視聴者数
- `StreamInfo` に `broadcasterId` / `gameId` / `viewerCount` を追加(パイプライン再起動キーには含めないため、視聴者数の変化で翻訳・Pick up は再起動しません)
- オフライン・Helix 利用不可時はチャンネル名のみのパネルで動作します(embed は Twitch のオフライン画面を表示)

## Test plan

- [x] TDD(RED → GREEN)で実装し、全793テストがパス
- [x] Lint 警告ゼロ・型チェックエラーゼロ・`next build` 成功
- [x] CodeRabbit レビュー実施(指摘0件)
- [x] 実ブラウザで確認: ライブ配信(ironmouse)に接続し、embed 再生・アバター・タイトル・ボックスアート・視聴者数・チャット流入を確認。オフラインチャンネル・未接続画面も確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH