### PR TITLE
feat: 配信情報(視聴者数など)を接続中に60秒間隔で定期リフレッシュする

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,6 +68,7 @@ import { startPickupPipeline, usePickupStore, warmUpPickupPipeline, type PickupD
 import { usePromptApiStore, type PromptApiStatus } from "@/store/prompt-api";
 import { hydrateSettingsStore, useSettingsStore } from "@/store/settings";
 import { useStreamInfoStore } from "@/store/stream-info";
+import { streamInfoPromptKey } from "@/lib/twitch/stream-info";
 import {
   startTranslationPipeline,
   useTranslationStore,
@@ -171,10 +172,8 @@ export default function Home() {
   // 読み込み完了・チャンネル切り替えで内容が変わったときもパイプラインを再起動して反映する
   // (言語設定の変更と同じ機構。生成済みの翻訳・Pick up は破棄され、表示中の発言は再生成される)
   const streamInfo = useStreamInfoStore((state) => state.streamInfo);
-  const streamInfoKey =
-    streamInfo === null
-      ? ""
-      : [streamInfo.title, streamInfo.category, streamInfo.broadcasterLogin, streamInfo.broadcasterName].join("|");
+  // viewerCount など、プロンプトに焼き込まないフィールドの定期リフレッシュ(issue #85)では再起動しない
+  const streamInfoKey = streamInfoPromptKey(streamInfo);
 
   // 受信した発言を自動で翻訳・抽出ジョブに流す。言語設定の復元後に開始し、言語設定が変わるたびに
   // 停止 → 開始し直す(セッションプールのシステムプロンプトに言語ペアを含むため)。

--- a/src/lib/twitch/stream-info.test.ts
+++ b/src/lib/twitch/stream-info.test.ts
@@ -6,8 +6,12 @@
  * Next.js プロキシ(`/api/twitch/streams`)経由の取得を検証する。
  * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
  */
-import { describe, expect, it, vi } from "vitest";
-import { fetchStreamInfo, fetchStreamInfoResult, parseStreamInfo } from "./stream-info";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchStreamInfoResult, parseStreamInfo, streamInfoPromptKey } from "./stream-info";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 /** Helix Get Streams API のライブ配信 1 件ぶんのレスポンス(検証に使う部分のみ) */
 function createHelixStreamsJson(overrides: Record<string, unknown> = {}): unknown {
@@ -121,35 +125,49 @@ describe("fetchStreamInfoResult", () => {
 
     expect(await fetchStreamInfoResult("zackrawrr", fetchFn)).toEqual({ status: "unavailable" });
   });
-});
 
-describe("fetchStreamInfo", () => {
-  it("Helix プロキシに user_login 付きで GET し、解析した配信情報を返す", async () => {
-    const fetchFn = vi.fn(async () => Response.json(createHelixStreamsJson()));
+  it("200 だが形式が不正なボディ(data が無い・配列でない・要素が解析できない)は unavailable を返す(配信終了と誤判定しない)", async () => {
+    const 不正なボディ一覧 = [{}, { data: "not-an-array" }, { data: [{ title: 123, game_name: 456 }] }];
+    for (const body of 不正なボディ一覧) {
+      const fetchFn = vi.fn(async () => Response.json(body));
 
-    const info = await fetchStreamInfo("zackrawrr", fetchFn);
-
-    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/streams?user_login=zackrawrr", { signal: undefined });
-    expect(info).toEqual(期待する配信情報);
+      expect(await fetchStreamInfoResult("zackrawrr", fetchFn)).toEqual({ status: "unavailable" });
+    }
   });
 
-  it("オフライン(data が空)の場合は null を返す", async () => {
-    const fetchFn = vi.fn(async () => Response.json({ data: [] }));
-
-    expect(await fetchStreamInfo("zackrawrr", fetchFn)).toBeNull();
-  });
-
-  it("HTTP エラー(503: Helix 未設定など)の場合は null を返す(文脈なしで動作を続けるため)", async () => {
+  it("failureLog を渡さない場合、取得失敗しても console.warn を出さない(定期リフレッシュで毎分警告を出さないため)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const fetchFn = vi.fn(async () => Response.json({ error: "Helix API が設定されていません" }, { status: 503 }));
 
-    expect(await fetchStreamInfo("zackrawrr", fetchFn)).toBeNull();
+    await fetchStreamInfoResult("zackrawrr", fetchFn);
+
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  it("ネットワークエラーの場合は null を返す", async () => {
-    const fetchFn = vi.fn(async () => {
-      throw new Error("network down");
-    });
+  it("failureLog を渡した場合、取得失敗時に console.warn を出す(初回読み込みでの利用)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fetchFn = vi.fn(async () => Response.json({ error: "Helix API が設定されていません" }, { status: 503 }));
 
-    expect(await fetchStreamInfo("zackrawrr", fetchFn)).toBeNull();
+    await fetchStreamInfoResult("zackrawrr", fetchFn, { subject: "配信情報", fallback: "文脈なしで動作します" });
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("streamInfoPromptKey", () => {
+  it("システムプロンプトに焼き込むフィールド(タイトル・カテゴリ・配信者名)だけからキーを作る", () => {
+    expect(streamInfoPromptKey(期待する配信情報)).toBe(
+      "Mythic raid progression! !drops|World of Warcraft|zackrawrr|ZackRawrr",
+    );
+  });
+
+  it("視聴者数だけが変わってもキーは変わらない(定期リフレッシュでパイプラインを再起動しないため)", () => {
+    expect(streamInfoPromptKey({ ...期待する配信情報, viewerCount: 9999 })).toBe(
+      streamInfoPromptKey(期待する配信情報),
+    );
+  });
+
+  it("null(未読み込み・オフライン)の場合は空文字を返す", () => {
+    expect(streamInfoPromptKey(null)).toBe("");
   });
 });

--- a/src/lib/twitch/stream-info.test.ts
+++ b/src/lib/twitch/stream-info.test.ts
@@ -7,7 +7,7 @@
  * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
  */
 import { describe, expect, it, vi } from "vitest";
-import { fetchStreamInfo, parseStreamInfo } from "./stream-info";
+import { fetchStreamInfo, fetchStreamInfoResult, parseStreamInfo } from "./stream-info";
 
 /** Helix Get Streams API のライブ配信 1 件ぶんのレスポンス(検証に使う部分のみ) */
 function createHelixStreamsJson(overrides: Record<string, unknown> = {}): unknown {
@@ -89,6 +89,37 @@ describe("parseStreamInfo", () => {
     expect(parseStreamInfo({})).toBeNull();
     expect(parseStreamInfo({ data: "not-an-array" })).toBeNull();
     expect(parseStreamInfo({ data: [{ title: 123, game_name: 456 }] })).toBeNull();
+  });
+});
+
+describe("fetchStreamInfoResult", () => {
+  it("ライブ配信中は live ステータスと解析した配信情報を返す", async () => {
+    const fetchFn = vi.fn(async () => Response.json(createHelixStreamsJson()));
+
+    const result = await fetchStreamInfoResult("zackrawrr", fetchFn);
+
+    expect(fetchFn).toHaveBeenCalledWith("/api/twitch/streams?user_login=zackrawrr", { signal: undefined });
+    expect(result).toEqual({ status: "live", info: 期待する配信情報 });
+  });
+
+  it("オフライン(data が空)の場合は offline ステータスを返す(配信終了の検知に使う)", async () => {
+    const fetchFn = vi.fn(async () => Response.json({ data: [] }));
+
+    expect(await fetchStreamInfoResult("zackrawrr", fetchFn)).toEqual({ status: "offline" });
+  });
+
+  it("HTTP エラー(503: Helix 未設定など)の場合は unavailable ステータスを返す(オフラインと区別する)", async () => {
+    const fetchFn = vi.fn(async () => Response.json({ error: "Helix API が設定されていません" }, { status: 503 }));
+
+    expect(await fetchStreamInfoResult("zackrawrr", fetchFn)).toEqual({ status: "unavailable" });
+  });
+
+  it("ネットワークエラーの場合は unavailable ステータスを返す", async () => {
+    const fetchFn = vi.fn(async () => {
+      throw new Error("network down");
+    });
+
+    expect(await fetchStreamInfoResult("zackrawrr", fetchFn)).toEqual({ status: "unavailable" });
   });
 });
 

--- a/src/lib/twitch/stream-info.ts
+++ b/src/lib/twitch/stream-info.ts
@@ -62,6 +62,41 @@ export function parseStreamInfo(json: unknown): StreamInfo | null {
 }
 
 /**
+ * 配信情報の取得結果。定期リフレッシュ(issue #85)が「配信終了(オフライン)」と
+ * 「取得失敗(API 障害など)」を区別して扱えるようにステータス付きで返す。
+ *
+ * - live: ライブ配信中。解析済みの配信情報を持つ
+ * - offline: 取得は成功したが配信していない(レスポンスの `data` が空)。
+ *   タイトル・カテゴリの両方が空など、文脈として意味の無いレスポンスもここに含める
+ * - unavailable: 取得に失敗した(Helix 未設定の 503・レート制限・障害・ネットワークエラー)。
+ *   配信が終了したとは判断できないため、呼び出し側は既存の情報を保持してよい
+ */
+export type StreamInfoFetchResult =
+  | { status: "live"; info: StreamInfo }
+  | { status: "offline" }
+  | { status: "unavailable" };
+
+/**
+ * Helix プロキシ(`/api/twitch/streams`)から、指定したチャンネル(user_login)の
+ * ライブ配信の情報をステータス付きで取得する。オフラインと取得失敗を区別する必要がある
+ * 定期リフレッシュ(issue #85)から使う。
+ */
+export async function fetchStreamInfoResult(
+  userLogin: string,
+  fetchFn: typeof fetch = fetch,
+): Promise<StreamInfoFetchResult> {
+  const json = await fetchHelixJson("streams", {
+    params: new URLSearchParams({ user_login: userLogin }),
+    fetchFn,
+    failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
+  });
+  if (json === null) return { status: "unavailable" };
+  const info = parseStreamInfo(json);
+  if (info === null) return { status: "offline" };
+  return { status: "live", info };
+}
+
+/**
  * Helix プロキシ(`/api/twitch/streams`)から、指定したチャンネル(user_login)の
  * ライブ配信のタイトル・カテゴリを取得する。
  *
@@ -74,11 +109,6 @@ export async function fetchStreamInfo(
   userLogin: string,
   fetchFn: typeof fetch = fetch,
 ): Promise<StreamInfo | null> {
-  const json = await fetchHelixJson("streams", {
-    params: new URLSearchParams({ user_login: userLogin }),
-    fetchFn,
-    failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
-  });
-  if (json === null) return null;
-  return parseStreamInfo(json);
+  const result = await fetchStreamInfoResult(userLogin, fetchFn);
+  return result.status === "live" ? result.info : null;
 }

--- a/src/lib/twitch/stream-info.ts
+++ b/src/lib/twitch/stream-info.ts
@@ -14,7 +14,7 @@
  *   文脈なしで動作を続ける(意図したフォールバック)
  */
 
-import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+import { extractDataArray, fetchHelixJson, type HelixFailureLog } from "./helix-proxy";
 
 /** 接続中チャンネルのライブ配信の情報。カテゴリ未設定の配信では category が空文字になる */
 export interface StreamInfo {
@@ -66,10 +66,10 @@ export function parseStreamInfo(json: unknown): StreamInfo | null {
  * 「取得失敗(API 障害など)」を区別して扱えるようにステータス付きで返す。
  *
  * - live: ライブ配信中。解析済みの配信情報を持つ
- * - offline: 取得は成功したが配信していない(レスポンスの `data` が空)。
- *   タイトル・カテゴリの両方が空など、文脈として意味の無いレスポンスもここに含める
- * - unavailable: 取得に失敗した(Helix 未設定の 503・レート制限・障害・ネットワークエラー)。
- *   配信が終了したとは判断できないため、呼び出し側は既存の情報を保持してよい
+ * - offline: 取得は成功したが配信していない(レスポンスの `data` が空)
+ * - unavailable: 取得に失敗した(Helix 未設定の 503・レート制限・障害・ネットワークエラー)、
+ *   または 200 だが形式が想定と異なるボディ(配信終了とは判断できない)。
+ *   呼び出し側は既存の情報を保持してよい
  */
 export type StreamInfoFetchResult =
   | { status: "live"; info: StreamInfo }
@@ -78,37 +78,40 @@ export type StreamInfoFetchResult =
 
 /**
  * Helix プロキシ(`/api/twitch/streams`)から、指定したチャンネル(user_login)の
- * ライブ配信の情報をステータス付きで取得する。オフラインと取得失敗を区別する必要がある
- * 定期リフレッシュ(issue #85)から使う。
+ * ライブ配信の情報をステータス付きで取得する。
+ *
+ * `failureLog` を渡した場合のみ、取得失敗時に console.warn で警告を出す。
+ * 定期リフレッシュ(issue #85)は省略して静かに失敗させる(障害中に毎分警告を出さない)。
  */
 export async function fetchStreamInfoResult(
   userLogin: string,
   fetchFn: typeof fetch = fetch,
+  failureLog?: HelixFailureLog,
 ): Promise<StreamInfoFetchResult> {
   const json = await fetchHelixJson("streams", {
     params: new URLSearchParams({ user_login: userLogin }),
     fetchFn,
-    failureLog: { subject: "配信情報", fallback: "文脈なしで動作します" },
+    failureLog,
   });
   if (json === null) return { status: "unavailable" };
+  const data = extractDataArray(json);
+  // 200 だが data が配列でない(形式不正)場合は、配信終了と誤判定して文脈を捨てないよう unavailable 扱いにする
+  if (data === null) return { status: "unavailable" };
+  if (data.length === 0) return { status: "offline" };
   const info = parseStreamInfo(json);
-  if (info === null) return { status: "offline" };
+  // 要素はあるのに解析できない(フィールドの型が違う・文脈として意味が無い)場合も同様に unavailable 扱い
+  if (info === null) return { status: "unavailable" };
   return { status: "live", info };
 }
 
 /**
- * Helix プロキシ(`/api/twitch/streams`)から、指定したチャンネル(user_login)の
- * ライブ配信のタイトル・カテゴリを取得する。
- *
- * 取得できない場合は null を返す(呼び出し側は文脈なしの現行プロンプトで動作する。意図した仕様):
- * - オフライン(レスポンスの `data` が空)
- * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害などの HTTP エラー
- * - ネットワークエラー
+ * 配信情報のうちシステムプロンプトに焼き込むフィールド(タイトル・カテゴリ・配信者名)だけから
+ * 比較用のキーを作る。パイプライン再起動(page.tsx)や手動Pick upのセッションプール再生成
+ * (manual-pickups.ts)の要否判定に使い、視聴者数(viewerCount)などプロンプトに影響しない
+ * フィールドの定期リフレッシュではキーが変わらないようにする(issue #85)。
+ * null(未読み込み・オフライン)の場合は空文字を返す。
  */
-export async function fetchStreamInfo(
-  userLogin: string,
-  fetchFn: typeof fetch = fetch,
-): Promise<StreamInfo | null> {
-  const result = await fetchStreamInfoResult(userLogin, fetchFn);
-  return result.status === "live" ? result.info : null;
+export function streamInfoPromptKey(streamInfo: StreamInfo | null): string {
+  if (streamInfo === null) return "";
+  return [streamInfo.title, streamInfo.category, streamInfo.broadcasterLogin, streamInfo.broadcasterName].join("|");
 }

--- a/src/store/chat-connection.test.ts
+++ b/src/store/chat-connection.test.ts
@@ -517,14 +517,19 @@ describe("チャットバッジ(Helix Chat Badges API)", () => {
 });
 
 // 配信情報(タイトル・カテゴリ)の読み込みも実 API(Helix プロキシ)を呼ぶため、ストア連携だけをモックで検証する
-const { mockLoadStreamInfo, mockClearStreamInfo } = vi.hoisted(() => ({
-  mockLoadStreamInfo: vi.fn(),
-  mockClearStreamInfo: vi.fn(),
-}));
+const { mockLoadStreamInfo, mockClearStreamInfo, mockStartStreamInfoRefresh, mockStopStreamInfoRefresh } =
+  vi.hoisted(() => ({
+    mockLoadStreamInfo: vi.fn(),
+    mockClearStreamInfo: vi.fn(),
+    mockStartStreamInfoRefresh: vi.fn(),
+    mockStopStreamInfoRefresh: vi.fn(),
+  }));
 
 vi.mock("./stream-info", () => ({
   loadStreamInfo: (channelLogin: string) => mockLoadStreamInfo(channelLogin),
   clearStreamInfo: () => mockClearStreamInfo(),
+  startStreamInfoRefresh: (channelLogin: string) => mockStartStreamInfoRefresh(channelLogin),
+  stopStreamInfoRefresh: () => mockStopStreamInfoRefresh(),
 }));
 
 describe("配信情報(タイトル・カテゴリ)との連携(issue #54)", () => {
@@ -532,6 +537,8 @@ describe("配信情報(タイトル・カテゴリ)との連携(issue #54)", () 
   beforeEach(() => {
     mockLoadStreamInfo.mockClear();
     mockClearStreamInfo.mockClear();
+    mockStartStreamInfoRefresh.mockClear();
+    mockStopStreamInfoRefresh.mockClear();
   });
 
   it("connect()を呼ぶと、前チャンネルの配信情報をクリアしてから正規化したチャンネル名で読み込む", () => {
@@ -548,5 +555,20 @@ describe("配信情報(タイトル・カテゴリ)との連携(issue #54)", () 
     useChatConnectionStore.getState().disconnect();
 
     expect(mockClearStreamInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("connect()を呼ぶと、正規化したチャンネル名で配信情報の定期リフレッシュを開始する(issue #85)", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+
+    expect(mockStartStreamInfoRefresh).toHaveBeenCalledWith("zackrawrr");
+  });
+
+  it("disconnect()を呼ぶと、配信情報の定期リフレッシュを停止する(issue #85)", () => {
+    useChatConnectionStore.getState().connect("ZackRawrr");
+    mockStopStreamInfoRefresh.mockClear();
+
+    useChatConnectionStore.getState().disconnect();
+
+    expect(mockStopStreamInfoRefresh).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -31,7 +31,7 @@ import { isExcludedFromChat } from "@/lib/bot-filter";
 import { isExcludedByBotFilter, useBotFilterStore } from "./bot-filter";
 import { clearAvatarLoadFailures, requestAvatar } from "./avatars";
 import { clearBadges, loadBadges } from "./badges";
-import { clearStreamInfo, loadStreamInfo } from "./stream-info";
+import { clearStreamInfo, loadStreamInfo, startStreamInfoRefresh, stopStreamInfoRefresh } from "./stream-info";
 import { clearThirdPartyEmotes, getThirdPartyEmoteMap, loadThirdPartyEmotes } from "./third-party-emotes";
 import { clearCheermotes, getCheermoteSet, loadCheermotes } from "./cheermotes";
 import { clearHiddenPickupTerms } from "./hidden-pickups";
@@ -128,11 +128,14 @@ export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
     // 配信情報(タイトル・カテゴリ。issue #54)はチャンネル名(user_login)だけで取得できるため、
     // ROOMSTATE を待たず接続開始と同時に読み込む
     void loadStreamInfo(normalized);
+    // 視聴者数・カテゴリの変化と配信終了に追従するため、接続中は定期的に再取得する(issue #85)
+    startStreamInfoRefresh(normalized);
     getClient().connect(channel);
   },
   disconnect: () => {
     set({ channel: null });
-    // 切断中に古い配信の文脈を残さない
+    // 切断中に古い配信の文脈を残さない(定期リフレッシュも止める)
+    stopStreamInfoRefresh();
     clearStreamInfo();
     getClient().disconnect();
   },

--- a/src/store/manual-pickups.ts
+++ b/src/store/manual-pickups.ts
@@ -21,6 +21,7 @@ import { sharedPromptJobQueue } from "./auto-pipeline";
 import { normalizePickupTerm } from "./hidden-pickups";
 import { usePromptApiStore, type PromptApiStatus } from "./prompt-api";
 import { useSettingsStore } from "./settings";
+import { streamInfoPromptKey } from "@/lib/twitch/stream-info";
 import { getStreamInfo } from "./stream-info";
 
 /** 手動Pick upした語句1件ぶんの状態 */
@@ -66,9 +67,10 @@ function getDefineTermPool(): SessionPool {
   // このメッセージは失敗理由として画面に表示され得るため、UIの言語(英語)で書く
   if (!hydrated) throw new Error("Settings are not restored yet. Call hydrateSettingsStore() first");
   const streamInfo = getStreamInfo();
-  // フィールドを手動列挙すると設定項目の追加時に漏れやすく、区切り文字がタイトル中の文字と衝突し得るため、
-  // 構造ごと JSON にして比較する(設定・配信情報はどちらも小さな平坦オブジェクト)
-  const key = JSON.stringify([settings, streamInfo]);
+  // 設定はフィールドを手動列挙すると項目追加時に漏れやすいため構造ごと JSON にして比較する。
+  // 配信情報はシステムプロンプトに焼き込むフィールドだけのキー(streamInfoPromptKey)を使い、
+  // 定期リフレッシュ(issue #85)による視聴者数だけの変化でウォームアップ済みプールを作り直さない
+  const key = JSON.stringify([settings, streamInfoPromptKey(streamInfo)]);
   if (cachedPool === null || cachedPool.key !== key) {
     // 旧プールに残っていたジョブは SessionPoolDisposedError で failed になり、
     // addManualPickup が再試行を促す理由に差し替える

--- a/src/store/stream-info.test.ts
+++ b/src/store/stream-info.test.ts
@@ -8,17 +8,21 @@
  * 実際の API 呼び出しは行わず、フェイクの読み込み関数を注入する。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { StreamInfo } from "@/lib/twitch/stream-info";
+import type { StreamInfo, StreamInfoFetchResult } from "@/lib/twitch/stream-info";
 import {
   clearStreamInfo,
   getStreamInfo,
   loadStreamInfo,
+  refreshStreamInfo,
   resetStreamInfoForTests,
+  startStreamInfoRefresh,
+  stopStreamInfoRefresh,
   useStreamInfoStore,
 } from "./stream-info";
 
 afterEach(() => {
   resetStreamInfoForTests();
+  vi.useRealTimers();
 });
 
 const FAKE_STREAM_INFO: StreamInfo = {
@@ -85,6 +89,112 @@ describe("loadStreamInfo", () => {
     await firstLoading;
 
     expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
+  });
+});
+
+/** リフレッシュで受け取る更新後の配信情報(視聴者数・カテゴリが変化したケース) */
+const 更新後の配信情報: StreamInfo = {
+  ...FAKE_STREAM_INFO,
+  category: "Just Chatting",
+  gameId: "509658",
+  viewerCount: 9876,
+};
+
+describe("refreshStreamInfo", () => {
+  it("live の場合は配信情報を更新する(視聴者数・カテゴリの変化を反映する)", async () => {
+    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+
+    await refreshStreamInfo(async () => ({ status: "live", info: 更新後の配信情報 }));
+
+    expect(getStreamInfo()).toEqual(更新後の配信情報);
+  });
+
+  it("offline の場合は配信情報をクリアする(配信終了後にライブ風の視聴者数を残さない)", async () => {
+    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+
+    await refreshStreamInfo(async () => ({ status: "offline" }));
+
+    expect(getStreamInfo()).toBeNull();
+  });
+
+  it("unavailable(API 失敗)の場合は既存の配信情報を保持する(リフレッシュの失敗でUIを壊さない)", async () => {
+    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+
+    await refreshStreamInfo(async () => ({ status: "unavailable" }));
+
+    expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
+  });
+
+  it("リフレッシュ完了前に clearStreamInfo された場合は結果を破棄する(チャンネル切り替え・切断)", async () => {
+    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+    let resolveFetch: (result: StreamInfoFetchResult) => void = () => {};
+    const refreshing = refreshStreamInfo(
+      () => new Promise<StreamInfoFetchResult>((resolve) => (resolveFetch = resolve)),
+    );
+
+    clearStreamInfo();
+    resolveFetch({ status: "live", info: 更新後の配信情報 });
+    await refreshing;
+
+    expect(getStreamInfo()).toBeNull();
+  });
+
+  it("リフレッシュ完了前に別チャンネルの読み込みが始まった場合、遅れて届いた結果は破棄する", async () => {
+    await loadStreamInfo("oldchannel", async () => FAKE_STREAM_INFO);
+    let resolveFetch: (result: StreamInfoFetchResult) => void = () => {};
+    const refreshing = refreshStreamInfo(
+      () => new Promise<StreamInfoFetchResult>((resolve) => (resolveFetch = resolve)),
+    );
+
+    clearStreamInfo();
+    await loadStreamInfo("newchannel", async () => 更新後の配信情報);
+    resolveFetch({ status: "offline" });
+    await refreshing;
+
+    expect(getStreamInfo()).toEqual(更新後の配信情報);
+  });
+});
+
+describe("startStreamInfoRefresh / stopStreamInfoRefresh", () => {
+  it("60秒間隔でリフレッシュを繰り返し実行する", async () => {
+    vi.useFakeTimers();
+    const fetchResult = vi.fn(async (): Promise<StreamInfoFetchResult> => ({ status: "live", info: 更新後の配信情報 }));
+
+    startStreamInfoRefresh("zackrawrr", fetchResult);
+    expect(fetchResult).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchResult).toHaveBeenCalledTimes(1);
+    expect(fetchResult).toHaveBeenCalledWith("zackrawrr");
+    expect(getStreamInfo()).toEqual(更新後の配信情報);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchResult).toHaveBeenCalledTimes(2);
+  });
+
+  it("stopStreamInfoRefresh 後はリフレッシュしない(切断時)", async () => {
+    vi.useFakeTimers();
+    const fetchResult = vi.fn(async (): Promise<StreamInfoFetchResult> => ({ status: "live", info: 更新後の配信情報 }));
+
+    startStreamInfoRefresh("zackrawrr", fetchResult);
+    stopStreamInfoRefresh();
+
+    await vi.advanceTimersByTimeAsync(180_000);
+    expect(fetchResult).not.toHaveBeenCalled();
+  });
+
+  it("start を再度呼ぶと前のタイマーを止めて新しいチャンネルで開始する(チャンネル切り替え)", async () => {
+    vi.useFakeTimers();
+    const oldFetch = vi.fn(async (): Promise<StreamInfoFetchResult> => ({ status: "unavailable" }));
+    const newFetch = vi.fn(async (): Promise<StreamInfoFetchResult> => ({ status: "unavailable" }));
+
+    startStreamInfoRefresh("oldchannel", oldFetch);
+    startStreamInfoRefresh("newchannel", newFetch);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(oldFetch).not.toHaveBeenCalled();
+    expect(newFetch).toHaveBeenCalledTimes(1);
+    expect(newFetch).toHaveBeenCalledWith("newchannel");
   });
 });
 

--- a/src/store/stream-info.test.ts
+++ b/src/store/stream-info.test.ts
@@ -4,7 +4,7 @@
  * `chat-connection.ts` の connect() で配信情報(タイトル・カテゴリ)を読み込み、
  * 翻訳・Pick up のシステムプロンプト組み立て(`translations.ts` / `pickups.ts`)が
  * 同期的に参照できる形で保持する流れと、チャンネル切り替え時のクリア・
- * 読み込み途中の結果破棄(世代ガード)を検証する。
+ * 読み込み途中の結果破棄(世代ガード)、接続中の定期リフレッシュ(issue #85)を検証する。
  * 実際の API 呼び出しは行わず、フェイクの読み込み関数を注入する。
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -35,63 +35,6 @@ const FAKE_STREAM_INFO: StreamInfo = {
   viewerCount: 4321,
 };
 
-describe("loadStreamInfo", () => {
-  it("未読み込みの間は null を返す(文脈なしの現行プロンプトで動作する)", () => {
-    expect(getStreamInfo()).toBeNull();
-  });
-
-  it("読み込んだ配信情報を getStreamInfo と Zustand ストアの両方で参照できる", async () => {
-    const fetchInfo = vi.fn(async () => FAKE_STREAM_INFO);
-
-    await loadStreamInfo("zackrawrr", fetchInfo);
-
-    expect(fetchInfo).toHaveBeenCalledWith("zackrawrr");
-    expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
-    expect(useStreamInfoStore.getState().streamInfo).toEqual(FAKE_STREAM_INFO);
-  });
-
-  it("取得できない場合(オフライン・API 失敗 = null)は null のまま(文脈なしで動作する)", async () => {
-    await loadStreamInfo("zackrawrr", async () => null);
-
-    expect(getStreamInfo()).toBeNull();
-  });
-
-  it("読み込み完了前に clearStreamInfo された場合は結果を破棄する(チャンネル切り替え)", async () => {
-    let resolveFetch: (info: StreamInfo | null) => void = () => {};
-    const fetchInfo = vi.fn(() => new Promise<StreamInfo | null>((resolve) => (resolveFetch = resolve)));
-
-    const loading = loadStreamInfo("zackrawrr", fetchInfo);
-    clearStreamInfo();
-    resolveFetch(FAKE_STREAM_INFO);
-    await loading;
-
-    expect(getStreamInfo()).toBeNull();
-  });
-
-  it("読み込み完了前に別チャンネルの読み込みが始まった場合、先に始めた読み込みの結果は破棄する", async () => {
-    let resolveFirst: (info: StreamInfo | null) => void = () => {};
-    const firstLoading = loadStreamInfo(
-      "oldchannel",
-      () => new Promise<StreamInfo | null>((resolve) => (resolveFirst = resolve)),
-    );
-    const secondLoading = loadStreamInfo("newchannel", async () => FAKE_STREAM_INFO);
-
-    await secondLoading;
-    resolveFirst({
-      title: "古いチャンネルの配信",
-      category: "Old Game",
-      broadcasterId: "999",
-      broadcasterLogin: "oldchannel",
-      broadcasterName: "OldChannel",
-      gameId: "111",
-      viewerCount: 10,
-    });
-    await firstLoading;
-
-    expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
-  });
-});
-
 /** リフレッシュで受け取る更新後の配信情報(視聴者数・カテゴリが変化したケース) */
 const 更新後の配信情報: StreamInfo = {
   ...FAKE_STREAM_INFO,
@@ -100,25 +43,125 @@ const 更新後の配信情報: StreamInfo = {
   viewerCount: 9876,
 };
 
+/** ライブ配信中の取得結果を返すフェイク読み込み関数を作る */
+function live(info: StreamInfo): () => Promise<StreamInfoFetchResult> {
+  return async () => ({ status: "live", info });
+}
+
+describe("loadStreamInfo", () => {
+  it("未読み込みの間は null を返す(文脈なしの現行プロンプトで動作する)", () => {
+    expect(getStreamInfo()).toBeNull();
+  });
+
+  it("読み込んだ配信情報を getStreamInfo と Zustand ストアの両方で参照できる", async () => {
+    const fetchResult = vi.fn(live(FAKE_STREAM_INFO));
+
+    await loadStreamInfo("zackrawrr", fetchResult);
+
+    expect(fetchResult).toHaveBeenCalledWith("zackrawrr");
+    expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
+    expect(useStreamInfoStore.getState().streamInfo).toEqual(FAKE_STREAM_INFO);
+  });
+
+  it("オフライン(配信していない)の場合は null のまま(文脈なしで動作する)", async () => {
+    await loadStreamInfo("zackrawrr", async () => ({ status: "offline" }));
+
+    expect(getStreamInfo()).toBeNull();
+  });
+
+  it("取得に失敗した場合(Helix 未設定・API 失敗)は null のまま(文脈なしで動作する)", async () => {
+    await loadStreamInfo("zackrawrr", async () => ({ status: "unavailable" }));
+
+    expect(getStreamInfo()).toBeNull();
+  });
+
+  it("読み込み完了前に clearStreamInfo された場合は結果を破棄する(チャンネル切り替え)", async () => {
+    let resolveFetch: (result: StreamInfoFetchResult) => void = () => {};
+    const fetchResult = vi.fn(() => new Promise<StreamInfoFetchResult>((resolve) => (resolveFetch = resolve)));
+
+    const loading = loadStreamInfo("zackrawrr", fetchResult);
+    clearStreamInfo();
+    resolveFetch({ status: "live", info: FAKE_STREAM_INFO });
+    await loading;
+
+    expect(getStreamInfo()).toBeNull();
+  });
+
+  it("読み込み完了前に別チャンネルの読み込みが始まった場合、先に始めた読み込みの結果は破棄する", async () => {
+    let resolveFirst: (result: StreamInfoFetchResult) => void = () => {};
+    const firstLoading = loadStreamInfo(
+      "oldchannel",
+      () => new Promise<StreamInfoFetchResult>((resolve) => (resolveFirst = resolve)),
+    );
+    const secondLoading = loadStreamInfo("newchannel", live(FAKE_STREAM_INFO));
+
+    await secondLoading;
+    resolveFirst({
+      status: "live",
+      info: {
+        title: "古いチャンネルの配信",
+        category: "Old Game",
+        broadcasterId: "999",
+        broadcasterLogin: "oldchannel",
+        broadcasterName: "OldChannel",
+        gameId: "111",
+        viewerCount: 10,
+      },
+    });
+    await firstLoading;
+
+    expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
+  });
+});
+
 describe("refreshStreamInfo", () => {
   it("live の場合は配信情報を更新する(視聴者数・カテゴリの変化を反映する)", async () => {
-    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
 
-    await refreshStreamInfo(async () => ({ status: "live", info: 更新後の配信情報 }));
+    await refreshStreamInfo(live(更新後の配信情報));
 
     expect(getStreamInfo()).toEqual(更新後の配信情報);
   });
 
-  it("offline の場合は配信情報をクリアする(配信終了後にライブ風の視聴者数を残さない)", async () => {
-    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+  it("live で内容が前回と同一の場合はストアを更新しない(60秒ごとの無駄な再レンダリングを避ける)", async () => {
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
+    const 更新前の参照 = useStreamInfoStore.getState().streamInfo;
 
+    // parseStreamInfo は毎回新しいオブジェクトを返すため、内容が同じでも参照は異なる
+    await refreshStreamInfo(live({ ...FAKE_STREAM_INFO }));
+
+    expect(useStreamInfoStore.getState().streamInfo).toBe(更新前の参照);
+  });
+
+  it("offline が1回だけの場合は既存の配信情報を保持する(Helix の一時的な空レスポンスでパイプラインを再起動しない)", async () => {
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
+
+    await refreshStreamInfo(async () => ({ status: "offline" }));
+
+    expect(getStreamInfo()).toEqual(FAKE_STREAM_INFO);
+  });
+
+  it("offline が2回連続した場合は配信情報をクリアする(配信終了後にライブ風の視聴者数を残さない)", async () => {
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
+
+    await refreshStreamInfo(async () => ({ status: "offline" }));
     await refreshStreamInfo(async () => ({ status: "offline" }));
 
     expect(getStreamInfo()).toBeNull();
   });
 
+  it("offline の後に live に戻った場合は連続カウントをリセットする(その後の offline 1回ではクリアしない)", async () => {
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
+
+    await refreshStreamInfo(async () => ({ status: "offline" }));
+    await refreshStreamInfo(live(更新後の配信情報));
+    await refreshStreamInfo(async () => ({ status: "offline" }));
+
+    expect(getStreamInfo()).toEqual(更新後の配信情報);
+  });
+
   it("unavailable(API 失敗)の場合は既存の配信情報を保持する(リフレッシュの失敗でUIを壊さない)", async () => {
-    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
 
     await refreshStreamInfo(async () => ({ status: "unavailable" }));
 
@@ -126,7 +169,7 @@ describe("refreshStreamInfo", () => {
   });
 
   it("リフレッシュ完了前に clearStreamInfo された場合は結果を破棄する(チャンネル切り替え・切断)", async () => {
-    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
     let resolveFetch: (result: StreamInfoFetchResult) => void = () => {};
     const refreshing = refreshStreamInfo(
       () => new Promise<StreamInfoFetchResult>((resolve) => (resolveFetch = resolve)),
@@ -139,17 +182,18 @@ describe("refreshStreamInfo", () => {
     expect(getStreamInfo()).toBeNull();
   });
 
-  it("リフレッシュ完了前に別チャンネルの読み込みが始まった場合、遅れて届いた結果は破棄する", async () => {
-    await loadStreamInfo("oldchannel", async () => FAKE_STREAM_INFO);
-    let resolveFetch: (result: StreamInfoFetchResult) => void = () => {};
-    const refreshing = refreshStreamInfo(
-      () => new Promise<StreamInfoFetchResult>((resolve) => (resolveFetch = resolve)),
+  it("リフレッシュ同士が追い越した場合、先に始めた古いリフレッシュの結果は破棄する(遅延 fetch との競合)", async () => {
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
+    let resolveSlow: (result: StreamInfoFetchResult) => void = () => {};
+    const slowRefreshing = refreshStreamInfo(
+      () => new Promise<StreamInfoFetchResult>((resolve) => (resolveSlow = resolve)),
     );
 
-    clearStreamInfo();
-    await loadStreamInfo("newchannel", async () => 更新後の配信情報);
-    resolveFetch({ status: "offline" });
-    await refreshing;
+    // 後から始めたリフレッシュが先に完了して最新の情報を反映する
+    await refreshStreamInfo(live(更新後の配信情報));
+    // 遅れて届いた古いスナップショットは最新の情報を上書きしない
+    resolveSlow({ status: "live", info: FAKE_STREAM_INFO });
+    await slowRefreshing;
 
     expect(getStreamInfo()).toEqual(更新後の配信情報);
   });
@@ -200,11 +244,23 @@ describe("startStreamInfoRefresh / stopStreamInfoRefresh", () => {
 
 describe("clearStreamInfo", () => {
   it("読み込み済みの配信情報を破棄して null に戻す", async () => {
-    await loadStreamInfo("zackrawrr", async () => FAKE_STREAM_INFO);
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
 
     clearStreamInfo();
 
     expect(getStreamInfo()).toBeNull();
     expect(useStreamInfoStore.getState().streamInfo).toBeNull();
+  });
+
+  it("offline の連続カウントもリセットする(前チャンネルの offline を新チャンネルに持ち越さない)", async () => {
+    await loadStreamInfo("zackrawrr", live(FAKE_STREAM_INFO));
+    await refreshStreamInfo(async () => ({ status: "offline" }));
+
+    clearStreamInfo();
+    await loadStreamInfo("newchannel", live(更新後の配信情報));
+    await refreshStreamInfo(async () => ({ status: "offline" }));
+
+    // 新チャンネルでは offline 1回目のため、まだクリアしない
+    expect(getStreamInfo()).toEqual(更新後の配信情報);
   });
 });

--- a/src/store/stream-info.ts
+++ b/src/store/stream-info.ts
@@ -14,9 +14,19 @@
  *   文脈なしの現行プロンプトで動作する(意図したフォールバック)
  * - チャンネル切り替え(`connect()`)・切断時は `clearStreamInfo` で破棄し、
  *   読み込み途中だった前チャンネルの結果は世代番号の比較で捨てる
+ * - 接続中は定期リフレッシュ(issue #85)で視聴者数・タイトル・カテゴリの変化と
+ *   配信終了(オフライン → クリア)に追従する。API 失敗時は既存の情報を保持する
  */
 import { create } from "zustand";
-import { fetchStreamInfo, type StreamInfo } from "@/lib/twitch/stream-info";
+import {
+  fetchStreamInfo,
+  fetchStreamInfoResult,
+  type StreamInfo,
+  type StreamInfoFetchResult,
+} from "@/lib/twitch/stream-info";
+
+/** 定期リフレッシュ(issue #85)の実行間隔。視聴者数・カテゴリの変化をこの間隔で追従する */
+const STREAM_INFO_REFRESH_INTERVAL_MS = 60_000;
 
 interface StreamInfoState {
   /** 接続中チャンネルの配信情報。未読み込み・オフライン・取得失敗時は null(文脈なしで動作) */
@@ -51,13 +61,61 @@ export async function loadStreamInfo(
   useStreamInfoStore.setState({ streamInfo: info });
 }
 
+/**
+ * 保持中の配信情報を最新の取得結果で更新する(定期リフレッシュ。issue #85)。
+ *
+ * - live: 配信情報を置き換える(視聴者数・タイトル・カテゴリの変化を反映する)
+ * - offline: 配信情報をクリアする(配信終了後にライブ風の視聴者数を残さない)
+ * - unavailable(API 失敗): 既存の配信情報を保持する(リフレッシュの失敗で文脈を失わない)
+ *
+ * 世代番号は進めず取得開始時点の値を控えるだけとし、取得中にチャンネル切り替え・切断
+ * (= クリア・読み込み開始で世代が進む)があった場合は、遅れて届いた結果を破棄する。
+ */
+export async function refreshStreamInfo(fetchResult: () => Promise<StreamInfoFetchResult>): Promise<void> {
+  const requestGeneration = generation;
+
+  const result = await fetchResult();
+
+  if (generation !== requestGeneration) return;
+  if (result.status === "unavailable") return;
+  useStreamInfoStore.setState({ streamInfo: result.status === "live" ? result.info : null });
+}
+
+/** 定期リフレッシュのタイマー。未開始・停止中は null */
+let refreshTimer: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * 指定したチャンネル(正規化済みの user_login)の配信情報の定期リフレッシュを開始する。
+ * `chat-connection.ts` の connect() から呼ぶ。既に動いているタイマーがあれば止めて
+ * 新しいチャンネルで開始する(チャンネル切り替え)。初回の取得は `loadStreamInfo` が
+ * 担うため、ここでは1周期後から更新を始める。
+ */
+export function startStreamInfoRefresh(
+  channelLogin: string,
+  fetchResult: (userLogin: string) => Promise<StreamInfoFetchResult> = fetchStreamInfoResult,
+): void {
+  stopStreamInfoRefresh();
+  refreshTimer = setInterval(() => {
+    void refreshStreamInfo(() => fetchResult(channelLogin));
+  }, STREAM_INFO_REFRESH_INTERVAL_MS);
+}
+
+/** 配信情報の定期リフレッシュを停止する。`chat-connection.ts` の disconnect() から呼ぶ */
+export function stopStreamInfoRefresh(): void {
+  if (refreshTimer !== null) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
 /** 配信情報を破棄して null に戻す。チャンネル切り替え・切断時に呼ぶ */
 export function clearStreamInfo(): void {
   generation += 1;
   useStreamInfoStore.setState({ streamInfo: null });
 }
 
-/** テスト専用: モジュールスコープの状態を初期状態に戻す。各テストの afterEach で呼び出すこと */
+/** テスト専用: モジュールスコープの状態(保持中の配信情報・定期リフレッシュのタイマー)を初期状態に戻す。各テストの afterEach で呼び出すこと */
 export function resetStreamInfoForTests(): void {
+  stopStreamInfoRefresh();
   clearStreamInfo();
 }

--- a/src/store/stream-info.ts
+++ b/src/store/stream-info.ts
@@ -15,18 +15,24 @@
  * - チャンネル切り替え(`connect()`)・切断時は `clearStreamInfo` で破棄し、
  *   読み込み途中だった前チャンネルの結果は世代番号の比較で捨てる
  * - 接続中は定期リフレッシュ(issue #85)で視聴者数・タイトル・カテゴリの変化と
- *   配信終了(オフライン → クリア)に追従する。API 失敗時は既存の情報を保持する
+ *   配信終了(オフラインを連続で確認したらクリア)に追従する。API 失敗時は既存の情報を保持する
  */
 import { create } from "zustand";
-import {
-  fetchStreamInfo,
-  fetchStreamInfoResult,
-  type StreamInfo,
-  type StreamInfoFetchResult,
-} from "@/lib/twitch/stream-info";
+import { fetchStreamInfoResult, type StreamInfo, type StreamInfoFetchResult } from "@/lib/twitch/stream-info";
 
 /** 定期リフレッシュ(issue #85)の実行間隔。視聴者数・カテゴリの変化をこの間隔で追従する */
 const STREAM_INFO_REFRESH_INTERVAL_MS = 60_000;
+
+/**
+ * offline(配信終了)と判断して配信情報をクリアするまでに必要な連続 offline 回数。
+ * Helix Get Streams は配信中でも一時的に空の data を返すことがあり(配信開始直後・
+ * レプリケーション遅延)、1回で即クリアするとパイプラインが2回全再起動されて
+ * 生成済みの翻訳をすべて失うため、連続で確認してからクリアする
+ */
+const OFFLINE_CONFIRMATION_COUNT = 2;
+
+/** offline の連続回数。live の取得成功・チャンネル切り替え(クリア)でリセットする */
+let consecutiveOfflineCount = 0;
 
 interface StreamInfoState {
   /** 接続中チャンネルの配信情報。未読み込み・オフライン・取得失敗時は null(文脈なしで動作) */
@@ -45,40 +51,59 @@ export function getStreamInfo(): StreamInfo | null {
 
 /**
  * 指定したチャンネル(正規化済みの user_login)の配信情報を読み込む。
- * 読み込み中にチャンネルが切り替わった場合(クリア・別チャンネルの読み込み開始)は、
- * 遅れて届いた結果を破棄する。取得できない場合は null のまま(文脈なしで動作する)。
+ * `chat-connection.ts` の connect() から初回読み込みとして呼ぶ(取得失敗時は警告を出す)。
+ * 更新の判定・世代ガードは `refreshStreamInfo` に委譲する。
  */
 export async function loadStreamInfo(
   channelLogin: string,
-  fetchInfo: (userLogin: string) => Promise<StreamInfo | null> = fetchStreamInfo,
+  fetchResult: (userLogin: string) => Promise<StreamInfoFetchResult> = (userLogin) =>
+    fetchStreamInfoResult(userLogin, fetch, { subject: "配信情報", fallback: "文脈なしで動作します" }),
 ): Promise<void> {
-  const requestGeneration = ++generation;
+  await refreshStreamInfo(() => fetchResult(channelLogin));
+}
 
-  const info = await fetchInfo(channelLogin);
-
-  if (generation !== requestGeneration) return;
-  if (info === null) return;
-  useStreamInfoStore.setState({ streamInfo: info });
+/** 2つの配信情報の内容が同じかを比較する。同じ場合は setState を省き、無駄な再レンダリングを避ける */
+function isSameStreamInfo(a: StreamInfo | null, b: StreamInfo): boolean {
+  return (
+    a !== null &&
+    a.title === b.title &&
+    a.category === b.category &&
+    a.broadcasterId === b.broadcasterId &&
+    a.broadcasterLogin === b.broadcasterLogin &&
+    a.broadcasterName === b.broadcasterName &&
+    a.gameId === b.gameId &&
+    a.viewerCount === b.viewerCount
+  );
 }
 
 /**
- * 保持中の配信情報を最新の取得結果で更新する(定期リフレッシュ。issue #85)。
+ * 保持中の配信情報を最新の取得結果で更新する(初回読み込み・定期リフレッシュ共通。issue #85)。
  *
- * - live: 配信情報を置き換える(視聴者数・タイトル・カテゴリの変化を反映する)
- * - offline: 配信情報をクリアする(配信終了後にライブ風の視聴者数を残さない)
+ * - live: 配信情報を置き換える(視聴者数・タイトル・カテゴリの変化を反映する)。
+ *   内容が前回と同一なら更新しない(60秒ごとの無駄な再レンダリングを避ける)
+ * - offline: 連続 OFFLINE_CONFIRMATION_COUNT 回で配信情報をクリアする
+ *   (配信終了後にライブ風の視聴者数を残さない。1回では Helix の一時的な空レスポンスの可能性があるため保持)
  * - unavailable(API 失敗): 既存の配信情報を保持する(リフレッシュの失敗で文脈を失わない)
  *
- * 世代番号は進めず取得開始時点の値を控えるだけとし、取得中にチャンネル切り替え・切断
- * (= クリア・読み込み開始で世代が進む)があった場合は、遅れて届いた結果を破棄する。
+ * リクエストごとに世代番号を採番し、取得中にチャンネル切り替え・切断・後続リクエストの開始が
+ * あった場合(= 世代が進んだ場合)は、遅れて届いた結果を破棄する(古い結果による上書きを防ぐ)。
  */
 export async function refreshStreamInfo(fetchResult: () => Promise<StreamInfoFetchResult>): Promise<void> {
-  const requestGeneration = generation;
+  const requestGeneration = ++generation;
 
   const result = await fetchResult();
 
   if (generation !== requestGeneration) return;
   if (result.status === "unavailable") return;
-  useStreamInfoStore.setState({ streamInfo: result.status === "live" ? result.info : null });
+  if (result.status === "offline") {
+    consecutiveOfflineCount += 1;
+    if (consecutiveOfflineCount < OFFLINE_CONFIRMATION_COUNT) return;
+    if (useStreamInfoStore.getState().streamInfo !== null) useStreamInfoStore.setState({ streamInfo: null });
+    return;
+  }
+  consecutiveOfflineCount = 0;
+  if (isSameStreamInfo(useStreamInfoStore.getState().streamInfo, result.info)) return;
+  useStreamInfoStore.setState({ streamInfo: result.info });
 }
 
 /** 定期リフレッシュのタイマー。未開始・停止中は null */
@@ -111,6 +136,8 @@ export function stopStreamInfoRefresh(): void {
 /** 配信情報を破棄して null に戻す。チャンネル切り替え・切断時に呼ぶ */
 export function clearStreamInfo(): void {
   generation += 1;
+  // 前チャンネルの offline 連続回数を新チャンネルに持ち越さない
+  consecutiveOfflineCount = 0;
   useStreamInfoStore.setState({ streamInfo: null });
 }
 


### PR DESCRIPTION
## Summary

接続時に一度だけ取得していた配信情報(タイトル・カテゴリ・視聴者数)を、接続中は60秒間隔で再取得して視聴者数バッジ・タイトル・カテゴリの変化と配信終了に追従するようにします。

## 変更内容

### 定期リフレッシュの導入
- `src/lib/twitch/stream-info.ts` に `fetchStreamInfoResult` を追加し、取得結果を **live / offline(配信終了) / unavailable(API失敗)** のステータス付きで返すようにしました。オフラインと取得失敗を区別するために必要です
- `src/store/stream-info.ts` に `refreshStreamInfo` / `startStreamInfoRefresh` / `stopStreamInfoRefresh` を追加し、`chat-connection.ts` の `connect()` で開始・`disconnect()` で停止します
- `loadStreamInfo`(初回読み込み)は `refreshStreamInfo` へ委譲し、旧 `fetchStreamInfo` は削除しました(重複排除)

### リフレッシュ時の判定
- **live**: 配信情報を更新します。内容が前回と同一の場合は setState を省略し、60秒ごとの無駄な再レンダリングを避けます
- **offline**: **2回連続**で確認してから `streamInfo` をクリアします(Helix Get Streams が配信中に一時的に空の data を返すことがあり、1回で即クリアするとパイプラインが2回全再起動されて生成済みの翻訳を失うため)。200 だが形式不正なボディは unavailable に分類し、配信終了と誤判定しません
- **unavailable**: 既存の配信情報を保持し、静かに動作を継続します。リフレッシュ経路では console.warn を出しません(障害中に毎分警告を出さないため。初回読み込みのみ警告)

### issue の実装時の注意点への対応
- **パイプラインの不要な再起動を避ける**: `streamInfoPromptKey`(プロンプトに焼き込む title / category / broadcasterLogin / broadcasterName のみのキー)を導入し、`page.tsx` の `streamInfoKey` と `manual-pickups.ts` のセッションプールキーを統一しました。viewerCount だけの変化ではパイプライン再起動もプール再生成も発生しません
- **世代番号との整合**: `refreshStreamInfo` もリクエストごとに世代番号を採番し、チャンネル切り替え・切断・リクエスト同士の追い越しで遅れて届いた結果を破棄します

## テスト

- `npm run lint` / `npm run type-check` / `npm test`(815件) / `npm run build` すべて成功
- CodeRabbit はレートリミットのため `/code-review`(high)で代替実施しました。CONFIRMED 6件・PLAUSIBLE 1件のうち6件に対応済み(偽offline・manual-pickupsプールキー・世代競合・再レンダリング・warn連発・重複排除)。残る PLAUSIBLE 1件(タイマーのライフサイクルを呼び出し規約でなく stream-info.ts 内に集約する案)は、現行の呼び出しパスに不具合がなく将来の仮定的なリスクのため見送りました

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)