### PR TITLE
feat: Pick upで文中の固有名詞を含む句と疑問文まるごとの抽出を決定的に落とす

### DIFF
--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -9,11 +9,16 @@
  *   由来しやすい固有名詞的な語句(大文字小文字の混在・大文字始まりのハイフン語)を落とす
  * - `filterForeignScriptMeaningTerms`: 意味テキストに解説言語で使わない文字種(キリル文字など)が
  *   混ざった語句を落とす(issue #98)
+ * - `filterProperNounPhraseTerms`: 文中(先頭以外)に固有名詞的な語(大文字始まりかつ小文字を含む語)を
+ *   含む語句を落とす(issue #100)
+ * - `filterQuestionSentenceTerms`: 末尾が疑問符の複数語の語句(疑問文まるごとの抽出)を落とす(issue #100)
  */
 import { describe, expect, it } from "vitest";
 import {
   filterForeignScriptMeaningTerms,
   filterPickupTerms,
+  filterProperNounPhraseTerms,
+  filterQuestionSentenceTerms,
   filterTranslationArtifactTerms,
   preparePickupInput,
 } from "./pickup-filter";
@@ -431,5 +436,110 @@ describe("filterForeignScriptMeaningTerms", () => {
     const terms = [{ term: "7-2", meaning: "サッカーの大差スコア 😂 (7対2)" }];
 
     expect(filterForeignScriptMeaningTerms(terms, "ja", "en")).toEqual(terms);
+  });
+});
+
+describe("filterProperNounPhraseTerms", () => {
+  // issue #100 の観測ケース: 固有名詞(ブランド名・人名)は高頻度語リストに無いため
+  // 「非高頻度語を含む複数語句」としてハイブリッドフィルタ(issue #95)を通過してしまう
+
+  it("文中(先頭以外)に大文字始まりで小文字を含む語(固有名詞)がある語句を落とす", () => {
+    const terms = [
+      { term: "Do you mean Snickers?", meaning: "スニッカーズのこと?" },
+      { term: "playing with Tataru", meaning: "タタルと遊ぶ" },
+      { term: "no cap", meaning: "嘘じゃない、マジで" },
+    ];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual([{ term: "no cap", meaning: "嘘じゃない、マジで" }]);
+  });
+
+  it("先頭の語だけが大文字始まりの語句(文頭に置かれただけの表現)は落とさない", () => {
+    const terms = [
+      { term: "Toss it!", meaning: "捨てる!" },
+      { term: "Nice try", meaning: "惜しかったね" },
+    ];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("文中の全大文字の語(略語・強調)は固有名詞とみなさず残す", () => {
+    const terms = [
+      { term: "big W", meaning: "大勝利" },
+      { term: "GG WP", meaning: "good game, well played の略" },
+      { term: "actual LOL moment", meaning: "本当に声が出た場面" },
+    ];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("一人称の I / I'm のような語は固有名詞とみなさず残す", () => {
+    const terms = [
+      { term: "what am I saying", meaning: "何を言ってるんだ俺は" },
+      { term: "and I'm dead", meaning: "笑いすぎて死んだ(ミーム的表現)" },
+    ];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("表現リストに一致する語句はタイトルケースで書かれていても残す(誤殺の救済)", () => {
+    // "what's up" は表現リスト収録。チャットがタイトルケースで書かれても落とさない
+    const terms = [{ term: "What's Up", meaning: "調子どう?(挨拶)" }];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("先頭の1語だけの語句は対象外として残す(文頭と固有名詞を区別できないため)", () => {
+    const terms = [{ term: "Snickers", meaning: "チョコバーのブランド" }];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual(terms);
+  });
+
+  it("学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれるため、何も落とさずそのまま返す", () => {
+    const terms = [
+      { term: "die Daumen drücken", meaning: "幸運を祈る" },
+      { term: "auf dem Schlauch stehen", meaning: "ピンとこない" },
+    ];
+
+    expect(filterProperNounPhraseTerms(terms, "de")).toEqual(terms);
+  });
+});
+
+describe("filterQuestionSentenceTerms", () => {
+  // issue #100 の観測ケース: 疑問文などの発言ほぼ全体が1つの「表現」として返る
+
+  it("末尾が疑問符でリスト外の複数語の語句(疑問文まるごとの抽出)を落とす", () => {
+    const terms = [
+      { term: "are you malding right now?", meaning: "今キレてるの?" },
+      { term: "malding", meaning: "ハゲるほどキレること" },
+    ];
+
+    expect(filterQuestionSentenceTerms(terms)).toEqual([{ term: "malding", meaning: "ハゲるほどキレること" }]);
+  });
+
+  it("全角の疑問符(？)で終わる複数語の語句も落とす(機械翻訳の訳文に残るケース)", () => {
+    const terms = [{ term: "do you like this game？", meaning: "このゲーム好き?" }];
+
+    expect(filterQuestionSentenceTerms(terms)).toEqual([]);
+  });
+
+  it("表現リストに一致する疑問形の定型表現は疑問符付きでも残す(誤殺の救済)", () => {
+    const terms = [{ term: "what's up?", meaning: "調子どう?(挨拶)" }];
+
+    expect(filterQuestionSentenceTerms(terms)).toEqual(terms);
+  });
+
+  it("1語の語句は疑問符付きでも残す(単語の聞き返しは学習価値があるため)", () => {
+    const terms = [{ term: "Pardon?", meaning: "もう一度言って?(聞き返し)" }];
+
+    expect(filterQuestionSentenceTerms(terms)).toEqual(terms);
+  });
+
+  it("疑問符で終わらない語句はそのまま残す", () => {
+    const terms = [
+      { term: "no cap", meaning: "嘘じゃない、マジで" },
+      { term: "let him cook", meaning: "彼にやらせておけ(ミーム)" },
+    ];
+
+    expect(filterQuestionSentenceTerms(terms)).toEqual(terms);
   });
 });

--- a/src/lib/ai/pickup-filter.test.ts
+++ b/src/lib/ai/pickup-filter.test.ts
@@ -472,6 +472,15 @@ describe("filterProperNounPhraseTerms", () => {
     expect(filterProperNounPhraseTerms(terms, "en")).toEqual(terms);
   });
 
+  it("文中の語中に大文字を含む語(iPhone / eBay のようなブランド名)がある語句も落とす(CodeRabbit の指摘)", () => {
+    const terms = [
+      { term: "grab the iPhone", meaning: "iPhoneを手に取る" },
+      { term: "selling on eBay", meaning: "eBayで売る" },
+    ];
+
+    expect(filterProperNounPhraseTerms(terms, "en")).toEqual([]);
+  });
+
   it("一人称の I / I'm のような語は固有名詞とみなさず残す", () => {
     const terms = [
       { term: "what am I saying", meaning: "何を言ってるんだ俺は" },
@@ -518,6 +527,15 @@ describe("filterQuestionSentenceTerms", () => {
 
   it("全角の疑問符(？)で終わる複数語の語句も落とす(機械翻訳の訳文に残るケース)", () => {
     const terms = [{ term: "do you like this game？", meaning: "このゲーム好き?" }];
+
+    expect(filterQuestionSentenceTerms(terms)).toEqual([]);
+  });
+
+  it("疑問符に感嘆符が続く形(?! / ？！)で終わる複数語の語句も落とす(CodeRabbit の指摘)", () => {
+    const terms = [
+      { term: "are you serious?!", meaning: "マジで言ってる!?" },
+      { term: "is this real？！", meaning: "これ現実!?" },
+    ];
 
     expect(filterQuestionSentenceTerms(terms)).toEqual([]);
   });

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -16,14 +16,18 @@
  *   訳文の誤訳・幻覚に由来しやすい固有名詞的な語句を落とす
  * - `filterForeignScriptMeaningTerms`: 意味テキストに解説言語で使わない文字種(キリル文字など)が
  *   混ざった語句を落とす(issue #98)
+ * - `filterProperNounPhraseTerms`: 順方向 Pick up 用の後段フィルタ。文中(先頭以外)に固有名詞的な語を
+ *   含む語句を落とす(issue #100)
+ * - `filterQuestionSentenceTerms`: 末尾が疑問符の複数語の語句(疑問文まるごとの抽出)を落とす(issue #100)
  *
  * 翻訳列は「emote 名はそのまま残す」設計のため、この処理は Pick up 専用である。
  */
 import { splitMessageIntoSegments } from "@/lib/twitch/emotes";
 import type { EmotePosition } from "@/lib/twitch/irc-parser";
+import { isListedExpression } from "./pickup-ordinary-filter";
 import type { SupportedLanguage } from "./prompts";
 import type { PickupTerm } from "./schemas";
-import { collapseRepeatedLetters } from "./stem";
+import { collapseRepeatedLetters, splitIntoMatchWords } from "./stem";
 
 /** `preparePickupInput` の結果。LLM に渡す本文と、後段フィルタの照合に使う情報 */
 export interface PreparedPickupInput {
@@ -184,6 +188,75 @@ export function filterTranslationArtifactTerms(terms: PickupTerm[], learningLang
 /** 単語の前後の記号(括弧・引用符など)を外したうえで、大文字始まりのハイフン語かを判定する */
 function hasCapitalizedHyphenatedForm(word: string): boolean {
   return CAPITALIZED_HYPHENATED_WORD_PATTERN.test(word.replace(SURROUNDING_NON_LETTERS_PATTERN, ""));
+}
+
+/** 大文字で始まる語(どの言語の大文字でもよい) */
+const CAPITALIZED_WORD_PATTERN = /^\p{Lu}/u;
+/** 一人称の I とその短縮形(I'm / I'll / I've / I'd。曲がった引用符も許容する) */
+const FIRST_PERSON_I_PATTERN = /^I['’]/;
+
+/**
+ * 順方向 Pick up(実際のチャット本文からの抽出)用の後段フィルタ(issue #100)。
+ *
+ * 固有名詞(ブランド名・人名など)は高頻度語リストに無いため、「非高頻度語を含む複数語句」として
+ * ハイブリッドフィルタ(issue #95 の `filterOrdinaryTerms`)を通過してしまう(実例: ブランド名を含む
+ * 疑問文がまるごと抽出された)。固有名詞は Pick up の対象外にしたい語のため、綴りの形で決定的に落とす。
+ * 逆方向 Pick up には、より厳しい語句全体での判定(`filterTranslationArtifactTerms`。issue #94)が
+ * 既に適用されるため、このフィルタは順方向専用である。
+ *
+ * 落とす条件: 文中(先頭以外)の語に「大文字で始まり、かつ小文字を含む語」がある語句。
+ * ただし表現リスト(issue #95)に一致する語句は正当な定型表現とみなして残す。
+ * - 先頭の語は文頭に置かれただけの表現("Toss it!")と区別できないため対象にしない
+ * - 全大文字の語("LOL" / "big W" の "W")は略語・強調であり固有名詞とみなさない
+ * - 一人称の "I" 単独は小文字を含まず対象外。"I'm" のような短縮形は明示的に除外する
+ *
+ * 学ぶ言語がドイツ語の場合は名詞が常に大文字で書かれ、正当な表現まで落としてしまうため何も落とさない
+ * (issue #94 と同じ扱い)。
+ *
+ * 既知のトレードオフ: 先頭の1語だけの固有名詞("Snickers")は文頭と区別できず残る。また
+ * チャット全体がタイトルケースで書かれた場合、表現リスト外の正当な表現も落ちる(固有名詞を
+ * 学習者に見せないこと(精度)を優先して許容する)。
+ */
+export function filterProperNounPhraseTerms(terms: PickupTerm[], learningLang: SupportedLanguage): PickupTerm[] {
+  if (learningLang === "de") return terms;
+  return terms.filter((item) => {
+    const words = splitIntoMatchWords(item.term);
+    const hasProperNounLikeWord = words
+      .slice(1)
+      .some(
+        (word) =>
+          CAPITALIZED_WORD_PATTERN.test(word) &&
+          LOWERCASE_LETTER_PATTERN.test(word) &&
+          !FIRST_PERSON_I_PATTERN.test(word),
+      );
+    if (!hasProperNounLikeWord) return true;
+    return isListedExpression(item.term);
+  });
+}
+
+/** 半角・全角の疑問符で終わる語句にマッチする(全角は機械翻訳の訳文に残ることがある) */
+const TRAILING_QUESTION_MARK_PATTERN = /[?？]$/;
+
+/**
+ * 疑問文がまるごと1つの「表現」として抽出されたと判別できる語句を落とす後段フィルタ(issue #100)。
+ *
+ * Gemini Nano は発言ほぼ全体(疑問文など)を1つの表現として返すことがある。文まるごとの抽出は
+ * 学ぶべき「特殊な表現」ではないため、末尾が疑問符の複数語の語句を落とす。
+ * ただし表現リスト(issue #95)に一致する語句("what's up?" など)は疑問形の定型表現とみなして残す。
+ * 1語の語句("Pardon?")は単語の聞き返しとして学習価値があるため対象にしない。
+ *
+ * 既知のトレードオフ:
+ * - 表現リストは全語が高頻度語の表現に枝刈りされているため、非高頻度語を含む疑問形の定型表現は
+ *   救済できず落ちる(文まるごとの抽出を学習者に見せないこと(精度)を優先して許容する)
+ * - 語の分割は空白基準のため、空白を使わない言語(日本語)の疑問文は1語扱いになり落とせない
+ */
+export function filterQuestionSentenceTerms(terms: PickupTerm[]): PickupTerm[] {
+  return terms.filter((item) => {
+    const trimmed = item.term.trim();
+    if (!TRAILING_QUESTION_MARK_PATTERN.test(trimmed)) return true;
+    if (splitIntoMatchWords(trimmed).length < 2) return true;
+    return isListedExpression(trimmed);
+  });
 }
 
 /**

--- a/src/lib/ai/pickup-filter.ts
+++ b/src/lib/ai/pickup-filter.ts
@@ -190,8 +190,6 @@ function hasCapitalizedHyphenatedForm(word: string): boolean {
   return CAPITALIZED_HYPHENATED_WORD_PATTERN.test(word.replace(SURROUNDING_NON_LETTERS_PATTERN, ""));
 }
 
-/** 大文字で始まる語(どの言語の大文字でもよい) */
-const CAPITALIZED_WORD_PATTERN = /^\p{Lu}/u;
 /** 一人称の I とその短縮形(I'm / I'll / I've / I'd。曲がった引用符も許容する) */
 const FIRST_PERSON_I_PATTERN = /^I['’]/;
 
@@ -204,8 +202,10 @@ const FIRST_PERSON_I_PATTERN = /^I['’]/;
  * 逆方向 Pick up には、より厳しい語句全体での判定(`filterTranslationArtifactTerms`。issue #94)が
  * 既に適用されるため、このフィルタは順方向専用である。
  *
- * 落とす条件: 文中(先頭以外)の語に「大文字で始まり、かつ小文字を含む語」がある語句。
- * ただし表現リスト(issue #95)に一致する語句は正当な定型表現とみなして残す。
+ * 落とす条件: 文中(先頭以外)の語に「大文字と小文字の両方を含む語」がある語句。
+ * 大文字始まりの固有名詞("Nike")に加え、語中に大文字を持つブランド名("iPhone" / "eBay")も
+ * 該当する(#94 と同じ基準)。ただし表現リスト(issue #95)に一致する語句は正当な定型表現と
+ * みなして残す。
  * - 先頭の語は文頭に置かれただけの表現("Toss it!")と区別できないため対象にしない
  * - 全大文字の語("LOL" / "big W" の "W")は略語・強調であり固有名詞とみなさない
  * - 一人称の "I" 単独は小文字を含まず対象外。"I'm" のような短縮形は明示的に除外する
@@ -225,7 +225,7 @@ export function filterProperNounPhraseTerms(terms: PickupTerm[], learningLang: S
       .slice(1)
       .some(
         (word) =>
-          CAPITALIZED_WORD_PATTERN.test(word) &&
+          UPPERCASE_LETTER_PATTERN.test(word) &&
           LOWERCASE_LETTER_PATTERN.test(word) &&
           !FIRST_PERSON_I_PATTERN.test(word),
       );
@@ -234,8 +234,11 @@ export function filterProperNounPhraseTerms(terms: PickupTerm[], learningLang: S
   });
 }
 
-/** 半角・全角の疑問符で終わる語句にマッチする(全角は機械翻訳の訳文に残ることがある) */
-const TRAILING_QUESTION_MARK_PATTERN = /[?？]$/;
+/**
+ * 半角・全角の疑問符で終わる語句にマッチする(全角は機械翻訳の訳文に残ることがある)。
+ * "are you serious?!" のように疑問符の後に感嘆符が続く形も疑問文の終わりとみなす。
+ */
+const TRAILING_QUESTION_MARK_PATTERN = /[?？]+[!！]*$/;
 
 /**
  * 疑問文がまるごと1つの「表現」として抽出されたと判別できる語句を落とす後段フィルタ(issue #100)。

--- a/src/lib/ai/pickup-ordinary-filter.test.ts
+++ b/src/lib/ai/pickup-ordinary-filter.test.ts
@@ -12,7 +12,7 @@
  * 回帰テストとして固定する。
  */
 import { describe, expect, it } from "vitest";
-import { filterOrdinaryTerms } from "./pickup-ordinary-filter";
+import { filterOrdinaryTerms, isListedExpression } from "./pickup-ordinary-filter";
 import type { PickupTerm } from "./schemas";
 
 /** テストデータ組み立てヘルパー。意味の文字列は判定に影響しない */
@@ -153,5 +153,24 @@ describe("filterOrdinaryTerms", () => {
   it("学ぶ言語が en 以外の場合はリスト未整備のため何も落とさない", () => {
     expect(survivingTerms(["rare", "main quests"], "ja")).toEqual(["rare", "main quests"]);
     expect(survivingTerms(["rare", "main quests"], "fr")).toEqual(["rare", "main quests"]);
+  });
+});
+
+describe("isListedExpression", () => {
+  it("Wiktionary 由来の表現リストにある語句は、大文字・語形変化・前後の記号があっても一致する", () => {
+    // "give up" が表現リストにあるため、タイトルケース・進行形・末尾の疑問符でも同じ照合キーになる
+    expect(isListedExpression("give up")).toBe(true);
+    expect(isListedExpression("Giving Up")).toBe(true);
+    expect(isListedExpression("what's up?")).toBe(true);
+  });
+
+  it("手動補完リスト(CURATED_EXPRESSIONS)の表現にも一致する", () => {
+    expect(isListedExpression("let him cook")).toBe(true);
+    expect(isListedExpression("even though")).toBe(true);
+  });
+
+  it("リストに無い語句(普通の句・文まるごとの抽出)には一致しない", () => {
+    expect(isListedExpression("main quests")).toBe(false);
+    expect(isListedExpression("are you coming to the party tonight?")).toBe(false);
   });
 });

--- a/src/lib/ai/pickup-ordinary-filter.ts
+++ b/src/lib/ai/pickup-ordinary-filter.ts
@@ -88,6 +88,20 @@ const EXPRESSION_KEYS: ReadonlySet<string> = new Set(
 );
 
 /**
+ * 語句が表現リスト(Wiktionary 由来 + 手動補完)に一致するかを判定する。
+ * リスト側・語句側とも同じレンマ正規化(`stemForMatch`)を通すため、大文字・語形変化・
+ * 前後の記号の揺れがあっても一致する。issue #100 のフィルタ(固有名詞・疑問文まるごとの足切り)が
+ * 正当な定型表現を誤って落とさないための救済判定に使う。
+ *
+ * 注意: 表現リストは「全語が高頻度語で構成される表現」に枝刈りして生成している
+ * (`scripts/generate-pickup-filter-data.mjs`)ため、"make a mountain out of a molehill" のような
+ * 非高頻度語を含むイディオムには一致しない。
+ */
+export function isListedExpression(term: string): boolean {
+  return EXPRESSION_KEYS.has(buildExpressionKey(splitIntoMatchWords(term)));
+}
+
+/**
  * 普通の単語・字義通りの句と決定的に判別できる語句を落とす。
  * 学ぶ言語が en 以外の場合はリスト未整備のため何も落とさない。
  */

--- a/src/store/pickups.test.ts
+++ b/src/store/pickups.test.ts
@@ -135,6 +135,35 @@ describe("startPickupPipeline", () => {
     stop();
   });
 
+  it("文中に固有名詞を含む句と、疑問文まるごとの抽出(issue #100)を結果から落とす", async () => {
+    const { deps, emit } = createDeps({
+      promptResults: [
+        Promise.resolve(
+          JSON.stringify({
+            terms: [
+              // ブランド名(固有名詞)を含む疑問文がまるごと抽出されたケース(issue #100 の観測例に相当)
+              { term: "Do you mean Snickers?", meaning: "スニッカーズのこと?" },
+              // 固有名詞を含まない疑問文まるごとの抽出
+              { term: "are you malding right now?", meaning: "今キレてるの?" },
+              { term: "malding", meaning: "ハゲるほどキレること" },
+            ],
+          }),
+        ),
+      ],
+    });
+
+    const stop = startPickupPipeline(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "Do you mean Snickers? are you malding right now?" }));
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "malding", meaning: "ハゲるほどキレること" }],
+    });
+    stop();
+  });
+
   it("抽出ジョブが失敗した場合は理由付きで failed として保持する(暗黙のフォールバックはしない)", async () => {
     const { deps, emit } = createDeps({ promptResults: [Promise.reject(new Error("モデルがクラッシュしました"))] });
 
@@ -330,6 +359,39 @@ describe("startPickupPipeline(逆方向: 翻訳パイプラインの訳文を再
     const stop = startPickupPipeline(deps);
     await flush();
     emit(createMessage({ id: "msg-1", text: "こんとめー！エオルゼアは終わりや、マジで" }));
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "no cap", meaning: "嘘じゃない、マジで" }],
+    });
+    stop();
+  });
+
+  it("逆方向でも疑問文まるごとの抽出(issue #100)を結果から落とす", async () => {
+    const { deps, emit } = createDeps({
+      detectedLanguage: "ja",
+      reversePromptResults: [
+        Promise.resolve(
+          JSON.stringify({
+            terms: [
+              // 訳文(疑問文)ほぼ全体が1つの「表現」として返ったケース
+              { term: "are you malding right now?", meaning: "今キレてるの?" },
+              { term: "no cap", meaning: "嘘じゃない、マジで" },
+            ],
+          }),
+        ),
+      ],
+    });
+    useTranslationStore.setState({
+      entries: {
+        "msg-1": { status: "done", segments: [{ type: "text", text: "are you malding right now? no cap" }] },
+      },
+    });
+
+    const stop = startPickupPipeline(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "今キレてるん？マジで" }));
     await flush();
 
     expect(usePickupStore.getState().entries["msg-1"]).toEqual({

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -18,13 +18,19 @@
  *   学ぶ言語の訳文(翻訳列に表示されるもの)を待って再利用し、その訳文に対して順方向と同じ抽出を行う
  *   (issue #68。訳文の二重生成と、照合対象と表示訳文の不整合を防ぐ)。抽出結果からは、機械翻訳の
  *   誤訳・幻覚に由来しやすい固有名詞的な語句を `filterTranslationArtifactTerms` で決定的に落とす
- * - 順方向・逆方向とも、抽出結果からは普通の単語・字義通りの句(`filterOrdinaryTerms`。issue #95)と、
- *   意味テキストに解説言語で使わない文字種が混ざった語句(`filterForeignScriptMeaningTerms`。issue #98)を
- *   決定的に落とす
+ * - 順方向・逆方向とも、抽出結果からは普通の単語・字義通りの句(`filterOrdinaryTerms`。issue #95)、
+ *   疑問文まるごとの抽出(`filterQuestionSentenceTerms`。issue #100)、意味テキストに解説言語で
+ *   使わない文字種が混ざった語句(`filterForeignScriptMeaningTerms`。issue #98)を決定的に落とす。
+ *   順方向では文中に固有名詞的な語を含む句(`filterProperNounPhraseTerms`。issue #100)も落とす
  * - Prompt API の利用可否は `prompt-api.ts` の共有ストアを参照する(翻訳列と共通)
  */
 import { createPickupBaseSessionFactory, pickUpExpressions } from "@/lib/ai/pickup";
-import { filterForeignScriptMeaningTerms, filterTranslationArtifactTerms } from "@/lib/ai/pickup-filter";
+import {
+  filterForeignScriptMeaningTerms,
+  filterProperNounPhraseTerms,
+  filterQuestionSentenceTerms,
+  filterTranslationArtifactTerms,
+} from "@/lib/ai/pickup-filter";
 import { filterOrdinaryTerms } from "@/lib/ai/pickup-ordinary-filter";
 import { LowPriorityQueueOverflowError } from "@/lib/ai/session-pool";
 import type { MessageSegment } from "@/lib/twitch/emotes";
@@ -65,14 +71,16 @@ const pipeline = createAutoPipeline<PickupDone>({
     createPickupBaseSessionFactory(useSettingsStore.getState().settings, learningLang, explainLang, getStreamInfo()),
   resolveWithoutModel: (message) =>
     isTextlessMessage(message.text, message.emotes) || isChatCommandMessage(message.text) ? { terms: [] } : null,
-  // 抽出結果からは、普通の単語・字義通りの句を高頻度語リスト・表現リストで決定的に落とし(issue #95)、
+  // 抽出結果からは、文中に固有名詞を含む句と疑問文まるごとの抽出を落とし(issue #100)、
+  // 普通の単語・字義通りの句を高頻度語リスト・表現リストで決定的に落とし(issue #95)、
   // 意味テキストに解説言語で使わない文字種が混ざった語句も落とす(issue #98)。
   // 言語設定はベースセッション生成時(createBaseSession)と同じく生成時点のストアの値を読めばよい
   runJob: async (pool, message, context) => {
     const result = await pickUpExpressions(pool, message.text, buildPickupJobOptions(message, context));
     const { learningLang, explainLang } = useSettingsStore.getState().settings;
+    const terms = filterQuestionSentenceTerms(filterProperNounPhraseTerms(result.terms, learningLang));
     return {
-      terms: filterForeignScriptMeaningTerms(filterOrdinaryTerms(result.terms, learningLang), explainLang, learningLang),
+      terms: filterForeignScriptMeaningTerms(filterOrdinaryTerms(terms, learningLang), explainLang, learningLang),
     };
   },
   // 逆方向: 翻訳パイプラインの訳文(翻訳列に表示されるもの)を待って再利用し、訳文を二重生成しない(issue #68)。
@@ -91,16 +99,14 @@ const pipeline = createAutoPipeline<PickupDone>({
       excludedNames: collectExcludedNames(context),
     });
     // 訳文は機械翻訳のため、誤訳・幻覚に由来する固有名詞的な語句を決定的に落とし(issue #94)、
-    // 普通の単語・字義通りの句(issue #95)と、意味テキストに解説言語で使わない文字種が混ざった語句
-    // (issue #98)も落とす。言語設定はベースセッション生成時(createReverseBaseSession)と同じく
-    // 生成時点のストアの値を読めばよい
+    // 疑問文まるごとの抽出(issue #100)、普通の単語・字義通りの句(issue #95)、意味テキストに
+    // 解説言語で使わない文字種が混ざった語句(issue #98)も落とす。順方向の固有名詞フィルタ
+    // (filterProperNounPhraseTerms)は issue #94 のより厳しい判定に包含されるため適用しない。
+    // 言語設定はベースセッション生成時(createReverseBaseSession)と同じく生成時点のストアの値を読めばよい
     const { learningLang, explainLang } = useSettingsStore.getState().settings;
+    const terms = filterQuestionSentenceTerms(filterTranslationArtifactTerms(result.terms, learningLang));
     return {
-      terms: filterForeignScriptMeaningTerms(
-        filterOrdinaryTerms(filterTranslationArtifactTerms(result.terms, learningLang), learningLang),
-        explainLang,
-        learningLang,
-      ),
+      terms: filterForeignScriptMeaningTerms(filterOrdinaryTerms(terms, learningLang), explainLang, learningLang),
     };
   },
 });


### PR DESCRIPTION
## Summary

issue #100 で観測した、issue #95 のハイブリッドフィルタ導入後に残る2系統の誤抽出への対処です。

### 1. 順方向の固有名詞フィルタ(`filterProperNounPhraseTerms`)

固有名詞(ブランド名・人名)は高頻度語リストに無いため「非高頻度語を含む複数語句」としてハイブリッドフィルタを通過していました。文中(先頭以外)に「大文字と小文字の両方を含む語」がある語句を決定的に落とします(`src/lib/ai/pickup-filter.ts` に追加)。

- 先頭の語は文頭に置かれただけの表現("Toss it!")と区別できないため対象外
- 全大文字の語("LOL" / "big W" の "W")は略語・強調とみなして残す
- 一人称の "I" / "I'm" は固有名詞とみなさない
- 表現リスト(issue #95)に一致する語句はタイトルケースで書かれていても救済する
- 学ぶ言語がドイツ語の場合は名詞が常に大文字のため適用しない(#94 と同様)
- 逆方向にはより厳しい語句全体での判定(#94 の `filterTranslationArtifactTerms`)が既に適用されるため順方向専用

### 2. 疑問文まるごとフィルタ(`filterQuestionSentenceTerms`)

発言ほぼ全体(疑問文)が1つの「表現」として返るケースに対し、末尾が疑問符(半角・全角、"?!" の形も含む)の複数語・表現リスト外の語句を落とします。順方向・逆方向の両方に適用します。

- "what's up?" のような疑問形の定型表現は表現リスト一致で救済する
- 1語の聞き返し("Pardon?")は学習価値があるため対象外

### 見送り: 語数上限による足切り

表現リストが「全語が高頻度語」に枝刈りされており長いイディオム("make a mountain out of a molehill")を救済できないため、データ生成の枝刈り方針変更とセットで #104 に分離しました。

## 変更ファイル

- `src/lib/ai/pickup-filter.ts`: 新フィルタ2つを追加
- `src/lib/ai/pickup-ordinary-filter.ts`: 表現リスト照合(`isListedExpression`)を公開し救済判定に共通利用
- `src/store/pickups.ts`: 順方向・逆方向のパイプラインに配線
- 各テスト: 単体テストと配線テストを追加(TDD)

## テスト

- `npm test`: 971件すべて成功
- `npm run lint` / `npm run type-check` / `npm run build`: エラー・警告なし
- CodeRabbitレビュー実施済み(指摘2件に対応: 語中大文字のブランド名 iPhone/eBay の捕捉、"?!" 終わりの疑問文の捕捉)

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)