### PR TITLE
feat: 逆方向Pick upで機械翻訳の幻覚に由来する固有名詞的な語句を落とす

### DIFF
--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -299,6 +299,17 @@ describe("filterTranslationArtifactTerms", () => {
     expect(filterTranslationArtifactTerms(terms, "en")).toEqual(terms);
   });
 
+  it("既知のトレードオフ: 実在する混在ケースの語(iPhone / eBay)や大文字始まりの複合語(T-shirt / X-ray)も落ちる(綴りの形だけで判定するため。幻覚を学習者に見せない精度を優先)", () => {
+    const terms = [
+      { term: "iPhone", meaning: "Appleのスマートフォン" },
+      { term: "eBay", meaning: "オークションサイト" },
+      { term: "T-shirt", meaning: "Tシャツ" },
+      { term: "X-ray", meaning: "レントゲン" },
+    ];
+
+    expect(filterTranslationArtifactTerms(terms, "en")).toEqual([]);
+  });
+
   it("学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれるため、何も落とさずそのまま返す", () => {
     const terms = [
       { term: "Feierabend machen", meaning: "仕事を切り上げる" },

--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -5,9 +5,11 @@
  * - `preparePickupInput`: emote・@メンション・URL を本文から除き、LLM に渡す本文を組み立てる
  * - `filterPickupTerms`: LLM が返した語句のうち emote 名・@メンション・文字を含まない語句・笑い声(issue #30)・
  *   相槌・感嘆詞(issue #33)を落とす
+ * - `filterTranslationArtifactTerms`: 逆方向 Pick up(機械翻訳の訳文からの抽出)専用。訳文の誤訳・幻覚に
+ *   由来しやすい固有名詞的な語句(大文字小文字の混在・大文字始まりのハイフン語)を落とす
  */
 import { describe, expect, it } from "vitest";
-import { filterPickupTerms, preparePickupInput } from "./pickup-filter";
+import { filterPickupTerms, filterTranslationArtifactTerms, preparePickupInput } from "./pickup-filter";
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
 
 describe("preparePickupInput", () => {
@@ -243,5 +245,72 @@ describe("filterPickupTerms", () => {
     const terms = [{ term: "sticky", meaning: "スタン状態にする" }];
 
     expect(filterPickupTerms(terms, 前処理済み)).toEqual(terms);
+  });
+});
+
+describe("filterTranslationArtifactTerms", () => {
+  // 実際に観測した誤り: 日本語チャット「エオルゼア」「タタルさんと遊んでた」を英訳した際に
+  // 機械翻訳が "EoR" という実在しない略記や固有名詞込みの句を作り、Pick up がそれを教材にしてしまった
+
+  it("2文字目以降に大文字を含み小文字も混在する語句(機械翻訳が作った固有名詞・偽の略記)を落とす", () => {
+    const terms = [
+      { term: "EoR", meaning: "Final Fantasy XIV略称(世界観)" },
+      { term: "juggling with Tataru", meaning: "タタルとのやり取りを繰り返していた" },
+      { term: "Becoming a Dragoon?!", meaning: "竜騎士になるの！？" },
+      { term: "no cap", meaning: "嘘じゃない、マジで" },
+    ];
+
+    expect(filterTranslationArtifactTerms(terms, "en")).toEqual([{ term: "no cap", meaning: "嘘じゃない、マジで" }]);
+  });
+
+  it("文頭だけが大文字の語句(文頭に置かれただけの普通の表現)は落とさない", () => {
+    const terms = [{ term: "Toss it!", meaning: "捨てる！" }];
+
+    expect(filterTranslationArtifactTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("全大文字の略語(LOL / GG)は落とさない", () => {
+    const terms = [
+      { term: "LOL", meaning: "爆笑" },
+      { term: "GG", meaning: "good game の略、お疲れ" },
+    ];
+
+    expect(filterTranslationArtifactTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("大文字で始まりハイフンを含む単語(訳文に残った音写・日本語の敬称)を含む語句を落とす", () => {
+    const terms = [
+      { term: "Conto-me", meaning: "話してくれ！(相槌の表現)" },
+      { term: "Twitch-san", meaning: "Twitchの配信者への敬称" },
+      { term: "uh-oh", meaning: "まずいことが起きたときの声" },
+    ];
+
+    expect(filterTranslationArtifactTerms(terms, "en")).toEqual([
+      { term: "uh-oh", meaning: "まずいことが起きたときの声" },
+    ]);
+  });
+
+  it("小文字だけの語句(通常のスラング・イディオム)は落とさない", () => {
+    const terms = [
+      { term: "no cap", meaning: "嘘じゃない、マジで" },
+      { term: "making a mountain out of a molehill", meaning: "些細な事を大げさに捉える" },
+    ];
+
+    expect(filterTranslationArtifactTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれるため、何も落とさずそのまま返す", () => {
+    const terms = [
+      { term: "Feierabend machen", meaning: "仕事を切り上げる" },
+      { term: "auf dem Schlauch stehen", meaning: "ピンとこない、理解できない" },
+    ];
+
+    expect(filterTranslationArtifactTerms(terms, "de")).toEqual(terms);
+  });
+
+  it("学ぶ言語が日本語の場合、ラテン文字を含まない語句はそのまま残す", () => {
+    const terms = [{ term: "それな", meaning: "共感を表す相槌" }];
+
+    expect(filterTranslationArtifactTerms(terms, "ja")).toEqual(terms);
   });
 });

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -11,11 +11,14 @@
  *   `!` で始まるチャットコマンド・文字を1つも含まない語句(数字や記号だけ)・
  *   `haha` のような笑い声(issue #30)・`oh` / `wow` / `hmm` のような相槌・感嘆詞(issue #33)・
  *   呼び出し側が指定した除外名(表示中の発言者名など)を落とし、重複する語句は1件にまとめる
+ * - `filterTranslationArtifactTerms`: 逆方向 Pick up(機械翻訳の訳文からの抽出)専用の後段フィルタ。
+ *   訳文の誤訳・幻覚に由来しやすい固有名詞的な語句を落とす
  *
  * 翻訳列は「emote 名はそのまま残す」設計のため、この処理は Pick up 専用である。
  */
 import { splitMessageIntoSegments } from "@/lib/twitch/emotes";
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
+import type { SupportedLanguage } from "./prompts";
 import type { PickupTerm } from "./schemas";
 
 /** `preparePickupInput` の結果。LLM に渡す本文と、後段フィルタの照合に使う情報 */
@@ -126,4 +129,42 @@ export function filterPickupTerms(
     seen.add(normalized);
     return true;
   });
+}
+
+/** 大文字(どの言語の大文字でもよい) */
+const UPPERCASE_LETTER_PATTERN = /\p{Lu}/u;
+/** 小文字(どの言語の小文字でもよい) */
+const LOWERCASE_LETTER_PATTERN = /\p{Ll}/u;
+/** 大文字で始まりハイフンを含む単語(`Conto-me` / `Twitch-san` のような音写・敬称の残骸) */
+const CAPITALIZED_HYPHENATED_WORD_PATTERN = /^\p{Lu}\S*-/u;
+
+/**
+ * 逆方向 Pick up(解説言語の発言を学ぶ言語へ機械翻訳した訳文からの抽出。issue #68)専用の後段フィルタ。
+ *
+ * 訳文は Gemini Nano が生成した機械翻訳であり、原文の固有名詞・挨拶・あだ名を誤訳・音写した
+ * 実在しない「表現」が混ざる(実例: 「エオルゼア」→ "EoR"、「こんとめー」→ "Conto-me")。
+ * 原文照合(`pickup.ts`)は訳文自体が壊れていると通過してしまうため、固有名詞的な形の語句を
+ * 決定的に落とす。順方向(実際のチャット本文からの抽出)には適用しないこと。
+ *
+ * 落とす条件(いずれかに該当):
+ * - 2文字目以降に大文字を含み、かつ小文字も含む語句("EoR" / "juggling with Tataru")。
+ *   文頭に置かれただけの表現("Toss it!")や全大文字の略語("LOL")は該当しない
+ * - 大文字で始まりハイフンを含む単語を含む語句("Conto-me" / "Twitch-san")。
+ *   小文字のハイフン語("uh-oh")は該当しない
+ *
+ * 学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれ、正当な表現まで落としてしまうため何も落とさない。
+ */
+export function filterTranslationArtifactTerms(terms: PickupTerm[], learningLang: SupportedLanguage): PickupTerm[] {
+  if (learningLang === "de") return terms;
+  return terms.filter((item) => {
+    const trimmed = item.term.trim();
+    if (UPPERCASE_LETTER_PATTERN.test(trimmed.slice(1)) && LOWERCASE_LETTER_PATTERN.test(trimmed)) return false;
+    if (trimmed.split(/\s+/).some(hasCapitalizedHyphenatedForm)) return false;
+    return true;
+  });
+}
+
+/** 単語の前後の記号(括弧・引用符など)を外したうえで、大文字始まりのハイフン語かを判定する */
+function hasCapitalizedHyphenatedForm(word: string): boolean {
+  return CAPITALIZED_HYPHENATED_WORD_PATTERN.test(word.replace(SURROUNDING_NON_LETTERS_PATTERN, ""));
 }

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -153,6 +153,12 @@ const CAPITALIZED_HYPHENATED_WORD_PATTERN = /^\p{Lu}\S*-/u;
  *   小文字のハイフン語("uh-oh")は該当しない
  *
  * 学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれ、正当な表現まで落としてしまうため何も落とさない。
+ *
+ * 既知のトレードオフ: 綴りの形だけで判定するため、実在する混在ケースの語("iPhone" / "eBay")や
+ * 大文字始まりの複合語("T-shirt" / "X-ray")も落ちる。ブランド名は固有名詞として Pick up の対象外に
+ * したい語であり、普通の複合語はスラング辞典としての抽出対象になりにくいため、機械翻訳の幻覚を
+ * 学習者に見せないこと(精度)を優先して許容する。決定的処理のままこれらを救う手段は語彙リストの
+ * 導入しかなく、必要になった時点で表現リスト方式(スコープ拡大の後続作業)と合わせて検討する。
  */
 export function filterTranslationArtifactTerms(terms: PickupTerm[], learningLang: SupportedLanguage): PickupTerm[] {
   if (learningLang === "de") return terms;

--- a/src/store/pickups.test.ts
+++ b/src/store/pickups.test.ts
@@ -242,4 +242,37 @@ describe("startPickupPipeline(逆方向: 翻訳パイプラインの訳文を再
     });
     stop();
   });
+
+  it("逆方向では機械翻訳が作った固有名詞的な語句(大文字小文字の混在・大文字始まりのハイフン語)を結果から落とす", async () => {
+    const { deps, emit } = createDeps({
+      detectedLanguage: "ja",
+      reversePromptResults: [
+        Promise.resolve(
+          JSON.stringify({
+            terms: [
+              // 「エオルゼア」の誤訳として機械翻訳が作った実在しない略記
+              { term: "EoR", meaning: "Final Fantasy XIV略称(世界観)" },
+              // 挨拶「こんとめー」が音写のまま訳文に残ったもの
+              { term: "Conto-me", meaning: "話してくれ！(相槌の表現)" },
+              { term: "no cap", meaning: "嘘じゃない、マジで" },
+            ],
+          }),
+        ),
+      ],
+    });
+    useTranslationStore.setState({
+      entries: { "msg-1": { status: "done", segments: [{ type: "text", text: "Conto-me! EoR is done, no cap" }] } },
+    });
+
+    const stop = startPickupPipeline(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "こんとめー！エオルゼアは終わりや、マジで" }));
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "no cap", meaning: "嘘じゃない、マジで" }],
+    });
+    stop();
+  });
 });

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -16,10 +16,12 @@
  *   `auto-pipeline.ts` が行う。ベースセッションは「学ぶ言語 × 解説言語」のペアから組み立てる
  * - 逆方向(解説言語の発言): 訳文を自前で生成せず、翻訳パイプライン(`translations.ts`)が生成した
  *   学ぶ言語の訳文(翻訳列に表示されるもの)を待って再利用し、その訳文に対して順方向と同じ抽出を行う
- *   (issue #68。訳文の二重生成と、照合対象と表示訳文の不整合を防ぐ)
+ *   (issue #68。訳文の二重生成と、照合対象と表示訳文の不整合を防ぐ)。抽出結果からは、機械翻訳の
+ *   誤訳・幻覚に由来しやすい固有名詞的な語句を `filterTranslationArtifactTerms` で決定的に落とす
  * - Prompt API の利用可否は `prompt-api.ts` の共有ストアを参照する(翻訳列と共通)
  */
 import { createPickupBaseSessionFactory, pickUpExpressions } from "@/lib/ai/pickup";
+import { filterTranslationArtifactTerms } from "@/lib/ai/pickup-filter";
 import { LowPriorityQueueOverflowError } from "@/lib/ai/session-pool";
 import type { MessageSegment } from "@/lib/twitch/emotes";
 import type { PickupTerm } from "@/lib/ai/schemas";
@@ -70,11 +72,14 @@ const pipeline = createAutoPipeline<PickupDone>({
     const segments = await waitForReverseTranslation(message.id, context.signal);
     const translationText = segments.map((segment) => (segment.type === "text" ? segment.text : " ")).join("");
     // 訳文は emote を空白化済みのため emotes は渡さない(順方向と異なり emote の位置情報も存在しない)
-    return pickUpExpressions(pool, translationText, {
+    const result = await pickUpExpressions(pool, translationText, {
       priority: "low",
       signal: context.signal,
       excludedNames: collectExcludedNames(context),
     });
+    // 訳文は機械翻訳のため、誤訳・幻覚に由来する固有名詞的な語句を決定的に落とす。
+    // 学ぶ言語はベースセッション生成時(createReverseBaseSession)と同じく生成時点のストアの値を読めばよい
+    return { terms: filterTranslationArtifactTerms(result.terms, useSettingsStore.getState().settings.learningLang) };
   },
 });
 


### PR DESCRIPTION
## Summary

逆方向Pick up(解説言語の発言を学ぶ言語へ機械翻訳した訳文からの抽出。#68)では、機械翻訳が原文の固有名詞・挨拶・あだ名を誤訳・音写した実在しない「表現」(実例: 「エオルゼア」→ "EoR"、「こんとめー」→ "Conto-me"、「ツイッチさん」→ "Twitch-san")を、意味まで捏造して学習者に提示してしまっていました。`pickup.ts` の原文照合は訳文自体が壊れていると通過するため、決定的な後段フィルタで落とします。

## 変更内容

- `filterTranslationArtifactTerms` を `pickup-filter.ts` に追加(逆方向専用)
  - 2文字目以降に大文字を含み小文字も混在する語句を落とす("EoR" / "juggling with Tataru" / "Becoming a Dragoon?!")。文頭だけ大文字の表現("Toss it!")や全大文字の略語("LOL" / "GG")は残す
  - 大文字始まりでハイフンを含む単語を含む語句を落とす("Conto-me" / "Twitch-san")。小文字のハイフン語("uh-oh")は残す
  - 学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれるため適用しない
- `store/pickups.ts` の `runReverseJob` で抽出結果に適用(順方向の実チャット本文には適用しない)

## 既知のトレードオフ

綴りの形だけで判定するため、実在する混在ケースの語("iPhone" / "eBay")や大文字始まりの複合語("T-shirt" / "X-ray")も落ちます。ブランド名は固有名詞としてPick upの対象外にしたい語であり、機械翻訳の幻覚を学習者に見せない精度を優先して許容します(TSDocとテストに明文化済み)。救済には語彙リストの導入が必要なため、Pick upスコープ拡大の後続作業と合わせて検討します。

## テスト

- `pickup-filter.test.ts`: フィルタ規則ごとの単体テスト(実際に観測した誤り実例を使用)
- `pickups.test.ts`: 逆方向パイプラインへの配線テスト
- lint / type-check / 全テスト(892件) / build すべて成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)