### PR TITLE
feat: チャンネル検索をnavbar中央に置き、トップをウェルカムページ化する

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1061,20 +1061,37 @@ describe("Home(手動Pick up。issue #72)", () => {
   });
 });
 
-describe("Home(未接続の接続画面)", () => {
+describe("Home(未接続のウェルカム画面)", () => {
   beforeEach(() => {
     useChatConnectionStore.setState({ connectionState: "idle", channel: null });
   });
 
-  it("チャンネル入力と Connect ボタンの接続画面を表示し、3カラムと配信embedは表示しない", () => {
+  it("アプリ名の見出しと、チャンネル入力 + Connect ボタンを表示し、3カラムと配信embedは表示しない", () => {
     render(<Home />);
 
+    expect(screen.getByRole("heading", { level: 1, name: "chat-sensei" })).toBeInTheDocument();
     expect(screen.getByLabelText("Channel")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Raw Chat" })).not.toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Translation" })).not.toBeInTheDocument();
     expect(screen.queryByRole("region", { name: "Pick up" })).not.toBeInTheDocument();
     expect(screen.queryByTitle(/Twitch player/)).not.toBeInTheDocument();
+  });
+
+  it("言語ペアのセレクト(学ぶ言語 / 解説言語)を表示する(未接続時はヘッダーが無いため、この画面に置く)", () => {
+    render(<Home />);
+
+    expect(screen.getByRole("combobox", { name: "Learning language" })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: "Explanation language" })).toBeInTheDocument();
+  });
+
+  it("AIモデル設定(設定ダイアログ)を開くラベル付きボタンを表示する", async () => {
+    const user = userEvent.setup();
+    render(<Home />);
+
+    // ダイアログを開くと LLM プロバイダ(AIモデル)の設定セクションが表示される
+    await user.click(screen.getByRole("button", { name: "AI model settings" }));
+    expect(screen.getByRole("region", { name: "LLM provider settings" })).toBeInTheDocument();
   });
 
   it("接続状態(Status)を表示する", () => {
@@ -1084,7 +1101,7 @@ describe("Home(未接続の接続画面)", () => {
     expect(screen.getByText("Idle")).toBeInTheDocument();
   });
 
-  it("切断(closed)後も接続画面に戻る", () => {
+  it("切断(closed)後もウェルカム画面に戻る", () => {
     useChatConnectionStore.setState({ connectionState: "closed" });
 
     render(<Home />);

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,9 @@
 /**
  * ホームページ(/)。接続状態で画面が切り替わる。
  *
- * - 未接続(idle / closed): 画面中央にチャンネル入力と Connect ボタンの接続画面を表示する
+ * - 未接続(idle / closed): ヘッダーなしのウェルカム画面を表示する。アプリ名とタグラインの下に
+ *   チャンネル検索(ChannelSearchForm の hero バリアント)、言語ペアのセレクト、
+ *   AIモデル設定(SettingsDialog のラベル付きトリガー)を縦に並べる
  * - 接続中(connecting / open / reconnecting): 上半分に配信embed(TwitchEmbedPlayer)と
  *   配信者情報パネル(StreamInfoPanel)、下半分に3カラムのチャット閲覧領域を表示する。
  *   全体がビューポート1ページに収まり(レイアウト側で高さを固定)、3カラム領域は
@@ -23,8 +25,8 @@
  * Raw Chat列の見出しには、新着発言に合わせてスクロール領域を最下部へ送り続ける追従トグル(FollowToggle。
  * 初期状態はオンで、利用者が上へスクロールして最下部から離れると自動でオフになる)と、
  * bot除外設定(BotFilterDialog)を開くアイコンを置く。
- * 言語ペア(学ぶ言語 / 解説言語)のセレクトと設定ダイアログは、接続前後のどちらの画面でも
- * 触れるようヘッダー(SiteHeader)に常時表示する(このページには置かない)。除外パターンは
+ * 言語ペア(学ぶ言語 / 解説言語)のセレクトと設定ダイアログは、未接続時はこのページの
+ * ウェルカム画面に、接続中はヘッダー(SiteHeader)に表示する。除外パターンは
  * bot-filter ストアが LocalStorage から復元し、chat-connection ストアが受信時に適用する。
  * 接続状態・受信済み発言はモジュールスコープのストア(chat-connection.ts)が、
  * 翻訳結果は translations ストアが、抽出結果は pickups ストアが保持し、
@@ -46,20 +48,20 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronsDownIcon, EyeIcon, EyeOffIcon, XIcon } from "lucide-react";
 import { BotFilterDialog } from "@/components/bot-filter-dialog";
 import { ManualPickupOverlay, MESSAGE_TEXT_ATTRIBUTE, RAW_IRC_COLUMN_NAME } from "@/components/manual-pickup";
-import { ChannelAutocompleteInput } from "@/components/channel-autocomplete";
-import { CONNECTION_STATE_LABEL, StreamInfoPanel } from "@/components/stream-info-panel";
+import { ChannelSearchForm } from "@/components/channel-search-form";
+import { LanguagePairSelect } from "@/components/language-pair-select";
+import { SettingsDialog } from "@/components/settings-dialog";
+import { StreamInfoPanel } from "@/components/stream-info-panel";
 import { TwitchEmbedPlayer } from "@/components/twitch-embed-player";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
-import type { ConnectionState } from "@/lib/twitch/irc-client";
 import type { TwitchChatMessage } from "@/lib/twitch/irc-parser";
 import { buildEmoteImageUrl, splitMessageIntoSegments, type MessageSegment } from "@/lib/twitch/emotes";
 import { useAvatarStore } from "@/store/avatars";
 import { useBadgeStore } from "@/store/badges";
 import { hydrateBotFilterStore } from "@/store/bot-filter";
-import { useChatConnectionStore } from "@/store/chat-connection";
+import { isConnectingOrConnected, useChatConnectionStore } from "@/store/chat-connection";
 import type { PipelineEntry } from "@/store/auto-pipeline";
 import { hidePickupTerm, isPickupTermHidden, useHiddenPickupStore } from "@/store/hidden-pickups";
 import { announcePickupRemoval, usePickupAnnouncementStore } from "@/store/pickup-announcements";
@@ -105,17 +107,10 @@ const PICKUP_LABELS: PipelineCellLabels = {
 /** 最下部からこの距離(px)を超えて上へスクロールしたら、新着への追従を自動でオフにする(サブピクセル誤差の吸収用) */
 const FOLLOW_RELEASE_THRESHOLD_PX = 4;
 
-/** 接続中とみなす状態(切断ボタンに切り替える基準) */
-function isConnectingOrConnected(state: ConnectionState): boolean {
-  return state === "connecting" || state === "open" || state === "reconnecting";
-}
-
 export default function Home() {
-  const [channelInput, setChannelInput] = useState("");
   const connectionState = useChatConnectionStore((state) => state.connectionState);
   const messages = useChatConnectionStore((state) => state.messages);
   const channel = useChatConnectionStore((state) => state.channel);
-  const connect = useChatConnectionStore((state) => state.connect);
 
   // 翻訳列・Pick up列のぼかし。初期状態はどちらも見える(自力で読みたいときに利用者がぼかす)
   const [translationBlurred, setTranslationBlurred] = useState(false);
@@ -191,15 +186,6 @@ export default function Home() {
     return stop;
   }, [settingsHydrated, settingsKey, streamInfoKey]);
 
-  const handleConnect = useCallback(() => {
-    const channel = channelInput.trim();
-    if (!channel) return;
-    // モデル未ダウンロード時の LanguageModel.create() にはユーザー操作が必要なため、クリックの延長で先に生成する
-    warmUpTranslationPipeline();
-    warmUpPickupPipeline();
-    connect(channel);
-  }, [channelInput, connect]);
-
   const connected = isConnectingOrConnected(connectionState);
 
   // Raw Chat列の範囲選択から手動Pick up(issue #72)。選択した語句の意味を、発言本文を文脈として生成する
@@ -213,24 +199,21 @@ export default function Home() {
   return (
     <div className="flex min-h-0 w-full flex-1 flex-col gap-4 p-4">
       {!connected ? (
-        // 未接続: 画面中央の接続画面(3カラム・配信embedは表示しない)
+        // 未接続: ヘッダーなしのウェルカム画面。アプリ名 + タグラインの下にチャンネル検索を置き、
+        // 言語ペア・AIモデルの設定もこの画面から触れるようにする(接続中はヘッダーに移る)
         <div className="flex flex-1 items-center justify-center">
-          <div className="flex w-full max-w-sm flex-col gap-1.5">
-            <Label htmlFor="channel-input">Channel</Label>
-            <div className="flex items-center gap-2">
-              <ChannelAutocompleteInput
-                id="channel-input"
-                placeholder="e.g. zackrawrr"
-                value={channelInput}
-                onValueChange={setChannelInput}
-              />
-              <Button onClick={handleConnect} disabled={channelInput.trim().length === 0}>
-                Connect
-              </Button>
+          <div className="flex w-full max-w-md flex-col items-center gap-10">
+            <div className="flex flex-col items-center gap-3 text-center">
+              <h1 className="font-heading text-4xl font-semibold tracking-tight">chat-sensei</h1>
+              <p className="text-sm text-muted-foreground">
+                Learn a language from live Twitch chat — translated and explained as it flows.
+              </p>
             </div>
-            <p className="text-xs text-muted-foreground" role="status">
-              Status: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
-            </p>
+            <ChannelSearchForm variant="hero" />
+            <div className="flex flex-col items-center gap-3">
+              <LanguagePairSelect />
+              <SettingsDialog triggerLabel="AI model settings" />
+            </div>
           </div>
         </div>
       ) : (

--- a/src/components/channel-autocomplete.test.tsx
+++ b/src/components/channel-autocomplete.test.tsx
@@ -201,4 +201,42 @@ describe("ChannelAutocompleteInput", () => {
     expect(screen.queryByRole("listbox")).toBeNull();
     expect(fetchSuggestions).toHaveBeenCalledTimes(1);
   });
+
+  it("親が value を外部から空にした場合(接続フォームの送信後クリアなど)もドロップダウンを閉じる", async () => {
+    // 入力欄の change イベントを経由せずに、親コンポーネントが value を直接空へ更新するケース。
+    // ヘッダーのチャンネル検索(channel-search-form.tsx)が送信後に入力をクリアしたとき、
+    // 開いたままの候補ドロップダウンが残らないことを検証する
+    function ClearableInput({
+      fetchSuggestions,
+    }: {
+      fetchSuggestions: (query: string, options: { signal?: AbortSignal }) => Promise<ChannelSuggestion[] | null>;
+    }) {
+      const [value, setValue] = useState("");
+      return (
+        <>
+          <ChannelAutocompleteInput
+            id="channel-input"
+            aria-label="Channel"
+            value={value}
+            onValueChange={setValue}
+            fetchSuggestions={fetchSuggestions}
+          />
+          <button type="button" onClick={() => setValue("")}>
+            クリア
+          </button>
+        </>
+      );
+    }
+    const fetchSuggestions = vi.fn().mockResolvedValue(サンプル候補);
+    render(<ClearableInput fetchSuggestions={fetchSuggestions} />);
+
+    const input = screen.getByLabelText("Channel");
+    typeInto(input, "zack");
+    await advanceDebounce();
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "クリア" }));
+
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
 });

--- a/src/components/channel-autocomplete.tsx
+++ b/src/components/channel-autocomplete.tsx
@@ -54,6 +54,19 @@ export function ChannelAutocompleteInput({
   /** 候補の選択で value を変えた直後は true にし、その変化による再検索を抑止する */
   const skipNextSearchRef = useRef(false);
 
+  // 親が value を外部から空にした場合(接続フォームの送信後クリアなど)は handleInputChange を
+  // 経由しないため、値の変化を render 中に検知してドロップダウンを閉じ、候補を破棄する
+  // (React の「render 中の派生 state 調整」パターン。effect 内の同期 setState は使わない)
+  const [prevValue, setPrevValue] = useState(value);
+  if (prevValue !== value) {
+    setPrevValue(value);
+    if (value.trim() === "") {
+      setSuggestions([]);
+      setOpen(false);
+      setActiveIndex(-1);
+    }
+  }
+
   // 入力の変化をデバウンスして候補を検索する。次の入力・アンマウントでタイマーと
   // 進行中のリクエストを破棄するため、古い結果が後から表示されることはない
   useEffect(() => {
@@ -61,7 +74,7 @@ export function ChannelAutocompleteInput({
       skipNextSearchRef.current = false;
       return;
     }
-    // 空入力時のクリアは handleInputChange(イベントハンドラ)で行うため、ここでは検索しないだけでよい
+    // 空入力では検索しない(空値時のドロップダウンのクローズは render 中の派生 state 調整で行う)
     const query = value.trim();
     if (query === "") return;
 
@@ -130,7 +143,8 @@ export function ChannelAutocompleteInput({
   };
 
   return (
-    <div className="relative">
+    // 置き場所(接続フォーム・ヘッダー検索)の行幅いっぱいに広がるよう w-full にする(幅は親が決める)
+    <div className="relative w-full">
       <Input
         {...inputProps}
         role="combobox"

--- a/src/components/channel-search-form.test.tsx
+++ b/src/components/channel-search-form.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * src/components/channel-search-form.tsx のテスト。
+ *
+ * チャンネル検索 + 接続の共通フォーム(ウェルカム画面の hero / ヘッダー中央の navbar の2バリアント)が、
+ * 入力値で chat-connection ストアの connect を呼ぶこと、接続クリックの延長で翻訳・Pick up の
+ * セッションをウォームアップすること(モデルDLにユーザー操作が必要なため)、空入力では何もしないことを検証する。
+ * 実際の IRC 接続(WebSocket)は行わず、connect をモックに差し替える。
+ * オートコンプリートの候補取得はネットワークに触れるためモックする(null = Helix 利用不可)。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
+
+const mockWarmUpTranslationPipeline = vi.fn();
+vi.mock("@/store/translations", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/translations")>()),
+  warmUpTranslationPipeline: () => mockWarmUpTranslationPipeline(),
+}));
+
+const mockWarmUpPickupPipeline = vi.fn();
+vi.mock("@/store/pickups", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/pickups")>()),
+  warmUpPickupPipeline: () => mockWarmUpPickupPipeline(),
+}));
+
+// チャンネル名のオートコンプリート(issue #59)の候補取得はネットワークに触れるためモックする。
+// null = Helix 利用不可(候補なし)として、ここでは手入力だけの動作を検証する
+vi.mock("@/lib/twitch/channel-search", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/twitch/channel-search")>()),
+  fetchChannelSuggestions: () => Promise.resolve(null),
+}));
+
+import { ChannelSearchForm } from "./channel-search-form";
+
+beforeEach(() => {
+  mockWarmUpTranslationPipeline.mockClear();
+  mockWarmUpPickupPipeline.mockClear();
+});
+
+afterEach(() => {
+  resetChatConnectionStoreForTests();
+});
+
+describe("ChannelSearchForm(hero: ウェルカム画面)", () => {
+  it("Channel ラベル付きの入力欄と Connect ボタンを表示する", () => {
+    render(<ChannelSearchForm variant="hero" />);
+
+    expect(screen.getByLabelText("Channel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+  });
+
+  it("入力が空の間は Connect ボタンを無効化する", () => {
+    render(<ChannelSearchForm variant="hero" />);
+
+    expect(screen.getByRole("button", { name: "Connect" })).toBeDisabled();
+  });
+
+  it("チャンネル名を入力して Connect を押すと、前後の空白を除いた値で connect を呼ぶ", async () => {
+    const user = userEvent.setup();
+    const connectMock = vi.fn();
+    useChatConnectionStore.setState({ connect: connectMock });
+    render(<ChannelSearchForm variant="hero" />);
+
+    await user.type(screen.getByLabelText("Channel"), "  example_streamer  ");
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(connectMock).toHaveBeenCalledWith("example_streamer");
+  });
+
+  it("Connect クリック(ユーザー操作)の延長で翻訳・Pick upのセッションをウォームアップする", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ connect: vi.fn() });
+    render(<ChannelSearchForm variant="hero" />);
+
+    await user.type(screen.getByLabelText("Channel"), "example_streamer");
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    expect(mockWarmUpTranslationPipeline).toHaveBeenCalledTimes(1);
+    expect(mockWarmUpPickupPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it("接続状態(Status)を表示する", () => {
+    render(<ChannelSearchForm variant="hero" />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Status: Idle");
+  });
+});
+
+describe("ChannelSearchForm(navbar: ヘッダー中央)", () => {
+  it("チャンネル検索の入力欄と接続ボタン(アイコン)を表示し、Status は表示しない", () => {
+    render(<ChannelSearchForm variant="navbar" />);
+
+    expect(screen.getByLabelText("Search channel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("チャンネル名を入力して Enter(フォーム送信)で connect を呼ぶ", async () => {
+    const user = userEvent.setup();
+    const connectMock = vi.fn();
+    useChatConnectionStore.setState({ connect: connectMock });
+    render(<ChannelSearchForm variant="navbar" />);
+
+    await user.type(screen.getByLabelText("Search channel"), "example_streamer{Enter}");
+
+    expect(connectMock).toHaveBeenCalledWith("example_streamer");
+    expect(mockWarmUpTranslationPipeline).toHaveBeenCalledTimes(1);
+    expect(mockWarmUpPickupPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it("フォーム送信後は入力欄を空に戻す(接続後に検索語を残さない)", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ connect: vi.fn() });
+    render(<ChannelSearchForm variant="navbar" />);
+
+    const input = screen.getByLabelText("Search channel");
+    await user.type(input, "example_streamer{Enter}");
+
+    expect(input).toHaveValue("");
+  });
+
+  it("入力が空のままフォーム送信しても connect を呼ばない", async () => {
+    const user = userEvent.setup();
+    const connectMock = vi.fn();
+    useChatConnectionStore.setState({ connect: connectMock });
+    render(<ChannelSearchForm variant="navbar" />);
+
+    await user.click(screen.getByLabelText("Search channel"));
+    await user.keyboard("{Enter}");
+
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/channel-search-form.tsx
+++ b/src/components/channel-search-form.tsx
@@ -1,0 +1,91 @@
+/**
+ * チャンネル検索 + 接続の共通フォーム。
+ *
+ * オートコンプリート付きの入力欄(`ChannelAutocompleteInput`)にチャンネル名を入力し、
+ * フォーム送信(Enter / ボタン)で chat-connection ストアの `connect` を呼ぶ。
+ * モデル未ダウンロード時の `LanguageModel.create()` にはユーザー操作が必要なため、
+ * 送信操作の延長で翻訳・Pick up のセッションを先にウォームアップする。
+ *
+ * 2つの置き場所に対応する:
+ *
+ * - `variant="hero"`: 未接続時のウェルカム画面用。Channel ラベル + 大きめの入力欄 +
+ *   Connect ボタン + 接続状態(Status)の表示
+ * - `variant="navbar"`: 接続中のヘッダー中央用。コンパクトな検索入力 + 検索アイコンの
+ *   送信ボタン。接続中に別のチャンネルへ移動する用途のため Status は表示しない
+ *
+ * IME 変換確定の Enter はフォーム送信を起こさない(ブラウザが composition 中の Enter を
+ * submit として扱わない)ため、ここでの追加対策は不要。候補選択の Enter の IME 対応は
+ * `ChannelAutocompleteInput` 側で行っている。
+ */
+"use client";
+
+import { useCallback, useState } from "react";
+import { SearchIcon } from "lucide-react";
+import { ChannelAutocompleteInput } from "@/components/channel-autocomplete";
+import { CONNECTION_STATE_LABEL } from "@/components/stream-info-panel";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { useChatConnectionStore } from "@/store/chat-connection";
+import { warmUpPickupPipeline } from "@/store/pickups";
+import { warmUpTranslationPipeline } from "@/store/translations";
+
+/** hero バリアントの入力欄の id(Label の htmlFor と対応させる) */
+const HERO_INPUT_ID = "channel-input";
+
+export function ChannelSearchForm({ variant }: { variant: "hero" | "navbar" }) {
+  const [channelInput, setChannelInput] = useState("");
+  const connect = useChatConnectionStore((state) => state.connect);
+  const connectionState = useChatConnectionStore((state) => state.connectionState);
+
+  const handleSubmit = useCallback(
+    (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const channel = channelInput.trim();
+      if (channel === "") return;
+      // モデル未ダウンロード時の LanguageModel.create() にはユーザー操作が必要なため、送信の延長で先に生成する
+      warmUpTranslationPipeline();
+      warmUpPickupPipeline();
+      connect(channel);
+      // 接続後に検索語・候補ドロップダウンを残さない(オートコンプリート側が空値でドロップダウンを閉じる)
+      setChannelInput("");
+    },
+    [channelInput, connect],
+  );
+
+  if (variant === "navbar") {
+    return (
+      <form onSubmit={handleSubmit} className="flex w-full max-w-sm items-center gap-1">
+        <ChannelAutocompleteInput
+          aria-label="Search channel"
+          placeholder="Search channel"
+          className="h-8"
+          value={channelInput}
+          onValueChange={setChannelInput}
+        />
+        <Button type="submit" variant="ghost" size="icon-sm" aria-label="Connect">
+          <SearchIcon />
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-1.5">
+      <Label htmlFor={HERO_INPUT_ID}>Channel</Label>
+      <div className="flex items-center gap-2">
+        <ChannelAutocompleteInput
+          id={HERO_INPUT_ID}
+          placeholder="e.g. zackrawrr"
+          value={channelInput}
+          onValueChange={setChannelInput}
+        />
+        <Button type="submit" disabled={channelInput.trim().length === 0}>
+          Connect
+        </Button>
+      </div>
+      <p className="text-xs text-muted-foreground" role="status">
+        Status: <span>{CONNECTION_STATE_LABEL[connectionState]}</span>
+      </p>
+    </form>
+  );
+}

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -53,7 +53,7 @@ const DIAGNOSIS_LEVEL_STYLE: Record<DiagnosisMessage["level"], { Icon: typeof Ch
   error: { Icon: XCircleIcon, className: "text-destructive" },
 };
 
-export function SettingsDialog() {
+export function SettingsDialog({ triggerLabel }: { triggerLabel?: string } = {}) {
   const hydrated = useSettingsStore((state) => state.hydrated);
   const wasCorrupted = useSettingsStore((state) => state.wasCorrupted);
 
@@ -61,10 +61,19 @@ export function SettingsDialog() {
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
-      {/* 未復元の間に初期化すると、まだ読み込んでいない LocalStorage の設定を消してしまうため、復元が済むまで開けないようにする */}
-      <DialogTrigger render={<Button variant="ghost" size="icon-sm" aria-label={DIALOG_TITLE} disabled={!hydrated} />}>
-        <SettingsIcon />
-      </DialogTrigger>
+      {/* 未復元の間に初期化すると、まだ読み込んでいない LocalStorage の設定を消してしまうため、復元が済むまで開けないようにする。
+          既定は歯車アイコンのみ(ヘッダー用)。triggerLabel を渡すとラベル付きのボタンになる
+          (ウェルカム画面で「AIモデル設定」であることを明示するため) */}
+      {triggerLabel === undefined ? (
+        <DialogTrigger render={<Button variant="ghost" size="icon-sm" aria-label={DIALOG_TITLE} disabled={!hydrated} />}>
+          <SettingsIcon />
+        </DialogTrigger>
+      ) : (
+        <DialogTrigger render={<Button variant="outline" size="sm" disabled={!hydrated} />}>
+          <SettingsIcon />
+          {triggerLabel}
+        </DialogTrigger>
+      )}
       <DialogContent aria-label={DIALOG_TITLE}>
         <DialogHeader>
           <DialogTitle>{DIALOG_TITLE}</DialogTitle>

--- a/src/components/site-header.test.tsx
+++ b/src/components/site-header.test.tsx
@@ -1,41 +1,79 @@
 /**
  * src/components/site-header.tsx のテスト。
  *
- * 全ページ共通ヘッダーが、アプリ名をホームへのリンクとして描画し、
- * 右側に言語ペアのセレクト(コンパクト表示)と設定ダイアログのトリガーを
- * 表示することを検証する(接続前後のどちらでも設定に触れるようにするため)。
+ * 共通ヘッダーが接続中(connecting / open / reconnecting)にだけ表示されることと、
+ * 表示中は左にアプリ名のリンク、中央にチャンネル検索(別チャンネルへの移動用)、
+ * 右に言語ペアのセレクトと設定ダイアログのトリガーを持つことを検証する。
+ * 未接続(idle / closed)のトップページはヘッダーなしのウェルカム画面
+ * (`src/app/page.tsx`)になるため、ヘッダーは何も描画しない。
  * 設定ダイアログの環境診断(`runBrowserDiagnosis`)はブラウザ API に触れるためモックする。
+ * チャンネル検索のオートコンプリート候補取得もネットワークに触れるためモックする。
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetSettingsStoreForTests } from "@/store/settings";
-import { SiteHeader } from "./site-header";
 
 vi.mock("@/lib/ai/runBrowserDiagnosis", () => ({
   runBrowserDiagnosis: () => new Promise(() => {}),
 }));
 
+// チャンネル名のオートコンプリート(issue #59)の候補取得はネットワークに触れるためモックする
+vi.mock("@/lib/twitch/channel-search", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/twitch/channel-search")>()),
+  fetchChannelSuggestions: () => Promise.resolve(null),
+}));
+
+import { SiteHeader } from "./site-header";
+
+beforeEach(() => {
+  // ヘッダーは接続中にだけ表示されるため、既定で接続済み(open)にする
+  useChatConnectionStore.setState({ connectionState: "open", channel: "example" });
+});
+
 afterEach(() => {
+  resetChatConnectionStoreForTests();
   resetSettingsStoreForTests();
   window.localStorage.clear();
 });
 
 describe("SiteHeader", () => {
-  it("アプリ名(chat-sensei)をホームへのリンクとして表示する", () => {
+  it("未接続(idle)の間は何も描画しない(トップページはヘッダーなしのウェルカム画面にする)", () => {
+    useChatConnectionStore.setState({ connectionState: "idle", channel: null });
+    render(<SiteHeader />);
+
+    expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+  });
+
+  it("切断後(closed)も何も描画しない", () => {
+    useChatConnectionStore.setState({ connectionState: "closed", channel: null });
+    render(<SiteHeader />);
+
+    expect(screen.queryByRole("banner")).not.toBeInTheDocument();
+  });
+
+  it("接続中はアプリ名(chat-sensei)をホームへのリンクとして表示する", () => {
     render(<SiteHeader />);
 
     const homeLink = screen.getByRole("link", { name: "chat-sensei" });
     expect(homeLink).toHaveAttribute("href", "/");
   });
 
-  it("ヘッダー右側に言語ペアのセレクト(学ぶ言語 / 解説言語)を表示する", () => {
+  it("接続中はヘッダー中央にチャンネル検索(別チャンネルへの移動用)を表示する", () => {
+    render(<SiteHeader />);
+
+    expect(screen.getByLabelText("Search channel")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
+  });
+
+  it("接続中はヘッダー右側に言語ペアのセレクト(学ぶ言語 / 解説言語)を表示する", () => {
     render(<SiteHeader />);
 
     expect(screen.getByRole("combobox", { name: "Learning language" })).toBeInTheDocument();
     expect(screen.getByRole("combobox", { name: "Explanation language" })).toBeInTheDocument();
   });
 
-  it("ヘッダー右側に設定ダイアログを開くボタンを表示する", () => {
+  it("接続中はヘッダー右側に設定ダイアログを開くボタンを表示する", () => {
     render(<SiteHeader />);
 
     expect(screen.getByRole("button", { name: "Settings" })).toBeInTheDocument();

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -1,24 +1,36 @@
 /**
- * 全ページ共通のヘッダー。
+ * 接続中(connecting / open / reconnecting)にだけ表示する共通ヘッダー。
  *
- * 左側にアプリ名のリンク、右側に言語ペアのセレクト(文章型レイアウト)と
- * 設定ダイアログのトリガーを表示する。言語設定・アプリ設定は接続前後の
- * どちらの画面(接続フォーム / embed + 3カラム)でも変更したくなるため、
- * 画面の状態に依存しないヘッダーに常時置く。
+ * 左にアプリ名のリンク、中央にチャンネル検索(`ChannelSearchForm` の navbar バリアント。
+ * 視聴中に別のチャンネルへ移動する用途)、右に言語ペアのセレクト(文章型レイアウト)と
+ * 設定ダイアログのトリガーを表示する。
+ *
+ * 未接続(idle / closed)のトップページは、言語設定・AIモデル設定・チャンネル検索を
+ * 画面中央に置いたヘッダーなしのウェルカム画面(`src/app/page.tsx`)にするため、
+ * ここでは何も描画しない。接続状態は chat-connection ストアを購読して判定する。
  */
+"use client";
+
 import Link from "next/link";
+import { ChannelSearchForm } from "@/components/channel-search-form";
 import { LanguagePairSelect } from "@/components/language-pair-select";
 import { SettingsDialog } from "@/components/settings-dialog";
+import { isConnectingOrConnected, useChatConnectionStore } from "@/store/chat-connection";
 
 export function SiteHeader() {
+  const connectionState = useChatConnectionStore((state) => state.connectionState);
+  if (!isConnectingOrConnected(connectionState)) return null;
+
   return (
     // Surface 色で配信embedと地続きに見せる(issue #87)
     <header className="border-b bg-card">
-      <nav className="mx-auto flex w-full items-center justify-between gap-4 px-6 py-2">
-        <Link href="/" className="font-heading text-lg font-semibold">
+      {/* 左右の幅を 1fr で揃え、チャンネル検索をヘッダーの中央に置く */}
+      <nav className="mx-auto grid w-full grid-cols-[1fr_auto_1fr] items-center gap-4 px-6 py-2">
+        <Link href="/" className="justify-self-start font-heading text-lg font-semibold">
           chat-sensei
         </Link>
-        <div className="flex items-center gap-2">
+        <ChannelSearchForm variant="navbar" />
+        <div className="flex items-center gap-2 justify-self-end">
           <LanguagePairSelect />
           <SettingsDialog />
         </div>

--- a/src/store/chat-connection.ts
+++ b/src/store/chat-connection.ts
@@ -106,6 +106,14 @@ function getClient(): TwitchIrcClient {
   return client;
 }
 
+/**
+ * 接続中とみなす状態かを判定する。ホーム画面(切断ボタンへの切り替え・3カラム表示)と
+ * 共通ヘッダー(接続中にだけ表示する)で共有する。
+ */
+export function isConnectingOrConnected(state: ConnectionState): boolean {
+  return state === "connecting" || state === "open" || state === "reconnecting";
+}
+
 export const useChatConnectionStore = create<ChatConnectionState>((set) => ({
   connectionState: "idle",
   messages: [],


### PR DESCRIPTION
## 概要

チャンネル検索の導線を再構成しました。

- **共通ヘッダー(navbar)**: 接続中のみ表示し、中央にチャンネル検索を配置。視聴中に検索から別のチャンネルへそのまま移動できます(送信後は入力をクリアし、候補ドロップダウンも閉じます)
- **トップページ(未接続)**: navbarを表示せず、アプリ名 + タグラインの下にチャンネル検索・言語ペアセレクト・AIモデル設定(ラベル付きの設定ダイアログトリガー)を縦に並べたウェルカムページに再構成

## 変更内容

- `src/components/channel-search-form.tsx`(新規): チャンネル検索 + 接続の共通フォーム。`hero`(ウェルカム用)/ `navbar`(ヘッダー中央用)の2バリアント。送信の延長で翻訳・Pick upセッションをウォームアップしてから `connect` を呼ぶ
- `src/components/site-header.tsx`: client化し、`isConnectingOrConnected` で未接続時は非表示。`grid-cols-[1fr_auto_1fr]` で検索をヘッダー中央に配置
- `src/app/page.tsx`: 未接続分岐をウェルカム画面に置き換え。接続フォームのローカルstate・接続処理は `ChannelSearchForm` へ移動
- `src/components/settings-dialog.tsx`: ラベル付きトリガー(`triggerLabel`)を追加(ウェルカム画面の「AI model settings」ボタン)
- `src/components/channel-autocomplete.tsx`: 親が `value` を外部から空にした場合もドロップダウンを閉じる(render中の派生state調整パターン)。ラッパーを `w-full` にして置き場所の行幅いっぱいに広げる
- `src/store/chat-connection.ts`: `isConnectingOrConnected` をエクスポートしてページ・ヘッダーで共有

## テスト

- `npm test`: 840件すべて成功(新規: channel-search-form 9件、site-header 7件、channel-autocomplete 1件、page 2件ほか)
- `npm run lint` / `npm run type-check`: エラー・警告ゼロ
- ブラウザで動作確認済み: ウェルカム画面表示 → 接続 → navbar検索で別チャンネルへ移動 → 切断でウェルカムへ復帰
- CodeRabbitレビュー実施済み(指摘0件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)