### PR TITLE
feat: UIをTwitchライクなダークファーストデザインに刷新する

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,9 +9,12 @@
   --color-foreground: var(--foreground);
   /* ライブ配信の指標(視聴者数など)を強調する Twitch 風の赤。text-live 等で使う */
   --color-live: var(--live);
+  /* Pick up 語句の強調用ゴールド(issue #87)。text-pickup / decoration-pickup 等で使う */
+  --color-pickup: var(--pickup);
   --font-sans: var(--font-sans);
   --font-mono: var(--font-geist-mono);
-  --font-heading: var(--font-sans);
+  /* 見出しは Sora(layout.tsx の next/font が --font-sora を注入する) */
+  --font-heading: var(--font-sora);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -50,77 +53,89 @@
   --radius-4xl: calc(var(--radius) * 2.6);
 }
 
+/*
+ * Twitch ライクなダークファーストのパレット(issue #87)。
+ * 紫みを帯びたダークグレー基調で配信embedと地続きの没入感を作る。
+ * - Ground   oklch(0.166 0.01 285.21)  ページ背景
+ * - Surface  oklch(0.208 0.016 284.95) カード・3カラムの列
+ * - Elevated oklch(0.24 0.021 284.72)  ポップオーバー等の浮き面
+ * - Violet   oklch(0.709 0.159 293.54) インタラクティブ要素のアクセント
+ * - Gold     oklch(0.824 0.141 70.17)  Pick up 語句の強調(--pickup)
+ * ダークを基準とするため :root と .dark は同じ値を持つ(ライトテーマの調整は別issue)。
+ */
 :root {
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  /* ライトテーマの白背景で WCAG AA(4.5:1)を満たす赤 */
-  --live: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
+  --background: oklch(0.166 0.01 285.21);
+  --foreground: oklch(0.954 0.007 286.27);
+  --card: oklch(0.208 0.016 284.95);
+  --card-foreground: oklch(0.954 0.007 286.27);
+  --popover: oklch(0.24 0.021 284.72);
+  --popover-foreground: oklch(0.954 0.007 286.27);
+  --primary: oklch(0.709 0.159 293.54);
+  --primary-foreground: oklch(0.166 0.01 285.21);
+  --secondary: oklch(0.24 0.021 284.72);
+  --secondary-foreground: oklch(0.954 0.007 286.27);
+  --muted: oklch(0.24 0.021 284.72);
+  --muted-foreground: oklch(0.684 0.025 293.83);
+  --accent: oklch(0.24 0.021 284.72);
+  --accent-foreground: oklch(0.954 0.007 286.27);
+  --destructive: oklch(0.704 0.191 22.216);
+  /* ダークの背景でも読める明るめの赤(視聴者数などのライブ指標用) */
+  --live: oklch(0.704 0.191 22.216);
+  /* Pick up 語句の強調用ゴールド。「チャットから拾い上げた語彙」を目立たせる */
+  --pickup: oklch(0.824 0.141 70.17);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.709 0.159 293.54);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --radius: 0.5rem;
+  --sidebar: oklch(0.208 0.016 284.95);
+  --sidebar-foreground: oklch(0.954 0.007 286.27);
+  --sidebar-primary: oklch(0.709 0.159 293.54);
+  --sidebar-primary-foreground: oklch(0.166 0.01 285.21);
+  --sidebar-accent: oklch(0.24 0.021 284.72);
+  --sidebar-accent-foreground: oklch(0.954 0.007 286.27);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --sidebar-ring: oklch(0.709 0.159 293.54);
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
+  --background: oklch(0.166 0.01 285.21);
+  --foreground: oklch(0.954 0.007 286.27);
+  --card: oklch(0.208 0.016 284.95);
+  --card-foreground: oklch(0.954 0.007 286.27);
+  --popover: oklch(0.24 0.021 284.72);
+  --popover-foreground: oklch(0.954 0.007 286.27);
+  --primary: oklch(0.709 0.159 293.54);
+  --primary-foreground: oklch(0.166 0.01 285.21);
+  --secondary: oklch(0.24 0.021 284.72);
+  --secondary-foreground: oklch(0.954 0.007 286.27);
+  --muted: oklch(0.24 0.021 284.72);
+  --muted-foreground: oklch(0.684 0.025 293.83);
+  --accent: oklch(0.24 0.021 284.72);
+  --accent-foreground: oklch(0.954 0.007 286.27);
   --destructive: oklch(0.704 0.191 22.216);
-  /* ダークテーマの暗い背景でも読める明るめの赤 */
   --live: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+  --pickup: oklch(0.824 0.141 70.17);
+  --border: oklch(1 0 0 / 8%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.709 0.159 293.54);
   --chart-1: oklch(0.87 0 0);
   --chart-2: oklch(0.556 0 0);
   --chart-3: oklch(0.439 0 0);
   --chart-4: oklch(0.371 0 0);
   --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --sidebar: oklch(0.208 0.016 284.95);
+  --sidebar-foreground: oklch(0.954 0.007 286.27);
+  --sidebar-primary: oklch(0.709 0.159 293.54);
+  --sidebar-primary-foreground: oklch(0.166 0.01 285.21);
+  --sidebar-accent: oklch(0.24 0.021 284.72);
+  --sidebar-accent-foreground: oklch(0.954 0.007 286.27);
+  --sidebar-border: oklch(1 0 0 / 8%);
+  --sidebar-ring: oklch(0.709 0.159 293.54);
 }
 
 @layer base {

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -1,0 +1,59 @@
+/**
+ * src/app/globals.css のデザイントークンのテスト(issue #87)。
+ *
+ * Twitch ライクなダークファーストのデザイントークンが定義されていることを、
+ * CSS ファイルのテキストとして検証する(jsdom は CSS カスタムプロパティの
+ * カスケードを解決しないため、ファイル内容ベースで仕様を固定する)。
+ *
+ * - `:root` が紫みを帯びたダークパレット(Ground / Surface / Violet)を持つこと
+ * - Pick up 語句の強調用トークン `--pickup`(ゴールド)が定義され、
+ *   Tailwind のユーティリティ(text-pickup 等)として使えるよう @theme に対応付くこと
+ * - 角丸が小さめ(0.5rem)に調整されていること
+ * - 見出しフォントが Sora(--font-sora。layout.tsx で next/font が注入する)に対応付くこと
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(join(process.cwd(), "src/app/globals.css"), "utf8");
+
+/** `:root { ... }` ブロックの中身だけを取り出す(`.dark` ブロックと区別して検証するため) */
+function rootBlock(): string {
+  const match = css.match(/:root \{([^}]*)\}/);
+  if (match === null) throw new Error("globals.css に :root ブロックがありません");
+  return match[1];
+}
+
+describe("globals.css のデザイントークン(Twitch ライクなダークファースト)", () => {
+  it(":root の背景が紫みを帯びたダーク(Ground)である", () => {
+    expect(rootBlock()).toContain("--background: oklch(0.166 0.01 285.21)");
+  });
+
+  it(":root のカード面が Ground より一段明るい Surface である", () => {
+    expect(rootBlock()).toContain("--card: oklch(0.208 0.016 284.95)");
+  });
+
+  it(":root のプライマリがバイオレットのアクセントである", () => {
+    expect(rootBlock()).toContain("--primary: oklch(0.709 0.159 293.54)");
+  });
+
+  it(":root に Pick up 語句の強調用トークン --pickup(ゴールド)が定義されている", () => {
+    expect(rootBlock()).toContain("--pickup: oklch(0.824 0.141 70.17)");
+  });
+
+  it("--pickup が Tailwind のカラーとして使えるよう @theme に対応付いている", () => {
+    expect(css).toContain("--color-pickup: var(--pickup)");
+  });
+
+  it("角丸が小さめ(0.5rem)に調整されている", () => {
+    expect(rootBlock()).toContain("--radius: 0.5rem");
+  });
+
+  it("見出しフォントが Sora(--font-sora)に対応付いている", () => {
+    expect(css).toContain("--font-heading: var(--font-sora)");
+  });
+
+  it("視聴者数などの --live トークンがダーク背景で読める明るめの赤のまま維持されている", () => {
+    expect(rootBlock()).toContain("--live: oklch(0.704 0.191 22.216)");
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist, Geist_Mono, Sora } from "next/font/google";
 import { SiteHeader } from "@/components/site-header";
 import "./globals.css";
 
@@ -10,6 +10,12 @@ const geistSans = Geist({
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
+
+// 見出し用フォント(issue #87)。globals.css の --font-heading が参照する
+const sora = Sora({
+  variable: "--font-sora",
   subsets: ["latin"],
 });
 
@@ -27,7 +33,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${geistSans.variable} ${geistMono.variable} ${sora.variable} h-full antialiased`}
     >
       {/* 接続中の画面(embed + 3カラム)をビューポート1ページに収めるため、高さを固定して内部スクロールに任せる */}
       <body className="flex h-dvh flex-col overflow-hidden">

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -431,6 +431,19 @@ describe("Home(Pick up列)", () => {
     expect(rows[1]).toHaveTextContent("激しく同意");
   });
 
+  it("語句(dt)はゴールドの強調色(text-pickup)で表示する(issue #87)", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: { "msg-1": { status: "done", terms: [{ term: "gg", meaning: "good game の略、お疲れ" }] } },
+    });
+
+    render(<Home />);
+
+    // 「チャットから拾い上げた語彙」が目に留まるよう、語句だけをゴールドで強調する
+    const term = within(screen.getByRole("region", { name: "Pick up" })).getByText("gg");
+    expect(term.className).toContain("text-pickup");
+  });
+
   it("該当する表現が無い行は、行自体は描画しつつ中身を空にする(「None」を出さない)", () => {
     useChatConnectionStore.setState({ messages: [サンプル発言] });
     usePickupStore.setState({ entries: { "msg-1": { status: "done", terms: [] } } });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -417,7 +417,8 @@ function Column({
     >
       <div className="sticky top-0 z-10 border-b bg-card px-4 py-2">
         <div className="flex items-center justify-between gap-2">
-          <h2 className="text-sm font-semibold">{title}</h2>
+          {/* 列見出しは小さめ + わずかな letter-spacing で引き締める(issue #87) */}
+          <h2 className="font-heading text-xs font-semibold tracking-wide">{title}</h2>
           <div className="flex items-center gap-1">{headerAction}</div>
         </div>
         {headerExtra}
@@ -566,7 +567,9 @@ function PickupTermRow({
 }) {
   return (
     <div className="group/term flex flex-wrap items-baseline gap-x-2">
-      <dt className="font-semibold">
+      {/* 「チャットから拾い上げた語彙」が目に留まるよう、語句をゴールド + 破線下線で強調する(issue #87)。
+          破線下線は inline-flex の削除ボタンには波及しない */}
+      <dt className="font-semibold text-pickup underline decoration-dashed decoration-pickup/50 underline-offset-4">
         {term}
         <Button
           variant="ghost"

--- a/src/components/site-header.test.tsx
+++ b/src/components/site-header.test.tsx
@@ -40,4 +40,11 @@ describe("SiteHeader", () => {
 
     expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();
   });
+
+  it("ヘッダーは Surface 色(bg-card)で描画し、配信embedと地続きに見せる(issue #87)", () => {
+    render(<SiteHeader />);
+
+    const header = screen.getByRole("banner");
+    expect(header.className).toContain("bg-card");
+  });
 });

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -12,7 +12,8 @@ import { SettingsDialog } from "@/components/settings-dialog";
 
 export function SiteHeader() {
   return (
-    <header className="border-b bg-background">
+    // Surface 色で配信embedと地続きに見せる(issue #87)
+    <header className="border-b bg-card">
       <nav className="mx-auto flex w-full items-center justify-between gap-4 px-6 py-2">
         <Link href="/" className="font-heading text-lg font-semibold">
           chat-sensei


### PR DESCRIPTION
## Summary

UIを shadcn/ui デフォルトのグレースケールから、Twitch ライクなダークファーストのデザインに刷新します(issue #87)。

- **カラートークン(`src/app/globals.css`)**: 紫みを帯びたダークグレー基調(Ground / Surface / Elevated の3段)+バイオレットのアクセント(primary)に差し替えました。Pick up 語句の強調用に `--pickup`(ゴールド)のセマンティックトークンを新設し、`@theme` に `--color-pickup` として対応付けて Tailwind ユーティリティ(`text-pickup` 等)から使えるようにしています。既存の `--live`(視聴者数の赤)はダーク背景で読める明るめの赤を維持します。ダークを基準とするため `:root` と `.dark` は同値で、ライトテーマの調整は別issueとします
- **角丸**: `--radius` を 0.625rem から 0.5rem に縮小しました
- **タイポグラフィ**: 見出しフォントに Sora を追加し(`layout.tsx` の next/font で `--font-sora` を注入)、`--font-heading` から参照します。3カラムの列見出しは小さめサイズ + `tracking-wide` で引き締めました
- **ヘッダー**: `bg-background` から Surface 色(`bg-card`)に変更し、配信embedと地続きに見せます
- **Pick up 語句**: 語句(`dt`)をゴールド + 破線下線で強調し、「チャットから拾い上げた語彙」が目に留まるようにしました(破線下線は inline-flex の削除ボタンには波及しません)

## Test plan

- [x] `npm test`(825件すべてパス。globals.css のトークン仕様テストを新規追加し、RED → GREEN を確認)
- [x] `npm run lint` / `npm run type-check` / `npm run build`
- [x] ブラウザで未接続画面・接続中画面(embed + 3カラム)のダークテーマ適用を目視確認
- [x] CodeRabbit レビュー実施(指摘 0 件)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)
