### PR TITLE
feat: Pick upの決定的フィルタで伸ばし字と日本語型の笑い声を落とす

### DIFF
--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -232,6 +232,30 @@ describe("filterPickupTerms", () => {
     ]);
   });
 
+  it("日本語型の笑い声(www / wwww / WWW / www!)を落とす(issue #97)", () => {
+    const terms = [
+      { term: "www", meaning: "日本語圏の笑い声" },
+      { term: "wwww", meaning: "日本語圏の笑い声" },
+      { term: "WWW", meaning: "日本語圏の笑い声" },
+      { term: "www!", meaning: "日本語圏の笑い声" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, { text: "www wwww WWW www! sticky", emoteNames: [], mentionNames: [] })).toEqual([
+      { term: "sticky", meaning: "スタン状態にする" },
+    ]);
+  });
+
+  it("単独の W(「勝ち」のスラング)や w を含む普通の語は落とさない(issue #97)", () => {
+    const terms = [
+      { term: "W", meaning: "勝利・最高" },
+      { term: "wallow", meaning: "ふける" },
+      { term: "big W", meaning: "大勝利" },
+    ];
+
+    expect(filterPickupTerms(terms, { text: "W wallow big W", emoteNames: [], mentionNames: [] })).toEqual(terms);
+  });
+
   it("相槌・感嘆詞を含む複数語の表現(oh my god / wow factor)は落とさない(issue #33)", () => {
     const terms = [
       { term: "oh my god", meaning: "なんてこった" },

--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -246,14 +246,28 @@ describe("filterPickupTerms", () => {
     ]);
   });
 
-  it("単独の W(「勝ち」のスラング)や w を含む普通の語は落とさない(issue #97)", () => {
+  it("全角の日本語型笑い声(ｗｗｗ / ＷＷＷ / 半角全角混在)も落とす(issue #97 のレビュー指摘)", () => {
+    const terms = [
+      { term: "ｗｗｗ", meaning: "日本語圏の笑い声" },
+      { term: "ＷＷＷ", meaning: "日本語圏の笑い声" },
+      { term: "wｗw", meaning: "日本語圏の笑い声" },
+      { term: "sticky", meaning: "スタン状態にする" },
+    ];
+
+    expect(filterPickupTerms(terms, { text: "ｗｗｗ ＷＷＷ wｗw sticky", emoteNames: [], mentionNames: [] })).toEqual([
+      { term: "sticky", meaning: "スタン状態にする" },
+    ]);
+  });
+
+  it("単独の W / ｗ(「勝ち」のスラング)や w を含む普通の語は落とさない(issue #97)", () => {
     const terms = [
       { term: "W", meaning: "勝利・最高" },
+      { term: "ｗ", meaning: "勝利・最高" },
       { term: "wallow", meaning: "ふける" },
       { term: "big W", meaning: "大勝利" },
     ];
 
-    expect(filterPickupTerms(terms, { text: "W wallow big W", emoteNames: [], mentionNames: [] })).toEqual(terms);
+    expect(filterPickupTerms(terms, { text: "W ｗ wallow big W", emoteNames: [], mentionNames: [] })).toEqual(terms);
   });
 
   it("相槌・感嘆詞を含む複数語の表現(oh my god / wow factor)は落とさない(issue #33)", () => {

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -9,7 +9,8 @@
  *   LLM に渡す本文と、後段フィルタで照合するための emote 名・メンション名を返す
  * - `filterPickupTerms`: 後段フィルタ。返ってきた語句のうち emote 名・@メンション・
  *   `!` で始まるチャットコマンド・文字を1つも含まない語句(数字や記号だけ)・
- *   `haha` のような笑い声(issue #30)・`oh` / `wow` / `hmm` のような相槌・感嘆詞(issue #33)・
+ *   `haha` のような笑い声(issue #30)・`www` のような日本語型の笑い声(issue #97)・
+ *   `oh` / `wow` / `hmm` のような相槌・感嘆詞(issue #33)・
  *   呼び出し側が指定した除外名(表示中の発言者名など)を落とし、重複する語句は1件にまとめる
  * - `filterTranslationArtifactTerms`: 逆方向 Pick up(機械翻訳の訳文からの抽出)専用の後段フィルタ。
  *   訳文の誤訳・幻覚に由来しやすい固有名詞的な語句を落とす
@@ -20,6 +21,7 @@ import { splitMessageIntoSegments } from "@/lib/twitch/emotes";
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
 import type { SupportedLanguage } from "./prompts";
 import type { PickupTerm } from "./schemas";
+import { collapseRepeatedLetters } from "./stem";
 
 /** `preparePickupInput` の結果。LLM に渡す本文と、後段フィルタの照合に使う情報 */
 export interface PreparedPickupInput {
@@ -43,14 +45,15 @@ const NO_LETTER_PATTERN = /^[^\p{L}]*$/u;
  * `haha!` / `(hehe)` のように前後に記号が付く形は、`SURROUNDING_NON_LETTERS_PATTERN` で記号を外してから照合する。
  */
 const LAUGHTER_PATTERN = /^(ha|he)+h?$/i;
+/**
+ * `www` / `wwww` のような日本語圏由来の笑い声にマッチする(issue #97)。
+ * 単独の `W` は「勝ち」を意味するスラング(learnable)のため2文字以上に限る。
+ * `collapseRepeatedLetters` を通すと `www` が `w` に潰れて単独の `W` と区別できなくなるため、
+ * この照合だけは潰す前の形(記号除去のみ)に対して行う。
+ */
+const JAPANESE_LAUGHTER_PATTERN = /^w{2,}$/i;
 /** 語句の先頭・末尾に連続する、文字以外の記号(`!` `(` `)` `...` など) */
 const SURROUNDING_NON_LETTERS_PATTERN = /^[^\p{L}]+|[^\p{L}]+$/gu;
-/** 同じ文字が2回以上連続する箇所(`ohhh` の `hhh` など) */
-const REPEATED_LETTER_PATTERN = /(\p{L})\1+/gu;
-/** `ohhh` / `hmmm` のように文字を伸ばした形を照合できるよう、同じ文字の連続を1文字にまとめる */
-function collapseRepeatedLetters(word: string): string {
-  return word.replace(REPEATED_LETTER_PATTERN, "$1");
-}
 /**
  * 言語を問わず普遍的に相槌・感嘆詞と判断できる語の除外辞書(issue #33)。
  * プロンプトで「相槌・感嘆詞は特殊な表現ではない」と指示しても Gemini Nano は `oh → 驚きを表す感嘆詞` のように返すため、
@@ -123,8 +126,11 @@ export function filterPickupTerms(
     if (excludedNames.has(normalized)) return false;
     if (NO_LETTER_PATTERN.test(normalized)) return false;
     // 笑い声・相槌は `haha!` / `ohhh` のように記号や伸ばしが付いても同じ語なので、揃えてから照合する
-    const collapsed = collapseRepeatedLetters(normalized.replace(SURROUNDING_NON_LETTERS_PATTERN, ""));
+    const stripped = normalized.replace(SURROUNDING_NON_LETTERS_PATTERN, "");
+    const collapsed = collapseRepeatedLetters(stripped);
     if (LAUGHTER_PATTERN.test(collapsed) || INTERJECTIONS.has(collapsed)) return false;
+    // 日本語型の笑い声(www)は潰すと単独の W(勝ちのスラング)と区別できないため、潰す前の形で照合する
+    if (JAPANESE_LAUGHTER_PATTERN.test(stripped)) return false;
     if (seen.has(normalized)) return false;
     seen.add(normalized);
     return true;

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -46,12 +46,13 @@ const NO_LETTER_PATTERN = /^[^\p{L}]*$/u;
  */
 const LAUGHTER_PATTERN = /^(ha|he)+h?$/i;
 /**
- * `www` / `wwww` のような日本語圏由来の笑い声にマッチする(issue #97)。
+ * `www` / `wwww` / 全角の `ｗｗｗ` のような日本語圏由来の笑い声にマッチする(issue #97)。
  * 単独の `W` は「勝ち」を意味するスラング(learnable)のため2文字以上に限る。
  * `collapseRepeatedLetters` を通すと `www` が `w` に潰れて単独の `W` と区別できなくなるため、
  * この照合だけは潰す前の形(記号除去のみ)に対して行う。
+ * 全角(`ｗ` U+FF57)は `i` フラグの simple case folding では半角に揃わないため文字クラスに明示する。
  */
-const JAPANESE_LAUGHTER_PATTERN = /^w{2,}$/i;
+const JAPANESE_LAUGHTER_PATTERN = /^[wｗ]{2,}$/i;
 /** 語句の先頭・末尾に連続する、文字以外の記号(`!` `(` `)` `...` など) */
 const SURROUNDING_NON_LETTERS_PATTERN = /^[^\p{L}]+|[^\p{L}]+$/gu;
 /**

--- a/src/lib/ai/pickup-ordinary-filter.test.ts
+++ b/src/lib/ai/pickup-ordinary-filter.test.ts
@@ -104,6 +104,15 @@ describe("filterOrdinaryTerms", () => {
     expect(survivingTerms(["maldinggg"])).toEqual(["maldinggg"]);
   });
 
+  it("2文字連続を含む正当なスラング(loot / yeet / weeb)は潰しの対象にせず残す(issue #97 のレビュー指摘)", () => {
+    // 2文字連続まで潰すと lot / yet / web の高頻度語と誤衝突するため、3連続以上だけを伸ばし字とみなす
+    expect(survivingTerms(["loot", "yeet", "weeb", "free loot"])).toEqual(["loot", "yeet", "weeb", "free loot"]);
+  });
+
+  it("大小文字が混在した伸ばし字(SOoo)も潰した形の照合で落とす(issue #97 のレビュー指摘)", () => {
+    expect(survivingTerms(["SOoo"])).toEqual([]);
+  });
+
   it("学ぶ言語が en 以外の場合はリスト未整備のため何も落とさない", () => {
     expect(survivingTerms(["rare", "main quests"], "ja")).toEqual(["rare", "main quests"]);
     expect(survivingTerms(["rare", "main quests"], "fr")).toEqual(["rare", "main quests"]);

--- a/src/lib/ai/pickup-ordinary-filter.test.ts
+++ b/src/lib/ai/pickup-ordinary-filter.test.ts
@@ -87,6 +87,23 @@ describe("filterOrdinaryTerms", () => {
     expect(survivingTerms(["quests", "streamers"])).toEqual([]);
   });
 
+  it("伸ばし字の1語(sooo / niceee)は同一文字の連続を潰した形でも照合して落とす(issue #97)", () => {
+    expect(survivingTerms(["sooo", "niceee", "yesss"])).toEqual([]);
+  });
+
+  it("伸ばし字を含む複数語句(sooo good)も潰した形の照合で全語が高頻度なら落とす(issue #97)", () => {
+    expect(survivingTerms(["sooo good"])).toEqual([]);
+  });
+
+  it("潰した形が高頻度語に一致しても、潰す前の形で高頻度語に一致する語は従来どおり落とす(good → god の誤変換で残さない)", () => {
+    // "good" を潰すと "god" になるが、元の形 "good" 自体が高頻度語のため落ちる
+    expect(survivingTerms(["good"])).toEqual([]);
+  });
+
+  it("潰しても高頻度語に一致しない伸ばしスラング(maldinggg)は残す(issue #97)", () => {
+    expect(survivingTerms(["maldinggg"])).toEqual(["maldinggg"]);
+  });
+
   it("学ぶ言語が en 以外の場合はリスト未整備のため何も落とさない", () => {
     expect(survivingTerms(["rare", "main quests"], "ja")).toEqual(["rare", "main quests"]);
     expect(survivingTerms(["rare", "main quests"], "fr")).toEqual(["rare", "main quests"]);

--- a/src/lib/ai/pickup-ordinary-filter.ts
+++ b/src/lib/ai/pickup-ordinary-filter.ts
@@ -7,7 +7,8 @@
  * 表現リストを併用するハイブリッド方式を採る:
  *
  * - 1語の語句: 高頻度語リスト(NGSL 1.2 約2800レンマ + 手動補完語)にあれば落とす。
- *   リストに無いスラング("lol" / "malding")や Twitch 用語("raid" / "emote")は残る
+ *   リストに無いスラング("lol" / "malding")や Twitch 用語("raid" / "emote")は残る。
+ *   "sooo" のような伸ばし字は同一文字の連続を潰した形でも照合して落とす(issue #97)
  * - 複数語の語句: 表現リスト(Wiktionary の句動詞・イディオム・スラング + 手動補完の定型表現)に
  *   レンマ正規化して一致すれば残す。リスト外で全語が高頻度なら落とす("main quests")。
  *   非高頻度語を1語でも含めば残す(リストに無い新しいミーム表現の偽陰性を減らす)
@@ -23,7 +24,7 @@ import enExpressionList from "./data/en-expression-list.json";
 import enFrequentWords from "./data/en-frequent-words.json";
 import type { SupportedLanguage } from "./prompts";
 import type { PickupTerm } from "./schemas";
-import { splitIntoMatchWords, stemForMatch } from "./stem";
+import { collapseRepeatedLetters, splitIntoMatchWords, stemForMatch } from "./stem";
 
 /**
  * Wiktionary のカテゴリに無い、学習価値のある定型表現の手動補完リスト。
@@ -56,6 +57,16 @@ const FREQUENT_STEMS: ReadonlySet<string> = new Set(
   [...enFrequentWords.ngslWords, ...enFrequentWords.supplementaryWords].map(stemForMatch),
 );
 
+/**
+ * 語が高頻度語かを判定する。`sooo` のような伸ばし字が頻度照合を素通りしないよう、
+ * 元の形に加えて同一文字の連続を1文字に潰した形(`sooo` → `so`)でも照合する(issue #97)。
+ * 潰した形だけで判定すると `good` → `god` のような誤変換で衝突しうるため、
+ * 「どちらかが高頻度語に一致したら普通の語」とみなす方式を採る。
+ */
+function isFrequentWord(word: string): boolean {
+  return FREQUENT_STEMS.has(stemForMatch(word)) || FREQUENT_STEMS.has(stemForMatch(collapseRepeatedLetters(word)));
+}
+
 /** 表現の照合キーを組み立てる。語ごとに正規化してから空白1つで連結する */
 function buildExpressionKey(words: string[]): string {
   return words.map(stemForMatch).join(" ");
@@ -78,9 +89,9 @@ export function filterOrdinaryTerms(terms: PickupTerm[], learningLang: Supported
     const words = splitIntoMatchWords(item.term);
     if (words.length === 0) return true;
     if (words.length === 1) {
-      return !FREQUENT_STEMS.has(stemForMatch(words[0]));
+      return !isFrequentWord(words[0]);
     }
     if (EXPRESSION_KEYS.has(buildExpressionKey(words))) return true;
-    return !words.every((word) => FREQUENT_STEMS.has(stemForMatch(word)));
+    return !words.every(isFrequentWord);
   });
 }

--- a/src/lib/ai/pickup-ordinary-filter.ts
+++ b/src/lib/ai/pickup-ordinary-filter.ts
@@ -8,7 +8,7 @@
  *
  * - 1語の語句: 高頻度語リスト(NGSL 1.2 約2800レンマ + 手動補完語)にあれば落とす。
  *   リストに無いスラング("lol" / "malding")や Twitch 用語("raid" / "emote")は残る。
- *   "sooo" のような伸ばし字は同一文字の連続を潰した形でも照合して落とす(issue #97)
+ *   "sooo" のような伸ばし字は同一文字の3連続以上を潰した形でも照合して落とす(issue #97)
  * - 複数語の語句: 表現リスト(Wiktionary の句動詞・イディオム・スラング + 手動補完の定型表現)に
  *   レンマ正規化して一致すれば残す。リスト外で全語が高頻度なら落とす("main quests")。
  *   非高頻度語を1語でも含めば残す(リストに無い新しいミーム表現の偽陰性を減らす)
@@ -24,7 +24,7 @@ import enExpressionList from "./data/en-expression-list.json";
 import enFrequentWords from "./data/en-frequent-words.json";
 import type { SupportedLanguage } from "./prompts";
 import type { PickupTerm } from "./schemas";
-import { collapseRepeatedLetters, splitIntoMatchWords, stemForMatch } from "./stem";
+import { collapseElongatedLetters, splitIntoMatchWords, stemForMatch } from "./stem";
 
 /**
  * Wiktionary のカテゴリに無い、学習価値のある定型表現の手動補完リスト。
@@ -59,12 +59,16 @@ const FREQUENT_STEMS: ReadonlySet<string> = new Set(
 
 /**
  * 語が高頻度語かを判定する。`sooo` のような伸ばし字が頻度照合を素通りしないよう、
- * 元の形に加えて同一文字の連続を1文字に潰した形(`sooo` → `so`)でも照合する(issue #97)。
- * 潰した形だけで判定すると `good` → `god` のような誤変換で衝突しうるため、
- * 「どちらかが高頻度語に一致したら普通の語」とみなす方式を採る。
+ * 元の形に加えて同一文字の3連続以上を1文字に潰した形(`sooo` → `so`)でも照合する(issue #97)。
+ * - 潰した形だけで判定すると誤変換で衝突しうるため、「どちらかが高頻度語に一致したら普通の語」とみなす
+ * - 2文字連続は `loot` / `yeet` / `weeb` のような正当なスラングを壊すため潰さない(`collapseElongatedLetters` 参照)
+ * - 潰しの後方参照が大小文字を区別するため、混在ケース(`SOoo`)に備えて先に小文字化する
  */
 function isFrequentWord(word: string): boolean {
-  return FREQUENT_STEMS.has(stemForMatch(word)) || FREQUENT_STEMS.has(stemForMatch(collapseRepeatedLetters(word)));
+  return (
+    FREQUENT_STEMS.has(stemForMatch(word)) ||
+    FREQUENT_STEMS.has(stemForMatch(collapseElongatedLetters(word.toLowerCase())))
+  );
 }
 
 /** 表現の照合キーを組み立てる。語ごとに正規化してから空白1つで連結する */

--- a/src/lib/ai/stem.test.ts
+++ b/src/lib/ai/stem.test.ts
@@ -8,7 +8,7 @@
  * そのためテストは「変化形と基本形が同じキーになる」ことを中心に検証する。
  */
 import { describe, expect, it } from "vitest";
-import { collapseRepeatedLetters, splitIntoMatchWords, stemForMatch } from "./stem";
+import { collapseElongatedLetters, collapseRepeatedLetters, splitIntoMatchWords, stemForMatch } from "./stem";
 
 /** 変化形と基本形が同じ照合キーに揃うことを検証するヘルパー */
 function expectSameKey(inflected: string, base: string) {
@@ -123,5 +123,19 @@ describe("collapseRepeatedLetters", () => {
 
   it("正当な重ね字も潰れる(good → god)。呼び出し側は元の形と併用して照合すること", () => {
     expect(collapseRepeatedLetters("good")).toBe("god");
+  });
+});
+
+describe("collapseElongatedLetters", () => {
+  it("同じ文字の3回以上の連続だけを1文字にまとめる(sooo → so / niceee → nice)", () => {
+    expect(collapseElongatedLetters("sooo")).toBe("so");
+    expect(collapseElongatedLetters("niceee")).toBe("nice");
+    expect(collapseElongatedLetters("yesss")).toBe("yes");
+  });
+
+  it("英語の正当な綴りに多い2文字連続は保持する(loot / weeb / good)", () => {
+    expect(collapseElongatedLetters("loot")).toBe("loot");
+    expect(collapseElongatedLetters("weeb")).toBe("weeb");
+    expect(collapseElongatedLetters("good")).toBe("good");
   });
 });

--- a/src/lib/ai/stem.test.ts
+++ b/src/lib/ai/stem.test.ts
@@ -8,7 +8,7 @@
  * そのためテストは「変化形と基本形が同じキーになる」ことを中心に検証する。
  */
 import { describe, expect, it } from "vitest";
-import { splitIntoMatchWords, stemForMatch } from "./stem";
+import { collapseRepeatedLetters, splitIntoMatchWords, stemForMatch } from "./stem";
 
 /** 変化形と基本形が同じ照合キーに揃うことを検証するヘルパー */
 function expectSameKey(inflected: string, base: string) {
@@ -106,5 +106,22 @@ describe("splitIntoMatchWords", () => {
 
   it("記号だけの語は除く", () => {
     expect(splitIntoMatchWords("wait ... what")).toEqual(["wait", "what"]);
+  });
+});
+
+describe("collapseRepeatedLetters", () => {
+  it("同じ文字の連続を1文字にまとめる(sooo → so / ohhh → oh)", () => {
+    expect(collapseRepeatedLetters("sooo")).toBe("so");
+    expect(collapseRepeatedLetters("ohhh")).toBe("oh");
+    expect(collapseRepeatedLetters("hmmm")).toBe("hm");
+  });
+
+  it("連続の無い語はそのまま返す", () => {
+    expect(collapseRepeatedLetters("sticky")).toBe("sticky");
+    expect(collapseRepeatedLetters("haha")).toBe("haha");
+  });
+
+  it("正当な重ね字も潰れる(good → god)。呼び出し側は元の形と併用して照合すること", () => {
+    expect(collapseRepeatedLetters("good")).toBe("god");
   });
 });

--- a/src/lib/ai/stem.ts
+++ b/src/lib/ai/stem.ts
@@ -19,6 +19,19 @@
 /** 語の前後に連続する、文字以外の記号(引用符・括弧・`!` など) */
 const SURROUNDING_NON_LETTERS_PATTERN = /^[^\p{L}]+|[^\p{L}]+$/gu;
 
+/** 同じ文字が2回以上連続する箇所(`ohhh` の `hhh` など) */
+const REPEATED_LETTER_PATTERN = /(\p{L})\1+/gu;
+
+/**
+ * `ohhh` / `sooo` のように文字を伸ばした形を照合できるよう、同じ文字の連続を1文字にまとめる。
+ * `good` → `god` のように正当な重ね字も潰れるため、この結果だけで判定せず、
+ * 必ず元の形と併用して照合すること(issue #97 の「どちらかが一致したら」方式)。
+ * 笑い声・相槌の照合(pickup-filter.ts)と高頻度語の照合(pickup-ordinary-filter.ts)で共用する。
+ */
+export function collapseRepeatedLetters(word: string): string {
+  return word.replace(REPEATED_LETTER_PATTERN, "$1");
+}
+
 /**
  * 語句を照合用の語の配列に分割する。空白で区切り、各語の前後の記号を外す。
  * 語の内部のアポストロフィ・ハイフン("don't" / "uh-oh")は保持し、

--- a/src/lib/ai/stem.ts
+++ b/src/lib/ai/stem.ts
@@ -23,13 +23,27 @@ const SURROUNDING_NON_LETTERS_PATTERN = /^[^\p{L}]+|[^\p{L}]+$/gu;
 const REPEATED_LETTER_PATTERN = /(\p{L})\1+/gu;
 
 /**
- * `ohhh` / `sooo` のように文字を伸ばした形を照合できるよう、同じ文字の連続を1文字にまとめる。
+ * `ohhh` / `hmmm` のように文字を伸ばした形を照合できるよう、同じ文字の連続を1文字にまとめる。
  * `good` → `god` のように正当な重ね字も潰れるため、この結果だけで判定せず、
  * 必ず元の形と併用して照合すること(issue #97 の「どちらかが一致したら」方式)。
- * 笑い声・相槌の照合(pickup-filter.ts)と高頻度語の照合(pickup-ordinary-filter.ts)で共用する。
+ * 笑い声・相槌の照合(pickup-filter.ts)で使う。
  */
 export function collapseRepeatedLetters(word: string): string {
   return word.replace(REPEATED_LETTER_PATTERN, "$1");
+}
+
+/** 同じ文字が3回以上連続する箇所(`sooo` の `ooo` など) */
+const ELONGATED_LETTER_PATTERN = /(\p{L})\1{2,}/gu;
+
+/**
+ * 同じ文字が3回以上連続する箇所だけを1文字にまとめる(`sooo` → `so` / `niceee` → `nice`)。
+ * 高頻度語の照合(pickup-ordinary-filter.ts)で使う。2文字連続まで潰すと `loot` → `lot` /
+ * `yeet` → `yet` / `weeb` → `web` のように正当なスラングが高頻度語と誤衝突するため、
+ * 英語の正当な綴りにほぼ現れない3連続以上だけを伸ばし字とみなす(issue #97 のレビュー指摘)。
+ * 正規表現の後方参照は大小文字を区別するため、混在ケース(`SOoo`)は呼び出し側で小文字化してから渡すこと。
+ */
+export function collapseElongatedLetters(word: string): string {
+  return word.replace(ELONGATED_LETTER_PATTERN, "$1");
 }
 
 /**


### PR DESCRIPTION
## Summary

issue #97 のハイブリッドフィルタ(PR #96)導入後に残っていた2系統の誤抽出を、決定的フィルタで落とします。

### 1. 伸ばし字("sooo")の頻度照合素通り対策

- `stem.ts` に `collapseElongatedLetters`(同一文字の**3連続以上**だけを1文字に潰す)を追加しました
- `pickup-ordinary-filter.ts` の高頻度語照合を「元の形と潰した形のどちらかが高頻度語に一致したら普通の語」方式に変更しました("sooo" → "so"、"sooo good" も落ちます)
- 2文字連続まで潰すと "loot" → "lot" / "yeet" → "yet" / "weeb" → "web" のような正当なスラングが高頻度語と誤衝突するため、3連続以上に限定しています(レビュー指摘対応)
- 潰しの後方参照は大小文字を区別するため、先に小文字化して "SOoo" のような混在ケースにも対応しています(レビュー指摘対応)

### 2. 日本語型の笑い声("www")対策

- `pickup-filter.ts` に `JAPANESE_LAUGHTER_PATTERN`(`/^[wｗ]{2,}$/i`)を追加しました
- 単独の "W" / "ｗ" は「勝ち」を意味するスラング(learnable)のため落としません
- 全角の "ｗｗｗ" / "ＷＷＷ" も落とします(レビュー指摘対応)
- `collapseRepeatedLetters` を通すと "www" が "w" に潰れて単独の "W" と区別できないため、この照合だけは潰す前の形に対して行います

### リファクタリング

- `collapseRepeatedLetters` を `pickup-filter.ts` から共通正規化モジュールの `stem.ts` へ移動しました(挙動は不変)

## Test plan

- [x] `npm test`(940件すべて成功)
- [x] `npm run lint` / `npm run type-check` / `npm run build`
- [x] TDD(RED → GREEN)で新規テスト11件を追加

## レビューについて

CodeRabbitはレートリミットのため `/code-review`(high)で代替実施しました(監査エージェントの指摘3件にすべて対応済み: loot/yeet/weeb の誤衝突、大小文字混在の伸ばし字、全角ｗｗｗ)。

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)