### PR TITLE
feat: 言語ペアのセレクトを「Learning [X] · explained in [Y]」の文章型レイアウトに変更する

### DIFF
--- a/src/components/language-pair-select.test.tsx
+++ b/src/components/language-pair-select.test.tsx
@@ -1,9 +1,9 @@
 /**
  * src/components/language-pair-select.tsx(言語ペアの常時表示セレクト)のテスト。
  *
- * チャンネル接続フォームの横に常時表示する「学ぶ言語」「解説言語」の2つのセレクトを検証する。
- * ファーストビューで「どのチャンネルに接続して、何の言語をどの言語で学んでいるか」が
- * 見えるようにするため、ダイアログではなくインラインのセレクトにしている。
+ * ヘッダーに常時表示する「学ぶ言語」「解説言語」の2つのセレクトを検証する。
+ * 「Learning [学ぶ言語] · explained in [解説言語]」という文章の中にセレクトを埋め込む
+ * 文章型レイアウトで、各セレクトが何を意味するかをラベルなしでも読み取れるようにしている。
  *
  * - 変更は即座に `useSettingsStore.setSettings`(→ LocalStorage)へ保存される
  * - 学ぶ言語と解説言語が同じペアはスキーマで禁止されているため、もう一方と同じ言語を
@@ -36,10 +36,20 @@ describe("LanguagePairSelect", () => {
     expect(screen.getByRole("combobox", { name: "Explanation language" })).toHaveValue("en");
   });
 
-  it("compact 指定時はラベルを視覚的に隠す(sr-only)が、アクセシブル名としては保持する(ヘッダー配置用)", () => {
+  it("「Learning [学ぶ言語] · explained in [解説言語]」という文章型レイアウトで表示する", () => {
     hydrateSettingsStore();
 
-    render(<LanguagePairSelect compact />);
+    render(<LanguagePairSelect />);
+
+    // セレクトの意味を伝えるつなぎのテキストが見えていること
+    expect(screen.getByText("Learning")).toBeInTheDocument();
+    expect(screen.getByText("explained in")).toBeInTheDocument();
+  });
+
+  it("ラベルは視覚的に隠す(sr-only)が、アクセシブル名としては保持する", () => {
+    hydrateSettingsStore();
+
+    render(<LanguagePairSelect />);
 
     const learningSelect = screen.getByRole("combobox", { name: "Learning language" });
     expect(learningSelect).toBeInTheDocument();

--- a/src/components/language-pair-select.tsx
+++ b/src/components/language-pair-select.tsx
@@ -1,8 +1,10 @@
 /**
- * チャンネル接続フォームの横に常時表示する、言語ペア(学ぶ言語 / 解説言語)のセレクト。
+ * ヘッダーに常時表示する、言語ペア(学ぶ言語 / 解説言語)のセレクト。
  *
- * ファーストビューで「どのチャンネルに接続して、何の言語をどの言語で学んでいるか」が
- * 見えるように、ダイアログではなくインラインのセレクトで置く(列見出しのダイアログは廃止した)。
+ * 「Learning [学ぶ言語] · explained in [解説言語]」という文章の中にセレクトを埋め込む
+ * 文章型レイアウトにすることで、各セレクトが何を意味するか(何の言語を学び、どの言語で
+ * 解説が出るか)をラベルなしでも読み取れるようにしている。ラベルは sr-only で保持し、
+ * スクリーンリーダー向けのアクセシブル名は維持する。
  *
  * - 変更は即座に `useSettingsStore.setSettings` が LocalStorage へ永続化し、ホーム画面が
  *   設定変更を購読して翻訳・Pick up のパイプラインを新しい言語ペアで再起動する
@@ -28,11 +30,10 @@ const languageSchema = z.enum(SUPPORTED_LANGUAGES);
 const SELECT_CLASS_NAME = "h-9 rounded-lg border border-input bg-transparent px-2.5 text-sm dark:bg-input/30";
 
 /**
- * 学ぶ言語・解説言語の2つのセレクト。
- * `compact` を指定するとラベルを視覚的に隠し(sr-only)、ヘッダーなど 高さの限られた場所に置ける
- * (アクセシブル名としてのラベルは保持する)。
+ * 学ぶ言語・解説言語の2つのセレクトを「Learning [X] · explained in [Y]」という
+ * 文章の中に埋め込んで表示する。
  */
-export function LanguagePairSelect({ compact = false }: { compact?: boolean } = {}) {
+export function LanguagePairSelect() {
   const settings = useSettingsStore((state) => state.settings);
   const hydrated = useSettingsStore((state) => state.hydrated);
   const setSettings = useSettingsStore((state) => state.setSettings);
@@ -54,29 +55,28 @@ export function LanguagePairSelect({ compact = false }: { compact?: boolean } = 
   };
 
   return (
-    <div className="flex items-end gap-3">
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor={LEARNING_SELECT_ID} className={compact ? "sr-only" : undefined}>
-          Learning language
-        </Label>
-        <LanguageSelect
-          id={LEARNING_SELECT_ID}
-          value={settings.learningLang}
-          disabled={!hydrated}
-          onChange={handleChange("learningLang")}
-        />
-      </div>
-      <div className="flex flex-col gap-1.5">
-        <Label htmlFor={EXPLANATION_SELECT_ID} className={compact ? "sr-only" : undefined}>
-          Explanation language
-        </Label>
-        <LanguageSelect
-          id={EXPLANATION_SELECT_ID}
-          value={settings.explainLang}
-          disabled={!hydrated}
-          onChange={handleChange("explainLang")}
-        />
-      </div>
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5 text-sm text-muted-foreground">
+      <Label htmlFor={LEARNING_SELECT_ID} className="sr-only">
+        Learning language
+      </Label>
+      <span aria-hidden="true">Learning</span>
+      <LanguageSelect
+        id={LEARNING_SELECT_ID}
+        value={settings.learningLang}
+        disabled={!hydrated}
+        onChange={handleChange("learningLang")}
+      />
+      <Label htmlFor={EXPLANATION_SELECT_ID} className="sr-only">
+        Explanation language
+      </Label>
+      <span aria-hidden="true">·</span>
+      <span aria-hidden="true">explained in</span>
+      <LanguageSelect
+        id={EXPLANATION_SELECT_ID}
+        value={settings.explainLang}
+        disabled={!hydrated}
+        onChange={handleChange("explainLang")}
+      />
     </div>
   );
 }

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,7 +1,7 @@
 /**
  * 全ページ共通のヘッダー。
  *
- * 左側にアプリ名のリンク、右側に言語ペアのセレクト(コンパクト表示)と
+ * 左側にアプリ名のリンク、右側に言語ペアのセレクト(文章型レイアウト)と
  * 設定ダイアログのトリガーを表示する。言語設定・アプリ設定は接続前後の
  * どちらの画面(接続フォーム / embed + 3カラム)でも変更したくなるため、
  * 画面の状態に依存しないヘッダーに常時置く。
@@ -18,7 +18,7 @@ export function SiteHeader() {
           chat-sensei
         </Link>
         <div className="flex items-center gap-2">
-          <LanguagePairSelect compact />
+          <LanguagePairSelect />
           <SettingsDialog />
         </div>
       </nav>


### PR DESCRIPTION
## Summary

ヘッダーの言語セレクトは2つのセレクトが説明なしに並んでいるだけで、それぞれが「学ぶ言語」「解説言語」のどちらなのか利用者に伝わりませんでした（`compact` 指定によりラベルが `sr-only` で視覚的に隠れていたため）。本PRでは、つなぎのテキストを挟んで **`Learning [English ▾] · explained in [日本語 ▾]`** という文章として読めるレイアウトに変更します。

## 変更内容

- `src/components/language-pair-select.tsx`
  - セレクトの前後につなぎテキスト（"Learning" / "·" / "explained in"）を配置する文章型レイアウトに変更しました。つなぎテキストは `text-muted-foreground` で控えめに表示し、狭い画面では `flex-wrap` で折り返します
  - ラベル（"Learning language" / "Explanation language"）は `sr-only` で常時保持し、スクリーンリーダー向けのアクセシブル名を維持します
  - 可視ラベルの出し分けに使っていた `compact` プロップは不要になったため削除しました
- `src/components/site-header.tsx`
  - `compact` 指定を削除しました
- `src/components/language-pair-select.test.tsx`
  - 文章型レイアウト（つなぎテキストの表示・sr-only ラベルの保持）のテストを追加しました

言語スワップ（もう一方と同じ言語を選ぶと入れ替えて保存する挙動）などの既存ロジックは変更していません。

## テスト

- `npm test`: 794件すべて成功
- `npm run lint` / `npm run type-check` / `npm run build`: エラー・警告ゼロ
- CodeRabbitレビュー: 指摘ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)