### PR TITLE
feat: 配信者パネルにタグとUptimeを表示し、Disconnectボタンを削除する

### DIFF
--- a/src/app/[channel]/page.test.tsx
+++ b/src/app/[channel]/page.test.tsx
@@ -1089,16 +1089,10 @@ describe("ChannelPage(接続中の配信embedと配信者情報)", () => {
     expect(screen.queryByRole("button", { name: "Connect" })).not.toBeInTheDocument();
   });
 
-  it("配信者情報パネルの Disconnect ボタンから切断できる", async () => {
-    const user = userEvent.setup();
-    const disconnectMock = vi.fn();
-    useChatConnectionStore.setState({ disconnect: disconnectMock });
-
+  it("配信者情報パネルに Disconnect ボタンは表示しない(切断はヘッダーのロゴクリックで行う)", () => {
     render(<ChannelPage />);
 
-    await user.click(screen.getByRole("button", { name: "Disconnect" }));
-
-    expect(disconnectMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
   });
 });
 

--- a/src/components/stream-info-panel.test.tsx
+++ b/src/components/stream-info-panel.test.tsx
@@ -7,14 +7,14 @@
  * - 配信者のアバター(avatars ストアに取得済みの場合のみ)と、アバター取得の要求
  * - 配信タイトル・カテゴリ(ボックスアート画像はゲームIDから取得できた場合のみ)
  * - 同時視聴者数(取得できた場合のみ)
- * - 接続状態と Disconnect ボタン
+ * - 配信タグ(取得できた場合のみ)と配信開始からの経過時間(1秒ごとに更新)
+ * - 接続状態のラベル(Disconnect ボタンは持たない。切断はヘッダーのロゴクリックで行う)
  *
  * 配信情報・アバターは各ストアの state を直接書き換えて注入し、
  * ボックスアート取得(`fetchGameBoxArtUrl`)とアバター取得要求(`requestAvatar`)はモックする。
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import type { StreamInfo } from "@/lib/twitch/stream-info";
 import { resetAvatarsForTests, useAvatarStore } from "@/store/avatars";
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
@@ -43,6 +43,8 @@ const サンプル配信情報: StreamInfo = {
   broadcasterName: "ZackRawrr",
   gameId: "18122",
   viewerCount: 4321,
+  tags: ["English", "MMORPG"],
+  startedAt: "2026-09-03T10:00:00Z",
 };
 
 beforeEach(() => {
@@ -119,6 +121,61 @@ describe("StreamInfoPanel(配信情報あり)", () => {
     expect(screen.queryByRole("img", { name: "World of Warcraft" })).toBeNull();
     expect(screen.getByText("World of Warcraft")).toBeInTheDocument();
   });
+
+  it("配信タグをチップのリストとして表示する", () => {
+    render(<StreamInfoPanel />);
+
+    const tagList = screen.getByRole("list", { name: "Stream tags" });
+    const tags = Array.from(tagList.querySelectorAll("li")).map((li) => li.textContent);
+    expect(tags).toEqual(["English", "MMORPG"]);
+  });
+
+  it("タグが空の場合、タグのリスト自体を表示しない", () => {
+    useStreamInfoStore.setState({ streamInfo: { ...サンプル配信情報, tags: [] } });
+
+    render(<StreamInfoPanel />);
+
+    expect(screen.queryByRole("list", { name: "Stream tags" })).toBeNull();
+  });
+});
+
+describe("StreamInfoPanel(配信開始からの経過時間)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    // 配信開始(10:00:00Z)から 1時間2分3秒 経過した時点に現在時刻を固定する
+    vi.setSystemTime(new Date("2026-09-03T11:02:03Z"));
+    useStreamInfoStore.setState({ streamInfo: サンプル配信情報 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("配信開始からの経過時間を H:MM:SS 形式で表示し、スクリーンリーダー向けに uptime の単位を補う", () => {
+    render(<StreamInfoPanel />);
+
+    const unit = screen.getByText("uptime");
+    expect(unit.className).toContain("sr-only");
+    expect(unit.parentElement).toHaveTextContent("1:02:03 uptime");
+  });
+
+  it("経過時間は1秒ごとに更新される", () => {
+    render(<StreamInfoPanel />);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText("uptime").parentElement).toHaveTextContent("1:02:04 uptime");
+  });
+
+  it("配信開始日時が取得できていない場合、経過時間を表示しない", () => {
+    useStreamInfoStore.setState({ streamInfo: { ...サンプル配信情報, startedAt: null } });
+
+    render(<StreamInfoPanel />);
+
+    expect(screen.queryByText("uptime")).toBeNull();
+  });
 });
 
 describe("StreamInfoPanel(配信情報なし = オフライン・Helix 利用不可)", () => {
@@ -136,7 +193,7 @@ describe("StreamInfoPanel(配信情報なし = オフライン・Helix 利用不
   });
 });
 
-describe("StreamInfoPanel(接続状態と切断)", () => {
+describe("StreamInfoPanel(接続状態)", () => {
   it("接続状態のラベルを表示する", () => {
     useChatConnectionStore.setState({ connectionState: "reconnecting" });
 
@@ -145,15 +202,9 @@ describe("StreamInfoPanel(接続状態と切断)", () => {
     expect(screen.getByText(/Reconnecting/)).toBeInTheDocument();
   });
 
-  it("Disconnect ボタンを押すと切断処理を呼ぶ", async () => {
-    const user = userEvent.setup();
-    const disconnectMock = vi.fn();
-    useChatConnectionStore.setState({ disconnect: disconnectMock });
-
+  it("Disconnect ボタンは表示しない(切断はヘッダーのロゴクリックで行う)", () => {
     render(<StreamInfoPanel />);
 
-    await user.click(screen.getByRole("button", { name: "Disconnect" }));
-
-    expect(disconnectMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Disconnect" })).toBeNull();
   });
 });

--- a/src/components/stream-info-panel.test.tsx
+++ b/src/components/stream-info-panel.test.tsx
@@ -169,6 +169,19 @@ describe("StreamInfoPanel(配信開始からの経過時間)", () => {
     expect(screen.getByText("uptime").parentElement).toHaveTextContent("1:02:04 uptime");
   });
 
+  it("マウント後に配信情報の読み込みが完了した場合も、表示直後から最新の経過時間を表示する", () => {
+    // 未読み込みの状態でマウントし、10秒後に読み込みが完了したケース
+    useStreamInfoStore.setState({ streamInfo: null });
+    render(<StreamInfoPanel />);
+
+    act(() => {
+      vi.advanceTimersByTime(10_000);
+      useStreamInfoStore.setState({ streamInfo: サンプル配信情報 });
+    });
+
+    expect(screen.getByText("uptime").parentElement).toHaveTextContent("1:02:13 uptime");
+  });
+
   it("配信開始日時が取得できていない場合、経過時間を表示しない", () => {
     useStreamInfoStore.setState({ streamInfo: { ...サンプル配信情報, startedAt: null } });
 

--- a/src/components/stream-info-panel.tsx
+++ b/src/components/stream-info-panel.tsx
@@ -7,7 +7,10 @@
  * - 配信カテゴリ(ゲーム名)。ゲームIDからボックスアート画像を取得できた場合は画像も表示する
  * - 同時視聴者数(Helix から取得できた場合のみ)。Twitch 本体と同様に、
  *   配信者名の横へ赤色の人アイコン + 桁区切りの数字で表示する
- * - 接続状態のラベルと Disconnect ボタン
+ * - 配信開始からの経過時間(Helix の `started_at` を取得できた場合のみ。1秒ごとに更新)
+ * - 配信タグ(取得できた場合のみ、チップのリストで表示)
+ * - 接続状態のラベル(Disconnect ボタンは持たない。切断はヘッダーのロゴクリック
+ *   (site-header.tsx)で行う)
  *
  * 配信情報は stream-info ストア(接続時に読み込み済み)を購読して表示するだけで、
  * このパネル自身は Helix を呼ばない(例外はボックスアート。ゲームIDが判明したときに
@@ -17,8 +20,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { UserIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { ClockIcon, UserIcon } from "lucide-react";
 import type { ConnectionState } from "@/lib/twitch/irc-client";
 import { fetchGameBoxArtUrl } from "@/lib/twitch/game-box-art";
 import { requestAvatar, useAvatarStore } from "@/store/avatars";
@@ -37,10 +39,24 @@ export const CONNECTION_STATE_LABEL: Record<ConnectionState, string> = {
 /** 同時視聴者数の桁区切り表示(UI は英語のためロケールも en-US 固定) */
 const VIEWER_COUNT_FORMAT = new Intl.NumberFormat("en-US");
 
+/** 経過時間の再計算間隔。Twitch 本体の稼働時間表示と同様に秒単位で進める */
+const UPTIME_TICK_INTERVAL_MS = 1_000;
+
+/**
+ * 配信開始からの経過ミリ秒を `H:MM:SS` 形式(時は桁埋めなし)にする。
+ * 端末の時計ずれなどで負になった場合は 0 秒として扱う。
+ */
+function formatUptime(elapsedMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+  return `${hours}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
 export function StreamInfoPanel() {
   const channel = useChatConnectionStore((state) => state.channel);
   const connectionState = useChatConnectionStore((state) => state.connectionState);
-  const disconnect = useChatConnectionStore((state) => state.disconnect);
   const streamInfo = useStreamInfoStore((state) => state.streamInfo);
 
   // 配信者のアバター。発言者アバターと同じ共通バッチ(avatars ストア)へ取得を要求する
@@ -67,6 +83,17 @@ export function StreamInfoPanel() {
     };
   }, [gameId]);
   const boxArtUrl = boxArt !== null && boxArt.gameId === gameId ? boxArt.url : null;
+
+  // 配信開始からの経過時間。startedAt がある間だけ、現在時刻を1秒ごとに更新して再計算する
+  // (初期値はマウント時の現在時刻。読み込み完了が遅れた場合も、最初の tick で最新に追従する)
+  const startedAt = streamInfo?.startedAt ?? null;
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt === null) return;
+    const timerId = setInterval(() => setNow(Date.now()), UPTIME_TICK_INTERVAL_MS);
+    return () => clearInterval(timerId);
+  }, [startedAt]);
+  const uptimeText = startedAt !== null ? formatUptime(now - Date.parse(startedAt)) : null;
 
   // 配信情報が無い間(オフライン・Helix 利用不可・読み込み中)は接続中のチャンネル名で代用する
   const displayName =
@@ -101,9 +128,17 @@ export function StreamInfoPanel() {
             </span>
           </span>
         )}
-        <Button onClick={disconnect} variant="outline" size="sm">
-          Disconnect
-        </Button>
+        {uptimeText !== null && (
+          // Twitch 本体と同様の稼働時間表示。画面には時間のみを表示し、
+          // スクリーンリーダーには sr-only の「uptime」で意味を補う
+          <span className="flex shrink-0 items-center gap-1 text-sm font-medium text-muted-foreground tabular-nums">
+            <ClockIcon aria-hidden="true" className="size-4" />
+            <span>
+              {uptimeText}
+              <span className="sr-only"> uptime</span>
+            </span>
+          </span>
+        )}
       </div>
       {streamInfo !== null && (
         <div className="flex min-h-0 flex-1 gap-3">
@@ -114,6 +149,19 @@ export function StreamInfoPanel() {
           <div className="min-w-0 space-y-1">
             <p className="text-sm break-words">{streamInfo.title}</p>
             {streamInfo.category !== "" && <p className="text-sm text-muted-foreground">{streamInfo.category}</p>}
+            {streamInfo.tags.length > 0 && (
+              // Twitch 本体と同様のタグチップ。取得できた場合のみ表示する
+              <ul aria-label="Stream tags" className="flex flex-wrap gap-1.5 pt-1">
+                {streamInfo.tags.map((tag) => (
+                  <li
+                    key={tag}
+                    className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                  >
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
       )}

--- a/src/components/stream-info-panel.tsx
+++ b/src/components/stream-info-panel.tsx
@@ -19,7 +19,7 @@
  */
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore } from "react";
 import { ClockIcon, UserIcon } from "lucide-react";
 import type { ConnectionState } from "@/lib/twitch/irc-client";
 import { fetchGameBoxArtUrl } from "@/lib/twitch/game-box-art";
@@ -41,6 +41,27 @@ const VIEWER_COUNT_FORMAT = new Intl.NumberFormat("en-US");
 
 /** 経過時間の再計算間隔。Twitch 本体の稼働時間表示と同様に秒単位で進める */
 const UPTIME_TICK_INTERVAL_MS = 1_000;
+
+/**
+ * 現在時刻(秒単位)を「外部ストア」として購読するための関数群。
+ * レンダー中の `Date.now()` 呼び出し(純粋性ルール違反)と effect 内の同期 setState を
+ * 避けるため、useSyncExternalStore で現在時刻を読む。
+ */
+/** 現在時刻のスナップショット(秒単位。ミリ秒のままだと毎レンダーで値が変わってしまうため丸める) */
+function getNowSecondsSnapshot(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+/** 1秒ごとに再読み取りを通知する購読関数(配信開始日時がある間だけ使う) */
+function subscribeUptimeTick(onTick: () => void): () => void {
+  const timerId = setInterval(onTick, UPTIME_TICK_INTERVAL_MS);
+  return () => clearInterval(timerId);
+}
+
+/** 何も通知しない購読関数(配信開始日時が無い間は tick を回さない) */
+function subscribeNothing(): () => void {
+  return () => {};
+}
 
 /**
  * 配信開始からの経過ミリ秒を `H:MM:SS` 形式(時は桁埋めなし)にする。
@@ -84,16 +105,16 @@ export function StreamInfoPanel() {
   }, [gameId]);
   const boxArtUrl = boxArt !== null && boxArt.gameId === gameId ? boxArt.url : null;
 
-  // 配信開始からの経過時間。startedAt がある間だけ、現在時刻を1秒ごとに更新して再計算する
-  // (初期値はマウント時の現在時刻。読み込み完了が遅れた場合も、最初の tick で最新に追従する)
+  // 配信開始からの経過時間。現在時刻(秒単位)を外部ストアとして購読し、
+  // startedAt がある間だけ1秒ごとに再読み取りする。読み込み完了が遅れた場合も、
+  // そのレンダーで最新のスナップショットを読むため表示直後から正しい値になる
   const startedAt = streamInfo?.startedAt ?? null;
-  const [now, setNow] = useState(() => Date.now());
-  useEffect(() => {
-    if (startedAt === null) return;
-    const timerId = setInterval(() => setNow(Date.now()), UPTIME_TICK_INTERVAL_MS);
-    return () => clearInterval(timerId);
-  }, [startedAt]);
-  const uptimeText = startedAt !== null ? formatUptime(now - Date.parse(startedAt)) : null;
+  const nowSeconds = useSyncExternalStore(
+    startedAt !== null ? subscribeUptimeTick : subscribeNothing,
+    getNowSecondsSnapshot,
+    getNowSecondsSnapshot,
+  );
+  const uptimeText = startedAt !== null ? formatUptime(nowSeconds * 1000 - Date.parse(startedAt)) : null;
 
   // 配信情報が無い間(オフライン・Helix 利用不可・読み込み中)は接続中のチャンネル名で代用する
   const displayName =

--- a/src/lib/twitch/stream-info.test.ts
+++ b/src/lib/twitch/stream-info.test.ts
@@ -26,6 +26,8 @@ function createHelixStreamsJson(overrides: Record<string, unknown> = {}): unknow
         game_id: "18122",
         game_name: "World of Warcraft",
         viewer_count: 4321,
+        tags: ["English", "FPS"],
+        started_at: "2026-09-03T10:00:00Z",
         ...overrides,
       },
     ],
@@ -41,6 +43,8 @@ const 期待する配信情報 = {
   broadcasterName: "ZackRawrr",
   gameId: "18122",
   viewerCount: 4321,
+  tags: ["English", "FPS"],
+  startedAt: "2026-09-03T10:00:00Z",
 };
 
 describe("parseStreamInfo", () => {
@@ -81,6 +85,39 @@ describe("parseStreamInfo", () => {
     expect(parseStreamInfo(createHelixStreamsJson({ viewer_count: "many" }))).toEqual({
       ...期待する配信情報,
       viewerCount: null,
+    });
+  });
+
+  it("タグが無い・配列でない場合は空配列として保持する(タグを表示しないだけ)", () => {
+    expect(parseStreamInfo(createHelixStreamsJson({ tags: undefined }))).toEqual({
+      ...期待する配信情報,
+      tags: [],
+    });
+    expect(parseStreamInfo(createHelixStreamsJson({ tags: "not-an-array" }))).toEqual({
+      ...期待する配信情報,
+      tags: [],
+    });
+  });
+
+  it("タグの配列に文字列以外の要素が混ざっている場合は、文字列の要素だけを保持する", () => {
+    expect(parseStreamInfo(createHelixStreamsJson({ tags: ["English", 123, null, "FPS"] }))).toEqual({
+      ...期待する配信情報,
+      tags: ["English", "FPS"],
+    });
+  });
+
+  it("配信開始日時が無い・型が違う・日時として解釈できない場合は null として保持する(経過時間を表示しないだけ)", () => {
+    expect(parseStreamInfo(createHelixStreamsJson({ started_at: undefined }))).toEqual({
+      ...期待する配信情報,
+      startedAt: null,
+    });
+    expect(parseStreamInfo(createHelixStreamsJson({ started_at: 1234567890 }))).toEqual({
+      ...期待する配信情報,
+      startedAt: null,
+    });
+    expect(parseStreamInfo(createHelixStreamsJson({ started_at: "invalid-date" }))).toEqual({
+      ...期待する配信情報,
+      startedAt: null,
     });
   });
 
@@ -165,6 +202,12 @@ describe("streamInfoPromptKey", () => {
     expect(streamInfoPromptKey({ ...期待する配信情報, viewerCount: 9999 })).toBe(
       streamInfoPromptKey(期待する配信情報),
     );
+  });
+
+  it("タグ・配信開始日時が変わってもキーは変わらない(プロンプトに焼き込まないため)", () => {
+    expect(
+      streamInfoPromptKey({ ...期待する配信情報, tags: ["別のタグ"], startedAt: "2026-09-03T12:00:00Z" }),
+    ).toBe(streamInfoPromptKey(期待する配信情報));
   });
 
   it("null(未読み込み・オフライン)の場合は空文字を返す", () => {

--- a/src/lib/twitch/stream-info.ts
+++ b/src/lib/twitch/stream-info.ts
@@ -32,6 +32,13 @@ export interface StreamInfo {
   gameId: string;
   /** 同時視聴者数(Helix の `viewer_count`)。取得できない場合は null(表示しないだけ) */
   viewerCount: number | null;
+  /** 配信タグ(Helix の `tags`)。取得できない場合は空配列(表示しないだけ) */
+  tags: string[];
+  /**
+   * 配信開始日時(Helix の `started_at`。ISO 8601 形式の文字列)。
+   * 取得できない・日時として解釈できない場合は null(経過時間を表示しないだけ)
+   */
+  startedAt: string | null;
 }
 
 /**
@@ -39,7 +46,8 @@ export interface StreamInfo {
  * 解析して StreamInfo を作る。オフライン(`data` が空)・形式が想定と異なる場合・
  * タイトルとカテゴリの両方が空の場合(文脈として意味が無い)は null を返す。
  * 配信者情報(ID・username・DisplayName)・ゲーム ID は取得できないフィールドだけを空文字として、
- * 視聴者数は null として読み飛ばす(いずれも表示しないだけで、文脈としては成立する)。
+ * 視聴者数は null、タグは空配列、配信開始日時は null として読み飛ばす
+ * (いずれも表示しないだけで、文脈としては成立する)。
  */
 export function parseStreamInfo(json: unknown): StreamInfo | null {
   const data = extractDataArray(json);
@@ -58,7 +66,12 @@ export function parseStreamInfo(json: unknown): StreamInfo | null {
   const broadcasterName = typeof record.user_name === "string" ? record.user_name : "";
   const gameId = typeof record.game_id === "string" ? record.game_id : "";
   const viewerCount = typeof record.viewer_count === "number" ? record.viewer_count : null;
-  return { title, category, broadcasterId, broadcasterLogin, broadcasterName, gameId, viewerCount };
+  // タグは文字列の要素だけを保持する(想定外の型の要素は読み飛ばす)
+  const tags = Array.isArray(record.tags) ? record.tags.filter((tag): tag is string => typeof tag === "string") : [];
+  // 配信開始日時は日時として解釈できる文字列だけを保持する(経過時間の計算に使うため)
+  const startedAt =
+    typeof record.started_at === "string" && !Number.isNaN(Date.parse(record.started_at)) ? record.started_at : null;
+  return { title, category, broadcasterId, broadcasterLogin, broadcasterName, gameId, viewerCount, tags, startedAt };
 }
 
 /**

--- a/src/store/stream-info.test.ts
+++ b/src/store/stream-info.test.ts
@@ -33,6 +33,8 @@ const FAKE_STREAM_INFO: StreamInfo = {
   broadcasterName: "ZackRawrr",
   gameId: "18122",
   viewerCount: 4321,
+  tags: ["English", "MMORPG"],
+  startedAt: "2026-09-03T10:00:00Z",
 };
 
 /** リフレッシュで受け取る更新後の配信情報(視聴者数・カテゴリが変化したケース) */
@@ -106,6 +108,8 @@ describe("loadStreamInfo", () => {
         broadcasterName: "OldChannel",
         gameId: "111",
         viewerCount: 10,
+        tags: [],
+        startedAt: null,
       },
     });
     await firstLoading;


### PR DESCRIPTION
## Summary

配信者情報パネル(StreamInfoPanel)の空きスペースを活用し、Twitch本体に近い情報表示へ拡充します。

- `StreamInfo` に配信タグ(Helix `tags`)と配信開始日時(Helix `started_at`)を追加しました。取得できない場合はタグは空配列・開始日時は null として読み飛ばします(表示しないだけで文脈は成立)
- パネルにタグチップ(カテゴリの下)と、配信開始からの経過時間(ヘッダー行に時計アイコン + `H:MM:SS`、1秒ごとに更新)を表示します
- Disconnect ボタンを削除しました。切断の導線はヘッダーのロゴクリック(site-header)に集約します
- 経過時間の現在時刻は `useSyncExternalStore` で購読し、レンダー純粋性ルールと effect 内同期 setState の Lint 違反を避けつつ、配信情報の読み込みが遅れた場合も表示直後から正しい値になります

## Test plan

- [x] `npm run lint` / `npm run type-check` / `npm test`(883件) / `npm run build` すべて成功
- [x] CodeRabbitレビュー実施(指摘1件: 経過時間の初期表示が古くなる → useSyncExternalStore で対応済み)
- [ ] 実配信チャンネルへ接続し、タグ・経過時間の表示と Disconnect ボタンが無いことを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)