### PR TITLE
feat: Pick upの意味テキストに解説言語で使わない文字種が混ざった語句を決定的に落とす

### DIFF
--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -7,9 +7,16 @@
  *   相槌・感嘆詞(issue #33)を落とす
  * - `filterTranslationArtifactTerms`: 逆方向 Pick up(機械翻訳の訳文からの抽出)専用。訳文の誤訳・幻覚に
  *   由来しやすい固有名詞的な語句(大文字小文字の混在・大文字始まりのハイフン語)を落とす
+ * - `filterForeignScriptMeaningTerms`: 意味テキストに解説言語で使わない文字種(キリル文字など)が
+ *   混ざった語句を落とす(issue #98)
  */
 import { describe, expect, it } from "vitest";
-import { filterPickupTerms, filterTranslationArtifactTerms, preparePickupInput } from "./pickup-filter";
+import {
+  filterForeignScriptMeaningTerms,
+  filterPickupTerms,
+  filterTranslationArtifactTerms,
+  preparePickupInput,
+} from "./pickup-filter";
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
 
 describe("preparePickupInput", () => {
@@ -361,5 +368,68 @@ describe("filterTranslationArtifactTerms", () => {
     const terms = [{ term: "それな", meaning: "共感を表す相槌" }];
 
     expect(filterTranslationArtifactTerms(terms, "ja")).toEqual(terms);
+  });
+});
+
+describe("filterForeignScriptMeaningTerms", () => {
+  it("解説言語が日本語の場合、意味にキリル文字の単語が混入した語句を落とす(issue #98 の観測ケース)", () => {
+    const terms = [
+      { term: "clutch", meaning: "土壇場で決める направление こと" },
+      { term: "gg", meaning: "good game の略。対戦後の挨拶" },
+    ];
+
+    expect(filterForeignScriptMeaningTerms(terms, "ja", "en")).toEqual([
+      { term: "gg", meaning: "good game の略。対戦後の挨拶" },
+    ]);
+  });
+
+  it("解説言語が日本語の場合、ひらがな・カタカナ・漢字・ラテン文字・数字・記号だけの意味はそのまま残す", () => {
+    const terms = [
+      { term: "cooked", meaning: "「終わった・ダメだ」を表すスラング" },
+      { term: "W", meaning: "win(勝ち)の略。称賛にも使う" },
+      { term: "poggers", meaning: "興奮・驚きを表すミーム(PogChamp 由来)" },
+    ];
+
+    expect(filterForeignScriptMeaningTerms(terms, "ja", "en")).toEqual(terms);
+  });
+
+  it("解説言語が英語の場合、キリル文字・アラビア文字を含む意味の語句を落とす", () => {
+    const terms = [
+      { term: "no cap", meaning: "means нет serious exaggeration" },
+      { term: "based", meaning: "confident in one's own العربية views" },
+      { term: "sus", meaning: "short for suspicious" },
+    ];
+
+    expect(filterForeignScriptMeaningTerms(terms, "en", "ja")).toEqual([
+      { term: "sus", meaning: "short for suspicious" },
+    ]);
+  });
+
+  it("学ぶ言語が日本語の場合、解説言語がラテン文字圏でも意味に引用された日本語の文字は許容する", () => {
+    // 意味テキストが原文の語句(草 など)をそのまま引用するのは正当な出力のため落とさない
+    const terms = [{ term: "草", meaning: "means lol (草 = grass, from wwww)" }];
+
+    expect(filterForeignScriptMeaningTerms(terms, "en", "ja")).toEqual(terms);
+  });
+
+  it("解説言語・学ぶ言語のどちらにも日本語が無い場合、意味に日本語の文字が混ざった語句を落とす", () => {
+    const terms = [{ term: "banger", meaning: "a great song 素晴らしい曲" }];
+
+    expect(filterForeignScriptMeaningTerms(terms, "en", "es")).toEqual([]);
+  });
+
+  it("アクセント付きラテン文字・半角カタカナ・伸ばし棒・々などの記号的な文字は許容する", () => {
+    const terms = [
+      { term: "château", meaning: "フランス語由来の「城」。café のようなアクセント付き綴り" },
+      { term: "kusa", meaning: "ｸｻ(草)ー。時々使われる笑いの表現" },
+    ];
+
+    expect(filterForeignScriptMeaningTerms(terms, "ja", "fr")).toEqual(terms);
+  });
+
+  it("絵文字・数字・記号は文字種の判定対象にしない", () => {
+    const terms = [{ term: "7-2", meaning: "サッカーの大差スコア 😂 (7対2)" }];
+
+    expect(filterForeignScriptMeaningTerms(terms, "ja", "en")).toEqual(terms);
   });
 });

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -14,6 +14,8 @@
  *   呼び出し側が指定した除外名(表示中の発言者名など)を落とし、重複する語句は1件にまとめる
  * - `filterTranslationArtifactTerms`: 逆方向 Pick up(機械翻訳の訳文からの抽出)専用の後段フィルタ。
  *   訳文の誤訳・幻覚に由来しやすい固有名詞的な語句を落とす
+ * - `filterForeignScriptMeaningTerms`: 意味テキストに解説言語で使わない文字種(キリル文字など)が
+ *   混ざった語句を落とす(issue #98)
  *
  * 翻訳列は「emote 名はそのまま残す」設計のため、この処理は Pick up 専用である。
  */
@@ -182,4 +184,44 @@ export function filterTranslationArtifactTerms(terms: PickupTerm[], learningLang
 /** 単語の前後の記号(括弧・引用符など)を外したうえで、大文字始まりのハイフン語かを判定する */
 function hasCapitalizedHyphenatedForm(word: string): boolean {
   return CAPITALIZED_HYPHENATED_WORD_PATTERN.test(word.replace(SURROUNDING_NON_LETTERS_PATTERN, ""));
+}
+
+/**
+ * ラテン文字圏の意味テキストで許容しない文字にマッチする。
+ * 「文字(`\p{L}`)であり、かつ Script_Extensions がラテン文字でも Common(々 などの共用文字)でも
+ * Inherited(結合文字)でもない」文字を探す。数字・記号・絵文字は文字ではないため対象にならない。
+ * Script ではなく Script_Extensions(scx)で判定するのは、複数スクリプトで共用される文字
+ * (伸ばし棒 ー など)を取りこぼさないため。
+ */
+const NON_LATIN_LETTER_PATTERN = /(?=\p{L})[^\p{scx=Latin}\p{scx=Common}\p{scx=Inherited}]/u;
+/** 日本語を含む意味テキストで許容しない文字にマッチする。上記にひらがな・カタカナ・漢字を加えた許容集合 */
+const NON_JAPANESE_OR_LATIN_LETTER_PATTERN =
+  /(?=\p{L})[^\p{scx=Latin}\p{scx=Hiragana}\p{scx=Katakana}\p{scx=Han}\p{scx=Common}\p{scx=Inherited}]/u;
+
+/**
+ * 意味テキストに解説言語で使わない文字種が混ざった語句を落とす後段フィルタ(issue #98)。
+ *
+ * Gemini Nano が生成した意味テキストには、解説言語で使わないスクリプトの単語が混入することがある
+ * (実例: 解説言語が日本語の意味テキストにキリル文字の単語が混入する)。語句(term)側は原文照合
+ * (`pickup.ts`)で正当性を担保できるが、意味(meaning)側には照合対象が無いため、文字種で
+ * 決定的に検証する。壊れた意味を学習者に見せないことを優先し、再試行はせず落とすだけにする。
+ *
+ * 許容する文字種:
+ * - ラテン文字はどの解説言語でも許容する(原文の語句や "laughing out loud" のような展開を
+ *   意味に含めるため)
+ * - 日本語の文字(ひらがな・カタカナ・漢字)は、解説言語か学ぶ言語のどちらかが日本語の場合に許容する。
+ *   解説言語がラテン文字圏でも、意味テキストが原文の日本語の語句を引用するのは正当な出力のため
+ * - 数字・記号・絵文字は文字ではないため常に許容する(emote 名はラテン文字なので同様に通る)
+ *
+ * 対応言語(`SupportedLanguage`)は en/ja/es/de/fr の5つで、日本語以外はすべてラテン文字圏のため、
+ * 許容集合は「ラテン文字のみ」か「ラテン文字 + 日本語」の2通りで足りる。
+ */
+export function filterForeignScriptMeaningTerms(
+  terms: PickupTerm[],
+  explainLang: SupportedLanguage,
+  learningLang: SupportedLanguage,
+): PickupTerm[] {
+  const foreignLetterPattern =
+    explainLang === "ja" || learningLang === "ja" ? NON_JAPANESE_OR_LATIN_LETTER_PATTERN : NON_LATIN_LETTER_PATTERN;
+  return terms.filter((item) => !foreignLetterPattern.test(item.meaning));
 }

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -18,10 +18,13 @@
  *   学ぶ言語の訳文(翻訳列に表示されるもの)を待って再利用し、その訳文に対して順方向と同じ抽出を行う
  *   (issue #68。訳文の二重生成と、照合対象と表示訳文の不整合を防ぐ)。抽出結果からは、機械翻訳の
  *   誤訳・幻覚に由来しやすい固有名詞的な語句を `filterTranslationArtifactTerms` で決定的に落とす
+ * - 順方向・逆方向とも、抽出結果からは普通の単語・字義通りの句(`filterOrdinaryTerms`。issue #95)と、
+ *   意味テキストに解説言語で使わない文字種が混ざった語句(`filterForeignScriptMeaningTerms`。issue #98)を
+ *   決定的に落とす
  * - Prompt API の利用可否は `prompt-api.ts` の共有ストアを参照する(翻訳列と共通)
  */
 import { createPickupBaseSessionFactory, pickUpExpressions } from "@/lib/ai/pickup";
-import { filterTranslationArtifactTerms } from "@/lib/ai/pickup-filter";
+import { filterForeignScriptMeaningTerms, filterTranslationArtifactTerms } from "@/lib/ai/pickup-filter";
 import { filterOrdinaryTerms } from "@/lib/ai/pickup-ordinary-filter";
 import { LowPriorityQueueOverflowError } from "@/lib/ai/session-pool";
 import type { MessageSegment } from "@/lib/twitch/emotes";
@@ -62,11 +65,15 @@ const pipeline = createAutoPipeline<PickupDone>({
     createPickupBaseSessionFactory(useSettingsStore.getState().settings, learningLang, explainLang, getStreamInfo()),
   resolveWithoutModel: (message) =>
     isTextlessMessage(message.text, message.emotes) || isChatCommandMessage(message.text) ? { terms: [] } : null,
-  // 抽出結果からは、普通の単語・字義通りの句を高頻度語リスト・表現リストで決定的に落とす(issue #95)。
-  // 学ぶ言語はベースセッション生成時(createBaseSession)と同じく生成時点のストアの値を読めばよい
+  // 抽出結果からは、普通の単語・字義通りの句を高頻度語リスト・表現リストで決定的に落とし(issue #95)、
+  // 意味テキストに解説言語で使わない文字種が混ざった語句も落とす(issue #98)。
+  // 言語設定はベースセッション生成時(createBaseSession)と同じく生成時点のストアの値を読めばよい
   runJob: async (pool, message, context) => {
     const result = await pickUpExpressions(pool, message.text, buildPickupJobOptions(message, context));
-    return { terms: filterOrdinaryTerms(result.terms, useSettingsStore.getState().settings.learningLang) };
+    const { learningLang, explainLang } = useSettingsStore.getState().settings;
+    return {
+      terms: filterForeignScriptMeaningTerms(filterOrdinaryTerms(result.terms, learningLang), explainLang, learningLang),
+    };
   },
   // 逆方向: 翻訳パイプラインの訳文(翻訳列に表示されるもの)を待って再利用し、訳文を二重生成しない(issue #68)。
   // 訳文は emote 復元済みのセグメント列なので、emote を空白に置き換えた本文に対して順方向と同じ抽出を行う
@@ -84,10 +91,17 @@ const pipeline = createAutoPipeline<PickupDone>({
       excludedNames: collectExcludedNames(context),
     });
     // 訳文は機械翻訳のため、誤訳・幻覚に由来する固有名詞的な語句を決定的に落とし(issue #94)、
-    // さらに普通の単語・字義通りの句も落とす(issue #95)。
-    // 学ぶ言語はベースセッション生成時(createReverseBaseSession)と同じく生成時点のストアの値を読めばよい
-    const learningLang = useSettingsStore.getState().settings.learningLang;
-    return { terms: filterOrdinaryTerms(filterTranslationArtifactTerms(result.terms, learningLang), learningLang) };
+    // 普通の単語・字義通りの句(issue #95)と、意味テキストに解説言語で使わない文字種が混ざった語句
+    // (issue #98)も落とす。言語設定はベースセッション生成時(createReverseBaseSession)と同じく
+    // 生成時点のストアの値を読めばよい
+    const { learningLang, explainLang } = useSettingsStore.getState().settings;
+    return {
+      terms: filterForeignScriptMeaningTerms(
+        filterOrdinaryTerms(filterTranslationArtifactTerms(result.terms, learningLang), learningLang),
+        explainLang,
+        learningLang,
+      ),
+    };
   },
 });
 


### PR DESCRIPTION
## Summary

issue #95 のフィルタ導入後の実チャット確認で、Gemini Nano が生成した意味テキストに解説言語で使わない文字種が混ざるケース(例: 解説言語が日本語の意味テキストへのキリル文字の単語の混入)を観測しました。語句(term)側は原文照合(`pickup.ts`)で正当性を担保できますが、意味(meaning)側には照合対象が無いため、文字種検証による決定的な後段フィルタを追加します。

## 変更内容

- `src/lib/ai/pickup-filter.ts`: `filterForeignScriptMeaningTerms` を追加
  - 意味テキストに許容外スクリプトの文字を含む term を落とす(再試行はせず、落とすだけの単純な実装)
  - ラテン文字はどの解説言語でも許容する(原文の語句や "laughing out loud" のような展開を意味に含めるため)
  - 日本語の文字(ひらがな・カタカナ・漢字)は、解説言語か学ぶ言語のどちらかが日本語の場合に許容する(意味テキストが原文の日本語の語句を引用するのは正当な出力のため)
  - 数字・記号・絵文字は文字(`\p{L}`)ではないため常に許容する(emote 名はラテン文字なので同様に通る)
  - 判定は Script ではなく Script_Extensions(scx)で行い、伸ばし棒(ー)のような複数スクリプト共用文字を取りこぼさない
- `src/store/pickups.ts`: 順方向(`runJob`)・逆方向(`runReverseJob`)の両パイプラインに適用
- `src/lib/ai/pickup-filter.test.ts`: 上記の振る舞いのテストを追加(7ケース)

## テスト

- `npm run lint` / `npm run type-check` / `npm test`(947件) / `npm run build` すべて成功
- CodeRabbitレビュー実施済み(指摘0件)

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)