### PR TITLE
feat: トップページに言語ペアの両タグを含むライブ配信一覧を表示する

### DIFF
--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -68,6 +68,16 @@ vi.mock("@/lib/twitch/channel-search", async (importOriginal) => ({
   fetchChannelSuggestions: () => Promise.resolve(null),
 }));
 
+// ウェルカム画面の配信一覧(issue #90)の取得もネットワークに触れるためモックする。
+// 既定は null = Helix 利用不可(一覧セクションを表示しない)とし、
+// 一覧を検証するテストだけ mockResolvedValue で配信データを注入する
+const mockFetchLanguagePairStreams = vi.fn();
+
+vi.mock("@/lib/twitch/stream-list", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/twitch/stream-list")>()),
+  fetchLanguagePairStreams: (...args: unknown[]) => mockFetchLanguagePairStreams(...args),
+}));
+
 import Home from "./page";
 
 const サンプル発言: TwitchChatMessage = {
@@ -103,6 +113,8 @@ beforeEach(() => {
   mockStopPickupPipeline.mockClear();
   mockWarmUpPickupPipeline.mockClear();
   mockAddManualPickup.mockClear();
+  mockFetchLanguagePairStreams.mockReset();
+  mockFetchLanguagePairStreams.mockResolvedValue(null);
   // 多くのテストは接続中(embed + 3カラム)の画面を検証するため、既定で接続済み(open)にする。
   // 未接続の接続画面を検証するテストは、テスト内で idle / closed に戻す
   useChatConnectionStore.setState({ connectionState: "open", channel: "example" });
@@ -1099,6 +1111,37 @@ describe("Home(未接続のウェルカム画面)", () => {
 
     expect(screen.getByText("Status:")).toBeInTheDocument();
     expect(screen.getByText("Idle")).toBeInTheDocument();
+  });
+
+  it("チャンネル接続UIの下に、言語ペアの両タグを含む配信一覧(issue #90)を表示する", async () => {
+    // Learning en · explained in ja(デフォルト)の両タグを含む配信が1件見つかった状態を注入する
+    mockFetchLanguagePairStreams.mockResolvedValue([
+      {
+        login: "eigo_sensei",
+        displayName: "英語の先生",
+        title: "English & Japanese chatting stream",
+        category: "Just Chatting",
+        viewerCount: 321,
+        thumbnailUrl: "",
+        tags: ["English", "日本語"],
+      },
+    ]);
+    render(<Home />);
+
+    expect(
+      await screen.findByRole("heading", { name: "Live streams tagged English · 日本語" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("English & Japanese chatting stream")).toBeInTheDocument();
+  });
+
+  it("配信一覧の取得に失敗した場合(Helix 利用不可)は、一覧セクションを表示しない", async () => {
+    render(<Home />);
+
+    // 既定のモック(null)が解決されるのを待ってから、セクションが無いことを確認する
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(screen.queryByRole("heading", { name: /Live streams tagged/ })).not.toBeInTheDocument();
   });
 
   it("切断(closed)後もウェルカム画面に戻る", () => {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,8 @@
  *
  * - 未接続(idle / closed): ヘッダーなしのウェルカム画面を表示する。アプリ名とタグラインの下に
  *   チャンネル検索(ChannelSearchForm の hero バリアント)、言語ペアのセレクト、
- *   AIモデル設定(SettingsDialog のラベル付きトリガー)を縦に並べる
+ *   AIモデル設定(SettingsDialog のラベル付きトリガー)を縦に並べ、その下に
+ *   言語ペアの両タグを含むライブ配信の一覧(LanguagePairStreamList。issue #90)を表示する
  * - 接続中(connecting / open / reconnecting): 上半分に配信embed(TwitchEmbedPlayer)と
  *   配信者情報パネル(StreamInfoPanel)、下半分に3カラムのチャット閲覧領域を表示する。
  *   全体がビューポート1ページに収まり(レイアウト側で高さを固定)、3カラム領域は
@@ -51,6 +52,7 @@ import { ManualPickupOverlay, MESSAGE_TEXT_ATTRIBUTE, RAW_IRC_COLUMN_NAME } from
 import { ChannelSearchForm } from "@/components/channel-search-form";
 import { LanguagePairSelect } from "@/components/language-pair-select";
 import { SettingsDialog } from "@/components/settings-dialog";
+import { LanguagePairStreamList } from "@/components/stream-list";
 import { StreamInfoPanel } from "@/components/stream-info-panel";
 import { TwitchEmbedPlayer } from "@/components/twitch-embed-player";
 import { Button } from "@/components/ui/button";
@@ -200,20 +202,25 @@ export default function Home() {
     <div className="flex min-h-0 w-full flex-1 flex-col gap-4 p-4">
       {!connected ? (
         // 未接続: ヘッダーなしのウェルカム画面。アプリ名 + タグラインの下にチャンネル検索を置き、
-        // 言語ペア・AIモデルの設定もこの画面から触れるようにする(接続中はヘッダーに移る)
-        <div className="flex flex-1 items-center justify-center">
-          <div className="flex w-full max-w-md flex-col items-center gap-10">
-            <div className="flex flex-col items-center gap-3 text-center">
-              <h1 className="font-heading text-4xl font-semibold tracking-tight">chat-sensei</h1>
-              <p className="text-sm text-muted-foreground">
-                Learn a language from live Twitch chat — translated and explained as it flows.
-              </p>
+        // 言語ペア・AIモデルの設定もこの画面から触れるようにする(接続中はヘッダーに移る)。
+        // その下に言語ペアの両タグを含む配信一覧(issue #90)を表示する。レイアウト(layout.tsx)が
+        // 高さを固定しているため、一覧が伸びたぶんはこのラッパーの内部でスクロールする
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          <div className="mx-auto flex min-h-full w-full max-w-5xl flex-col items-center justify-center gap-10 py-10">
+            <div className="flex w-full max-w-md flex-col items-center gap-10">
+              <div className="flex flex-col items-center gap-3 text-center">
+                <h1 className="font-heading text-4xl font-semibold tracking-tight">chat-sensei</h1>
+                <p className="text-sm text-muted-foreground">
+                  Learn a language from live Twitch chat — translated and explained as it flows.
+                </p>
+              </div>
+              <ChannelSearchForm variant="hero" />
+              <div className="flex flex-col items-center gap-3">
+                <LanguagePairSelect />
+                <SettingsDialog triggerLabel="AI model settings" />
+              </div>
             </div>
-            <ChannelSearchForm variant="hero" />
-            <div className="flex flex-col items-center gap-3">
-              <LanguagePairSelect />
-              <SettingsDialog triggerLabel="AI model settings" />
-            </div>
+            <LanguagePairStreamList />
           </div>
         </div>
       ) : (

--- a/src/components/stream-list.test.tsx
+++ b/src/components/stream-list.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * src/components/stream-list.tsx(言語ペアタグ付き配信一覧)のテスト。
+ *
+ * ウェルカム画面に表示する「選択中の言語ペアの両タグを含むライブ配信」の一覧が、
+ * 設定ストアの復元(hydrate)後に取得を始めること、取得結果をカードとして表示すること、
+ * カードのクリックで chat-connection ストアの connect を呼び翻訳・Pick up のセッションを
+ * ウォームアップすること、0件・取得失敗時の表示を検証する。
+ * 実際の API 呼び出しは行わず、取得関数(fetchLanguagePairStreams)をモックに差し替える。
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
+import type { TaggedStream } from "@/lib/twitch/stream-list";
+import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
+import { resetSettingsStoreForTests, useSettingsStore } from "@/store/settings";
+
+const mockFetchLanguagePairStreams = vi.fn();
+vi.mock("@/lib/twitch/stream-list", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/twitch/stream-list")>()),
+  fetchLanguagePairStreams: (...args: unknown[]) => mockFetchLanguagePairStreams(...args),
+}));
+
+const mockWarmUpTranslationPipeline = vi.fn();
+vi.mock("@/store/translations", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/translations")>()),
+  warmUpTranslationPipeline: () => mockWarmUpTranslationPipeline(),
+}));
+
+const mockWarmUpPickupPipeline = vi.fn();
+vi.mock("@/store/pickups", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/store/pickups")>()),
+  warmUpPickupPipeline: () => mockWarmUpPickupPipeline(),
+}));
+
+import { LanguagePairStreamList } from "./stream-list";
+
+/** 一覧表示の検証に使う配信データ(英語・日本語の両タグ付き) */
+function createTaggedStream(overrides: Partial<TaggedStream> = {}): TaggedStream {
+  return {
+    login: "eigo_sensei",
+    displayName: "英語の先生",
+    title: "English & Japanese chatting stream",
+    category: "Just Chatting",
+    viewerCount: 1234,
+    thumbnailUrl: "https://static-cdn.jtvnw.net/previews-ttv/live_user_eigo_sensei-440x248.jpg",
+    tags: ["English", "日本語"],
+    ...overrides,
+  };
+}
+
+/** 設定ストアを復元済み(デフォルト: Learning en · explained in ja)にする */
+function hydrateSettingsForTest(): void {
+  useSettingsStore.setState({ settings: DEFAULT_SETTINGS, hydrated: true });
+}
+
+beforeEach(() => {
+  mockFetchLanguagePairStreams.mockReset();
+  mockWarmUpTranslationPipeline.mockClear();
+  mockWarmUpPickupPipeline.mockClear();
+});
+
+afterEach(() => {
+  resetChatConnectionStoreForTests();
+  resetSettingsStoreForTests();
+});
+
+describe("LanguagePairStreamList", () => {
+  it("設定ストアが未復元(hydrated: false)の間は何も表示せず、取得も始めない", () => {
+    const { container } = render(<LanguagePairStreamList />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(mockFetchLanguagePairStreams).not.toHaveBeenCalled();
+  });
+
+  it("復元後、選択中の言語ペア(学習言語・解説言語)で配信一覧を取得する", async () => {
+    mockFetchLanguagePairStreams.mockResolvedValue([]);
+    hydrateSettingsForTest();
+    render(<LanguagePairStreamList />);
+
+    await waitFor(() => {
+      expect(mockFetchLanguagePairStreams).toHaveBeenCalledWith("en", "ja", expect.anything());
+    });
+  });
+
+  it("取得した配信を、言語ペアの見出しとともにカードで表示する(タイトル・表示名・カテゴリ・視聴者数)", async () => {
+    mockFetchLanguagePairStreams.mockResolvedValue([createTaggedStream()]);
+    hydrateSettingsForTest();
+    render(<LanguagePairStreamList />);
+
+    // 見出しは言語ペアのセレクト(Learning English · explained in 日本語)と同じ表示名を使う
+    expect(await screen.findByRole("heading", { name: "Live streams tagged English · 日本語" })).toBeInTheDocument();
+    expect(screen.getByText("English & Japanese chatting stream")).toBeInTheDocument();
+    expect(screen.getByText("英語の先生")).toBeInTheDocument();
+    expect(screen.getByText("Just Chatting")).toBeInTheDocument();
+    // 視聴者数は桁区切りで表示する(単位はスクリーンリーダー向けの sr-only で補う)
+    expect(screen.getByText("1,234")).toBeInTheDocument();
+  });
+
+  it("カードをクリックすると、そのチャンネルへ connect を呼び、翻訳・Pick up のセッションをウォームアップする", async () => {
+    const user = userEvent.setup();
+    const connectMock = vi.fn();
+    useChatConnectionStore.setState({ connect: connectMock });
+    mockFetchLanguagePairStreams.mockResolvedValue([createTaggedStream()]);
+    hydrateSettingsForTest();
+    render(<LanguagePairStreamList />);
+
+    await user.click(await screen.findByRole("button", { name: /英語の先生/ }));
+
+    expect(connectMock).toHaveBeenCalledWith("eigo_sensei");
+    expect(mockWarmUpTranslationPipeline).toHaveBeenCalledTimes(1);
+    expect(mockWarmUpPickupPipeline).toHaveBeenCalledTimes(1);
+  });
+
+  it("該当する配信が0件の場合は、空状態の文言を表示する", async () => {
+    mockFetchLanguagePairStreams.mockResolvedValue([]);
+    hydrateSettingsForTest();
+    render(<LanguagePairStreamList />);
+
+    expect(
+      await screen.findByText("No live streams with both language tags right now."),
+    ).toBeInTheDocument();
+  });
+
+  it("取得に失敗した場合(null)は、一覧セクションごと表示しない(静かなフォールバック)", async () => {
+    mockFetchLanguagePairStreams.mockResolvedValue(null);
+    hydrateSettingsForTest();
+    const { container } = render(<LanguagePairStreamList />);
+
+    await waitFor(() => {
+      expect(mockFetchLanguagePairStreams).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("言語ペアの変更に追従して一覧を取得し直す", async () => {
+    mockFetchLanguagePairStreams.mockResolvedValue([]);
+    hydrateSettingsForTest();
+    render(<LanguagePairStreamList />);
+    await waitFor(() => {
+      expect(mockFetchLanguagePairStreams).toHaveBeenCalledWith("en", "ja", expect.anything());
+    });
+
+    // 言語ペアを Learning ja · explained in en に変更する
+    useSettingsStore.setState({
+      settings: { ...DEFAULT_SETTINGS, learningLang: "ja", explainLang: "en" },
+    });
+
+    await waitFor(() => {
+      expect(mockFetchLanguagePairStreams).toHaveBeenCalledWith("ja", "en", expect.anything());
+    });
+  });
+});

--- a/src/components/stream-list.tsx
+++ b/src/components/stream-list.tsx
@@ -1,0 +1,130 @@
+/**
+ * 言語ペアタグ付き配信一覧(issue #90)。
+ *
+ * 未接続時のウェルカム画面で、チャンネル接続UIの下に「選択中の言語ペア
+ * (学習言語・解説言語)の両方の言語タグを含むライブ配信」の一覧をカードで表示する。
+ * カードをクリックするとそのチャンネルへ接続する(チャンネル検索フォームと同様に、
+ * モデル未ダウンロード時の `LanguageModel.create()` にはユーザー操作が必要なため、
+ * クリックの延長で翻訳・Pick up のセッションを先にウォームアップする)。
+ *
+ * - 設定ストアの復元(hydrate)後に取得を始め、言語ペアの変更に追従して取得し直す
+ * - 取得に失敗した場合(Helix 未設定の 503・障害など)はセクションごと表示しない
+ *   (チャンネルオートコンプリートと同じ静かなフォールバック)
+ * - 該当する配信が0件の場合は空状態の文言を表示する
+ */
+"use client";
+
+import { useEffect, useState } from "react";
+import { UsersIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { LANGUAGE_DISPLAY_NAMES } from "@/lib/settings";
+import { fetchLanguagePairStreams, type TaggedStream } from "@/lib/twitch/stream-list";
+import { useChatConnectionStore } from "@/store/chat-connection";
+import { warmUpPickupPipeline } from "@/store/pickups";
+import { useSettingsStore } from "@/store/settings";
+import { warmUpTranslationPipeline } from "@/store/translations";
+
+/** 視聴者数の桁区切り表示(1,234 のような英語圏形式。UI は英語で統一しているため) */
+const VIEWER_COUNT_FORMAT = new Intl.NumberFormat("en-US");
+
+/**
+ * 一覧の取得結果。null = 未取得(取得中) / 取得失敗(いずれも表示しない)。
+ * どの言語ペアに対する結果かを pairKey で持ち、言語ペア変更直後に古いペアの
+ * 一覧を表示しない(effect 内で同期的に state をリセットせずに済ませる)
+ */
+interface StreamListResult {
+  /** 取得時の言語ペア(`learningLang:explainLang`) */
+  pairKey: string;
+  /** 両タグを含む配信一覧。取得失敗時は null(セクションごと表示しない) */
+  streams: TaggedStream[] | null;
+}
+
+export function LanguagePairStreamList() {
+  const settings = useSettingsStore((state) => state.settings);
+  const hydrated = useSettingsStore((state) => state.hydrated);
+  const connect = useChatConnectionStore((state) => state.connect);
+  const [result, setResult] = useState<StreamListResult | null>(null);
+
+  const { learningLang, explainLang } = settings;
+  const pairKey = `${learningLang}:${explainLang}`;
+
+  useEffect(() => {
+    // SSR プリレンダリングと LocalStorage 復元前はデフォルト言語ペアで誤って取得しないよう待つ
+    if (!hydrated) return;
+    const controller = new AbortController();
+    void fetchLanguagePairStreams(learningLang, explainLang, { signal: controller.signal }).then((streams) => {
+      // 言語ペア変更・アンマウントで中断された古い結果は捨てる(新しい effect 側の結果を採用する)
+      if (controller.signal.aborted) return;
+      setResult({ pairKey: `${learningLang}:${explainLang}`, streams });
+    });
+    return () => controller.abort();
+  }, [hydrated, learningLang, explainLang]);
+
+  // 未取得(取得中)・取得失敗・言語ペア変更直後(古いペアの結果)は表示しない
+  if (!hydrated || result === null || result.pairKey !== pairKey || result.streams === null) return null;
+  const streams = result.streams;
+
+  const handleConnect = (login: string) => {
+    // モデル未ダウンロード時の LanguageModel.create() にはユーザー操作が必要なため、クリックの延長で先に生成する
+    warmUpTranslationPipeline();
+    warmUpPickupPipeline();
+    connect(login);
+  };
+
+  return (
+    <section aria-labelledby="language-pair-stream-list-heading" className="flex w-full flex-col gap-4">
+      <h2 id="language-pair-stream-list-heading" className="font-heading text-lg font-semibold">
+        Live streams tagged {LANGUAGE_DISPLAY_NAMES[learningLang]} · {LANGUAGE_DISPLAY_NAMES[explainLang]}
+      </h2>
+      {streams.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No live streams with both language tags right now.</p>
+      ) : (
+        <ul className="grid list-none grid-cols-1 gap-4 p-0 sm:grid-cols-2 lg:grid-cols-3">
+          {streams.map((stream) => (
+            <li key={stream.login}>
+              <button
+                type="button"
+                onClick={() => handleConnect(stream.login)}
+                className="flex w-full flex-col gap-2 rounded-lg border border-border bg-card p-2 text-left transition-colors hover:border-primary/60 hover:bg-muted/50 focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-none"
+              >
+                {stream.thumbnailUrl !== "" && (
+                  // 配信のプレビュー画像。タイトル等の文字情報が隣にあるため装飾扱い(alt は空)
+                  // eslint-disable-next-line @next/next/no-img-element -- Twitch CDN の動的プレビューのため next/image の最適化対象にしない
+                  <img
+                    src={stream.thumbnailUrl}
+                    alt=""
+                    loading="lazy"
+                    className="aspect-video w-full rounded-md object-cover"
+                  />
+                )}
+                <span className="flex flex-col gap-0.5">
+                  <span className="line-clamp-2 text-sm font-medium">{stream.title}</span>
+                  <span className="text-xs text-muted-foreground">{stream.displayName}</span>
+                  <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                    {stream.category !== "" && <span className="truncate">{stream.category}</span>}
+                    {stream.viewerCount !== null && (
+                      <span className="flex shrink-0 items-center gap-1">
+                        <UsersIcon aria-hidden="true" className="size-3" />
+                        {VIEWER_COUNT_FORMAT.format(stream.viewerCount)}
+                        <span className="sr-only"> viewers</span>
+                      </span>
+                    )}
+                  </span>
+                </span>
+                {stream.tags.length > 0 && (
+                  <span className="flex flex-wrap gap-1">
+                    {stream.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </span>
+                )}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/components/stream-list.tsx
+++ b/src/components/stream-list.tsx
@@ -15,7 +15,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { UsersIcon } from "lucide-react";
+import { UserIcon } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { LANGUAGE_DISPLAY_NAMES } from "@/lib/settings";
 import { fetchLanguagePairStreams, type TaggedStream } from "@/lib/twitch/stream-list";
@@ -103,8 +103,10 @@ export function LanguagePairStreamList() {
                   <span className="flex items-center gap-2 text-xs text-muted-foreground">
                     {stream.category !== "" && <span className="truncate">{stream.category}</span>}
                     {stream.viewerCount !== null && (
-                      <span className="flex shrink-0 items-center gap-1">
-                        <UsersIcon aria-hidden="true" className="size-3" />
+                      // 配信者情報パネル(stream-info-panel.tsx)と同じ「赤色の人アイコン + 数字」
+                      // (色はライブ配信用トークン --live)に揃える
+                      <span className="flex shrink-0 items-center gap-1 font-semibold text-live">
+                        <UserIcon aria-hidden="true" className="size-3" />
                         {VIEWER_COUNT_FORMAT.format(stream.viewerCount)}
                         <span className="sr-only"> viewers</span>
                       </span>

--- a/src/lib/twitch/stream-list.test.ts
+++ b/src/lib/twitch/stream-list.test.ts
@@ -1,0 +1,299 @@
+/**
+ * src/lib/twitch/stream-list.ts(言語ペアタグ付き配信一覧)のテスト。
+ *
+ * Helix の Get Streams API(`GET /streams?language=&first=`)のレスポンスを
+ * 配信一覧として解析する処理、タグの言語照合(自由入力の表記ゆれ・大文字小文字の吸収)、
+ * 言語ペアの両タグを含む配信だけを残すフィルタ、および Next.js プロキシ
+ * (`/api/twitch/streams`)経由の取得を検証する。
+ * 実際の API 呼び出しは行わず、フェイクの fetch を注入する。
+ */
+import { describe, expect, it, vi } from "vitest";
+import {
+  fetchLanguagePairStreams,
+  filterStreamsByLanguagePair,
+  parseTaggedStreams,
+  streamHasLanguageTag,
+  type TaggedStream,
+} from "./stream-list";
+
+/** Helix Get Streams API のレスポンス(検証に使う部分のみ) */
+function createHelixStreamsJson(): unknown {
+  return {
+    data: [
+      {
+        user_login: "eigo_sensei",
+        user_name: "英語の先生",
+        title: "English & Japanese chatting stream",
+        game_name: "Just Chatting",
+        viewer_count: 321,
+        thumbnail_url: "https://static-cdn.jtvnw.net/previews-ttv/live_user_eigo_sensei-{width}x{height}.jpg",
+        tags: ["English", "日本語", "LearnJapanese"],
+      },
+      {
+        user_login: "solo_gamer",
+        user_name: "SoloGamer",
+        title: "ranked grind",
+        game_name: "VALORANT",
+        viewer_count: 55,
+        thumbnail_url: "https://static-cdn.jtvnw.net/previews-ttv/live_user_solo_gamer-{width}x{height}.jpg",
+        tags: ["English"],
+      },
+    ],
+  };
+}
+
+describe("parseTaggedStreams", () => {
+  it("レスポンスから配信一覧(login・表示名・タイトル・カテゴリ・視聴者数・サムネイル・タグ)を順序どおり取り出す", () => {
+    const streams = parseTaggedStreams(createHelixStreamsJson());
+    expect(streams).toEqual([
+      {
+        login: "eigo_sensei",
+        displayName: "英語の先生",
+        title: "English & Japanese chatting stream",
+        category: "Just Chatting",
+        viewerCount: 321,
+        thumbnailUrl: "https://static-cdn.jtvnw.net/previews-ttv/live_user_eigo_sensei-440x248.jpg",
+        tags: ["English", "日本語", "LearnJapanese"],
+      },
+      {
+        login: "solo_gamer",
+        displayName: "SoloGamer",
+        title: "ranked grind",
+        category: "VALORANT",
+        viewerCount: 55,
+        thumbnailUrl: "https://static-cdn.jtvnw.net/previews-ttv/live_user_solo_gamer-440x248.jpg",
+        tags: ["English"],
+      },
+    ] satisfies TaggedStream[]);
+  });
+
+  it("data が空の場合は空配列を返す", () => {
+    expect(parseTaggedStreams({ data: [] })).toEqual([]);
+  });
+
+  it("data 配列が無い・オブジェクトでない場合は null を返す", () => {
+    expect(parseTaggedStreams({})).toBeNull();
+    expect(parseTaggedStreams("文字列のボディ")).toBeNull();
+    expect(parseTaggedStreams(null)).toBeNull();
+  });
+
+  it("user_login が無い項目・型が想定と異なる項目は読み飛ばす", () => {
+    const json = {
+      data: [
+        { user_name: "loginなし", tags: ["English"] },
+        "文字列の項目",
+        {
+          user_login: "valid_user",
+          user_name: "ValidUser",
+          title: "配信中",
+          game_name: "Minecraft",
+          viewer_count: 10,
+          thumbnail_url: "https://example.com/thumb-{width}x{height}.jpg",
+          tags: ["English", "日本語"],
+        },
+      ],
+    };
+    expect(parseTaggedStreams(json)).toEqual([
+      {
+        login: "valid_user",
+        displayName: "ValidUser",
+        title: "配信中",
+        category: "Minecraft",
+        viewerCount: 10,
+        thumbnailUrl: "https://example.com/thumb-440x248.jpg",
+        tags: ["English", "日本語"],
+      },
+    ]);
+  });
+
+  it("任意フィールドが欠けた項目は、表示名は login・文字列は空文字・視聴者数は null・タグは空配列として読み込む", () => {
+    const json = { data: [{ user_login: "bare_user" }] };
+    expect(parseTaggedStreams(json)).toEqual([
+      {
+        login: "bare_user",
+        displayName: "bare_user",
+        title: "",
+        category: "",
+        viewerCount: null,
+        thumbnailUrl: "",
+        tags: [],
+      },
+    ]);
+  });
+
+  it("tags 配列に文字列以外が混じっている場合、その要素だけ読み飛ばす", () => {
+    const json = { data: [{ user_login: "mixed_tags", tags: ["English", 123, null, "日本語"] }] };
+    const streams = parseTaggedStreams(json);
+    expect(streams?.[0].tags).toEqual(["English", "日本語"]);
+  });
+
+  it("tags 配列に同じタグが重複している場合、最初の1つだけを残す(実際の Helix レスポンスに重複がありうるため)", () => {
+    // 実例: あるアート配信のタグに「イラスト」が2回含まれていた(そのまま表示すると React の key が重複する)
+    const json = { data: [{ user_login: "art_streamer", tags: ["art", "イラスト", "English", "イラスト"] }] };
+    const streams = parseTaggedStreams(json);
+    expect(streams?.[0].tags).toEqual(["art", "イラスト", "English"]);
+  });
+});
+
+describe("streamHasLanguageTag", () => {
+  it("言語に対応するタグ候補語(英語名・ネイティブ表記)のいずれかと一致すれば true を返す", () => {
+    expect(streamHasLanguageTag(["Japanese"], "ja")).toBe(true);
+    expect(streamHasLanguageTag(["日本語"], "ja")).toBe(true);
+    expect(streamHasLanguageTag(["English"], "en")).toBe(true);
+    expect(streamHasLanguageTag(["Español"], "es")).toBe(true);
+    expect(streamHasLanguageTag(["Spanish"], "es")).toBe(true);
+    expect(streamHasLanguageTag(["Deutsch"], "de")).toBe(true);
+    expect(streamHasLanguageTag(["German"], "de")).toBe(true);
+    expect(streamHasLanguageTag(["Français"], "fr")).toBe(true);
+    expect(streamHasLanguageTag(["French"], "fr")).toBe(true);
+  });
+
+  it("大文字小文字・アクセント無し表記の違いを吸収する", () => {
+    expect(streamHasLanguageTag(["JAPANESE"], "ja")).toBe(true);
+    expect(streamHasLanguageTag(["espanol"], "es")).toBe(true);
+    expect(streamHasLanguageTag(["francais"], "fr")).toBe(true);
+  });
+
+  it("対応するタグが無ければ false を返す", () => {
+    expect(streamHasLanguageTag(["English", "Gaming"], "ja")).toBe(false);
+    expect(streamHasLanguageTag([], "en")).toBe(false);
+  });
+
+  it("タグ内の部分一致では true にしない(タグ全体との一致のみ)", () => {
+    expect(streamHasLanguageTag(["LearnJapanese"], "ja")).toBe(false);
+  });
+});
+
+describe("filterStreamsByLanguagePair", () => {
+  /** タグだけが検証に関係するため、他フィールドは最小のダミー値で埋める */
+  function createStream(login: string, tags: string[]): TaggedStream {
+    return {
+      login,
+      displayName: login,
+      title: "",
+      category: "",
+      viewerCount: null,
+      thumbnailUrl: "",
+      tags,
+    };
+  }
+
+  it("学習言語と解説言語の両方のタグを含む配信だけを順序を保って残す", () => {
+    const streams = [
+      createStream("both_tags", ["English", "日本語"]),
+      createStream("learning_only", ["English"]),
+      createStream("explain_only", ["日本語"]),
+      createStream("no_tags", []),
+      createStream("both_tags_2", ["Japanese", "english", "Gaming"]),
+    ];
+    expect(filterStreamsByLanguagePair(streams, "en", "ja").map((stream) => stream.login)).toEqual([
+      "both_tags",
+      "both_tags_2",
+    ]);
+  });
+});
+
+describe("fetchLanguagePairStreams", () => {
+  /**
+   * Helix の Get Streams は視聴者数降順の上位 first 件しか返さないため、2言語をまとめて
+   * 問い合わせると、視聴者数の多い言語(例: 英語)の大規模配信に埋もれて両タグ配信が
+   * 1件も入らない(実データで確認済み)。そのため言語ごとに1リクエストずつ発行し、
+   * 結果をマージしてからタグでフィルタする。
+   */
+  it("放送言語ごとに1リクエストずつ問い合わせ、マージした結果から両タグを含む配信だけを返す", async () => {
+    // 英語放送側は両タグ配信なし、日本語放送側に両タグ配信あり、という実態に近い状態を作る
+    const enBroadcastJson = {
+      data: [
+        {
+          user_login: "big_english_streamer",
+          user_name: "BigEnglishStreamer",
+          viewer_count: 50_000,
+          tags: ["English"],
+        },
+      ],
+    };
+    const jaBroadcastJson = createHelixStreamsJson();
+    const fetchFn = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(
+          new Response(JSON.stringify(url.includes("language=en") ? enBroadcastJson : jaBroadcastJson), {
+            status: 200,
+          }),
+        ),
+      );
+
+    const streams = await fetchLanguagePairStreams("en", "ja", { fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    const requestedUrls = fetchFn.mock.calls.map((call) => call[0] as string);
+    expect(requestedUrls[0]).toContain("/api/twitch/streams?");
+    expect(requestedUrls[0]).toContain("language=en");
+    expect(requestedUrls[0]).toContain("first=100");
+    expect(requestedUrls[1]).toContain("language=ja");
+    expect(streams?.map((stream) => stream.login)).toEqual(["eigo_sensei"]);
+  });
+
+  it("2つの結果に同じ配信が含まれる場合は1件にまとめ、視聴者数の多い順に並べる", async () => {
+    // 両言語の結果に重複して現れる配信(dup_streamer)と、視聴者数の異なる両タグ配信を用意する
+    const createBothTagStream = (login: string, viewerCount: number) => ({
+      user_login: login,
+      user_name: login,
+      viewer_count: viewerCount,
+      tags: ["English", "日本語"],
+    });
+    const enBroadcastJson = { data: [createBothTagStream("dup_streamer", 300), createBothTagStream("en_side", 100)] };
+    const jaBroadcastJson = { data: [createBothTagStream("dup_streamer", 300), createBothTagStream("ja_side", 200)] };
+    const fetchFn = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(
+          new Response(JSON.stringify(url.includes("language=en") ? enBroadcastJson : jaBroadcastJson), {
+            status: 200,
+          }),
+        ),
+      );
+
+    const streams = await fetchLanguagePairStreams("en", "ja", { fetchFn });
+
+    expect(streams?.map((stream) => stream.login)).toEqual(["dup_streamer", "ja_side", "en_side"]);
+  });
+
+  it("HTTP エラー(Helix 未設定の 503 など)の場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response("Service Unavailable", { status: 503 }));
+    expect(await fetchLanguagePairStreams("en", "ja", { fetchFn })).toBeNull();
+  });
+
+  it("片方のリクエストだけ失敗した場合も null を返す(部分的な一覧を正常時と区別できないため)", async () => {
+    const fetchFn = vi
+      .fn()
+      .mockImplementation((url: string) =>
+        Promise.resolve(
+          url.includes("language=en")
+            ? new Response(JSON.stringify(createHelixStreamsJson()), { status: 200 })
+            : new Response("Too Many Requests", { status: 429 }),
+        ),
+      );
+    expect(await fetchLanguagePairStreams("en", "ja", { fetchFn })).toBeNull();
+  });
+
+  it("ネットワークエラーの場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError("network error"));
+    expect(await fetchLanguagePairStreams("en", "ja", { fetchFn })).toBeNull();
+  });
+
+  it("200 だが data が配列でない(形式不正)場合は null を返す", async () => {
+    const fetchFn = vi.fn().mockResolvedValue(new Response(JSON.stringify({ data: "不正" }), { status: 200 }));
+    expect(await fetchLanguagePairStreams("en", "ja", { fetchFn })).toBeNull();
+  });
+
+  it("signal を各 fetch へ引き渡す(言語ペア変更時の中断用)", async () => {
+    const fetchFn = vi.fn().mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify({ data: [] }), { status: 200 })),
+    );
+    const controller = new AbortController();
+    await fetchLanguagePairStreams("en", "ja", { fetchFn, signal: controller.signal });
+    expect(fetchFn.mock.calls[0][1]).toMatchObject({ signal: controller.signal });
+    expect(fetchFn.mock.calls[1][1]).toMatchObject({ signal: controller.signal });
+  });
+});

--- a/src/lib/twitch/stream-list.ts
+++ b/src/lib/twitch/stream-list.ts
@@ -1,0 +1,173 @@
+/**
+ * 言語ペアの両タグを含むライブ配信一覧の取得(issue #90)。
+ *
+ * Helix の Get Streams API(`GET /streams?language=&first=`)を Next.js プロキシ
+ * (`/api/twitch/`)経由で呼び、選択中の言語ペア(学習言語・解説言語)の両方の
+ * 言語タグを付けたライブ配信の一覧を取得する。ウェルカム画面の配信一覧
+ * (`src/components/stream-list.tsx`)が利用する。
+ *
+ * - Helix はタグでのサーバーサイド絞り込みを提供しない(旧 `tag_ids` パラメータは廃止済み)ため、
+ *   `language` パラメータ(繰り返し指定可)で放送言語により母数を絞り、レスポンスの
+ *   `tags` 配列をクライアント側で照合する
+ * - タグは配信者の自由入力文字列のため、言語ごとにタグ候補語の対応表
+ *   (`LANGUAGE_TAG_KEYWORDS`)を持ち、大文字小文字を無視してタグ全体と照合する
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害・ネットワーク
+ *   エラー・中断は null を返し、呼び出し側は一覧セクションを表示しない
+ *   (チャンネルオートコンプリートと同じ静かなフォールバック。意図した仕様)
+ */
+
+import type { SupportedLanguage } from "@/lib/ai/prompts";
+import { extractDataArray, fetchHelixJson } from "./helix-proxy";
+
+/** 言語ペアタグ付き配信一覧の 1 件(Helix Get Streams API の 1 項目) */
+export interface TaggedStream {
+  /** 接続に使うログイン名(Helix の `user_login`) */
+  login: string;
+  /** 表示名(Helix の `user_name`。日本語名など)。無ければ login と同じ値 */
+  displayName: string;
+  /** 配信タイトル(Helix の `title`)。無ければ空文字 */
+  title: string;
+  /** 配信カテゴリ = ゲーム名(Helix の `game_name`)。無ければ空文字 */
+  category: string;
+  /** 同時視聴者数(Helix の `viewer_count`)。無ければ null(表示しないだけ) */
+  viewerCount: number | null;
+  /** サムネイル URL(Helix の `thumbnail_url` のサイズプレースホルダを置換済み)。無ければ空文字 */
+  thumbnailUrl: string;
+  /** 配信者が付けたタグ(Helix の `tags`。自由入力文字列、最大10個)。無ければ空配列 */
+  tags: string[];
+}
+
+/** サムネイル URL の `{width}x{height}` プレースホルダに埋めるサイズ(カード表示用の 16:9) */
+const THUMBNAIL_WIDTH = 440;
+const THUMBNAIL_HEIGHT = 248;
+
+/** 1 回の取得で問い合わせる配信の最大件数(Helix の `first` パラメータの上限) */
+const STREAM_FETCH_LIMIT = 100;
+
+/**
+ * 言語ごとのタグ候補語(すべて小文字)。タグは配信者の自由入力文字列のため、
+ * 英語名・ネイティブ表記・アクセント無し表記の表記ゆれを吸収する。
+ * 照合はタグ全体との一致のみ(部分一致にすると "LearnJapanese" のような
+ * 学習者向けタグを「日本語で配信中」と誤認するため)。
+ */
+const LANGUAGE_TAG_KEYWORDS: Record<SupportedLanguage, readonly string[]> = {
+  en: ["english"],
+  ja: ["japanese", "日本語"],
+  es: ["spanish", "español", "espanol"],
+  de: ["german", "deutsch"],
+  fr: ["french", "français", "francais"],
+};
+
+/**
+ * Helix の Get Streams API レスポンス(`{data: [{user_login, user_name, title, game_name,
+ * viewer_count, thumbnail_url, tags, ...}]}`)を解析して配信一覧を作る。
+ * `data` が配列でない(形式不正)場合は null を返す(取得失敗と同じ扱いにする)。
+ * `user_login` が無い項目・型が想定と異なる項目は読み飛ばし、任意フィールドは
+ * 欠けたぶんだけデフォルト値(空文字・null・空配列)で埋める(表示しないだけで一覧としては成立する)。
+ */
+export function parseTaggedStreams(json: unknown): TaggedStream[] | null {
+  const data = extractDataArray(json);
+  if (data === null) return null;
+
+  const streams: TaggedStream[] = [];
+  for (const entry of data) {
+    if (typeof entry !== "object" || entry === null) continue;
+    const record = entry as Record<string, unknown>;
+    if (typeof record.user_login !== "string" || record.user_login === "") continue;
+
+    streams.push({
+      login: record.user_login,
+      displayName:
+        typeof record.user_name === "string" && record.user_name !== ""
+          ? record.user_name
+          : record.user_login,
+      title: typeof record.title === "string" ? record.title : "",
+      category: typeof record.game_name === "string" ? record.game_name : "",
+      viewerCount: typeof record.viewer_count === "number" ? record.viewer_count : null,
+      thumbnailUrl:
+        typeof record.thumbnail_url === "string"
+          ? record.thumbnail_url
+              .replace("{width}", String(THUMBNAIL_WIDTH))
+              .replace("{height}", String(THUMBNAIL_HEIGHT))
+          : "",
+      // 実際の Helix レスポンスに同じタグの重複がありうる(そのまま表示すると React の key が重複する)ため、
+      // 文字列だけ残したうえで最初の1つだけに重複排除する
+      tags: Array.isArray(record.tags)
+        ? [...new Set(record.tags.filter((tag): tag is string => typeof tag === "string"))]
+        : [],
+    });
+  }
+  return streams;
+}
+
+/** タグ一覧に指定言語のタグ候補語(大文字小文字無視・タグ全体一致)が含まれるか */
+export function streamHasLanguageTag(tags: readonly string[], language: SupportedLanguage): boolean {
+  const keywords = LANGUAGE_TAG_KEYWORDS[language];
+  return tags.some((tag) => keywords.includes(tag.toLowerCase()));
+}
+
+/** 学習言語と解説言語の両方のタグを含む配信だけを、元の順序(Helix の視聴者数降順)を保って残す */
+export function filterStreamsByLanguagePair(
+  streams: readonly TaggedStream[],
+  learningLang: SupportedLanguage,
+  explainLang: SupportedLanguage,
+): TaggedStream[] {
+  return streams.filter(
+    (stream) => streamHasLanguageTag(stream.tags, learningLang) && streamHasLanguageTag(stream.tags, explainLang),
+  );
+}
+
+/** 指定した放送言語のライブ配信の上位 STREAM_FETCH_LIMIT 件を取得する。取得失敗・形式不正は null */
+async function fetchStreamsByBroadcastLanguage(
+  language: SupportedLanguage,
+  signal: AbortSignal | undefined,
+  fetchFn: typeof fetch,
+): Promise<TaggedStream[] | null> {
+  const params = new URLSearchParams();
+  params.append("language", language);
+  params.append("first", String(STREAM_FETCH_LIMIT));
+  // failureLog を渡さない = 失敗しても console.warn しない(中断・障害を一覧非表示として静かに扱う)
+  const json = await fetchHelixJson("streams", { params, fetchFn, signal });
+  if (json === null) return null;
+  return parseTaggedStreams(json);
+}
+
+/**
+ * Helix プロキシ(`/api/twitch/streams`)から、言語ペアの両タグを含むライブ配信の
+ * 一覧を取得する。タグ照合はクライアント側で行う(Helix はタグでの絞り込みを提供しないため)。
+ *
+ * Get Streams は視聴者数降順の上位 `first` 件しか返さないため、2言語をまとめて
+ * 1リクエストで問い合わせると、視聴者数の多い言語(例: 英語)の大規模配信が上位を
+ * 占めて両タグ配信が1件も入らない(実データで確認済み)。そのため放送言語ごとに
+ * 1リクエストずつ発行し(どちらの言語で放送していても両タグ付きなら対象にする)、
+ * 重複を除いてマージした結果を視聴者数の多い順に並べてからタグでフィルタする。
+ *
+ * 取得できない場合は null を返す(呼び出し側は一覧セクションを表示しない。意図した仕様):
+ * - Helix 未設定(プロキシが 503 を返す)・レート制限・障害などの HTTP エラー
+ * - ネットワークエラー・`signal` による中断(AbortError)
+ * - 200 だが `data` が配列でない(形式不正)ボディ
+ * - いずれか片方のリクエストだけ失敗した場合(部分的な一覧を正常時と区別できないため)
+ */
+export async function fetchLanguagePairStreams(
+  learningLang: SupportedLanguage,
+  explainLang: SupportedLanguage,
+  options: { signal?: AbortSignal; fetchFn?: typeof fetch } = {},
+): Promise<TaggedStream[] | null> {
+  const { signal, fetchFn = fetch } = options;
+  const [learningSide, explainSide] = await Promise.all([
+    fetchStreamsByBroadcastLanguage(learningLang, signal, fetchFn),
+    fetchStreamsByBroadcastLanguage(explainLang, signal, fetchFn),
+  ]);
+  if (learningSide === null || explainSide === null) return null;
+
+  // 両言語の結果に同じ配信が現れうる(放送言語は1つだが上位に重なるケースを保険で除く)ため login で重複を除く
+  const mergedByLogin = new Map<string, TaggedStream>();
+  for (const stream of [...learningSide, ...explainSide]) {
+    if (!mergedByLogin.has(stream.login)) mergedByLogin.set(stream.login, stream);
+  }
+  // 2つの結果(それぞれ視聴者数降順)を混ぜたため、全体を視聴者数の多い順に並べ直す(視聴者数不明は末尾)
+  const merged = [...mergedByLogin.values()].sort(
+    (a, b) => (b.viewerCount ?? -1) - (a.viewerCount ?? -1),
+  );
+  return filterStreamsByLanguagePair(merged, learningLang, explainLang);
+}

--- a/src/lib/twitch/stream-list.ts
+++ b/src/lib/twitch/stream-list.ts
@@ -147,6 +147,10 @@ async function fetchStreamsByBroadcastLanguage(
  * - ネットワークエラー・`signal` による中断(AbortError)
  * - 200 だが `data` が配列でない(形式不正)ボディ
  * - いずれか片方のリクエストだけ失敗した場合(部分的な一覧を正常時と区別できないため)
+ *
+ * 前提条件: learningLang と explainLang は異なる言語であること(同一言語ペアは
+ * 設定スキーマ(`lib/settings.ts` の settingsSchema)が保存時点で拒否するため発生しない。
+ * 同値の場合の重複リクエスト排除は意図的に実装していない)。
  */
 export async function fetchLanguagePairStreams(
   learningLang: SupportedLanguage,


### PR DESCRIPTION
## Summary

未接続時のウェルカム画面で、チャンネル接続UIの下に「選択中の言語ペア(Learning X · explained in Y)の両方の言語タグを含むライブ配信」の一覧をカードで表示します。カードをクリックするとそのチャンネルへ接続します。

## 変更内容

- 新規 `src/lib/twitch/stream-list.ts`: Get Streams レスポンスのパーサ(`parseTaggedStreams`)、言語タグ照合(`streamHasLanguageTag`)、両タグフィルタ(`filterStreamsByLanguagePair`)、取得(`fetchLanguagePairStreams`)
- 新規 `src/components/stream-list.tsx`: 一覧UI(`LanguagePairStreamList`)。設定ストアの復元後に取得し、言語ペア変更に追従。カードクリックで `connect` + 翻訳/Pick up のウォームアップ(チャンネル検索フォームと同じ流れ)
- 変更 `src/app/page.tsx`: ウェルカム画面に一覧を挿入し、コンテナを `max-w-5xl` + 内部スクロールに変更

## 設計上のポイント

- Helix はタグでのサーバーサイド絞り込みを提供しない(旧 `tag_ids` は廃止済み)ため、放送言語で母数を絞ってからレスポンスの `tags` 配列をクライアント側で照合します
- **言語別に1リクエストずつ発行してマージ**します。2言語をまとめて1リクエストにすると視聴者数降順の上位100件が大規模な英語配信で埋まり、両タグ配信が1件も入らないことを実データで確認済みです(言語別方式では en/ja ペアで7件ヒット)
- タグは自由入力のため、言語ごとのタグ候補語対応表(例: ja → japanese / 日本語)で大文字小文字を無視してタグ全体一致で照合します(部分一致は "LearnJapanese" 等を誤認するため不採用)
- 実際の Helix レスポンスに同じタグの重複が含まれる実例があった(React の key 重複エラーになる)ため、パース時に重複排除します
- 取得失敗時は一覧セクションごと非表示(オートコンプリートと同じ静かなフォールバック)、0件時は空状態の文言を表示します
- プロキシ(`/api/twitch/[...path]`)の allowlist に `streams` は既存のためサーバー側変更はありません

## テスト・検証

- ユニットテスト26件を追加(lib 19件・コンポーネント7件)し、`page.test.tsx` にも2件追加。全868件パス
- Lint(警告ゼロ)・型チェック・ビルドすべて成功
- 実ブラウザ(dev サーバー + 実 Twitch API)で一覧表示・スクロール・カードクリックからの接続を確認済み
- CodeRabbit レビュー実施済み(指摘1件は設定スキーマの不変条件により発生しない同一言語ペアの重複リクエスト排除の提案のため、TSDoc への前提条件明記で対応)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)