### PR TITLE
feat: Pick upの既出管理を追加し、クールダウン内の同一表現の再表示を抑制する(ユーザー辞書 Phase 1)

### DIFF
--- a/src/lib/ai/pickup-ordinary-filter.test.ts
+++ b/src/lib/ai/pickup-ordinary-filter.test.ts
@@ -12,7 +12,7 @@
  * 回帰テストとして固定する。
  */
 import { describe, expect, it } from "vitest";
-import { filterOrdinaryTerms, isListedExpression } from "./pickup-ordinary-filter";
+import { buildTermExpressionKey, filterOrdinaryTerms, isListedExpression } from "./pickup-ordinary-filter";
 import type { PickupTerm } from "./schemas";
 
 /** テストデータ組み立てヘルパー。意味の文字列は判定に影響しない */
@@ -172,5 +172,17 @@ describe("isListedExpression", () => {
   it("リストに無い語句(普通の句・文まるごとの抽出)には一致しない", () => {
     expect(isListedExpression("main quests")).toBe(false);
     expect(isListedExpression("are you coming to the party tonight?")).toBe(false);
+  });
+});
+
+describe("buildTermExpressionKey", () => {
+  it("語形変化・大文字・前後の記号の揺れを吸収し、同じ表現には同じキーを返す(issue #108 の既出管理のキーに使う)", () => {
+    expect(buildTermExpressionKey("picked up")).toBe(buildTermExpressionKey("pick up"));
+    expect(buildTermExpressionKey("Even Though")).toBe(buildTermExpressionKey("even though"));
+    expect(buildTermExpressionKey("what's up?")).toBe(buildTermExpressionKey("what's up"));
+  });
+
+  it("異なる表現には異なるキーを返す", () => {
+    expect(buildTermExpressionKey("give up")).not.toBe(buildTermExpressionKey("pick up"));
   });
 });

--- a/src/lib/ai/pickup-ordinary-filter.ts
+++ b/src/lib/ai/pickup-ordinary-filter.ts
@@ -80,6 +80,15 @@ function buildExpressionKey(words: string[]): string {
   return words.map(stemForMatch).join(" ");
 }
 
+/**
+ * 語句の表現キー(レンマ正規化キー)を組み立てる。大文字・語形変化・前後の記号の揺れを吸収し、
+ * "picked up" と "pick up" を同じキーに集約する。既出管理(issue #108。`store/pickup-encounters.ts`)が
+ * 遭遇記録のキーとして流用する。
+ */
+export function buildTermExpressionKey(term: string): string {
+  return buildExpressionKey(splitIntoMatchWords(term));
+}
+
 /** 表現リストの照合キー集合。Wiktionary 由来のリストと手動補完リストを正規化して持つ */
 const EXPRESSION_KEYS: ReadonlySet<string> = new Set(
   [...enExpressionList.expressions, ...CURATED_EXPRESSIONS].map((expression) =>

--- a/src/store/pickup-encounters.test.ts
+++ b/src/store/pickup-encounters.test.ts
@@ -16,6 +16,7 @@ import { buildTermExpressionKey } from "@/lib/ai/pickup-ordinary-filter";
 import type { PickupTerm } from "@/lib/ai/schemas";
 import {
   MAX_PICKUP_ENCOUNTER_ENTRIES,
+  MAX_SHOWN_MESSAGE_IDS_PER_ENTRY,
   PICKUP_ENCOUNTER_COOLDOWN_MS,
   PICKUP_ENCOUNTER_STORAGE_KEY,
   resetPickupEncountersForTests,
@@ -33,10 +34,10 @@ function surviving(termTexts: string[], messageId: string): string[] {
 }
 
 /** localStorage に保存された遭遇記録を読み出すヘルパー */
-function storedEntries(): Record<string, { count: number; lastShownAt: number; lastShownMessageId: string }> {
+function storedEntries(): Record<string, { count: number; lastShownAt: number; shownMessageIds: string[] }> {
   const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
   if (raw === null) throw new Error("遭遇記録が localStorage に保存されていません");
-  return (JSON.parse(raw) as { entries: Record<string, { count: number; lastShownAt: number; lastShownMessageId: string }> })
+  return (JSON.parse(raw) as { entries: Record<string, { count: number; lastShownAt: number; shownMessageIds: string[] }> })
     .entries;
 }
 
@@ -52,7 +53,7 @@ afterEach(() => {
 });
 
 describe("suppressRecentPickupTerms", () => {
-  it("初回遭遇の表現は表示し、遭遇回数1・最終表示日時・最終表示メッセージIDを記録する", () => {
+  it("初回遭遇の表現は表示し、遭遇回数1・最終表示日時・表示したメッセージIDを記録する", () => {
     expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
 
     const entries = storedEntries();
@@ -61,7 +62,7 @@ describe("suppressRecentPickupTerms", () => {
     expect(entries[keys[0]]).toEqual({
       count: 1,
       lastShownAt: Date.now(),
-      lastShownMessageId: "msg-1",
+      shownMessageIds: ["msg-1"],
     });
   });
 
@@ -71,14 +72,14 @@ describe("suppressRecentPickupTerms", () => {
 
     expect(surviving(["even though"], "msg-2")).toEqual([]);
 
-    // 抑制時は遭遇回数だけ加算し、最終表示日時・メッセージIDは更新しない(表示していないため)
+    // 抑制時は遭遇回数だけ加算し、最終表示日時・表示したメッセージIDは更新しない(表示していないため)
     const entries = storedEntries();
     const record = entries[Object.keys(entries)[0]];
     expect(record.count).toBe(2);
-    expect(record.lastShownMessageId).toBe("msg-1");
+    expect(record.shownMessageIds).toEqual(["msg-1"]);
   });
 
-  it("最終表示からクールダウンが経過した表現は再び表示し、最終表示日時・メッセージIDを更新する", () => {
+  it("最終表示からクールダウンが経過した表現は再び表示し、最終表示日時を更新して表示したメッセージIDを追記する", () => {
     surviving(["even though"], "msg-1");
     vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
 
@@ -86,10 +87,10 @@ describe("suppressRecentPickupTerms", () => {
 
     const entries = storedEntries();
     const record = entries[Object.keys(entries)[0]];
-    expect(record).toEqual({ count: 2, lastShownAt: Date.now(), lastShownMessageId: "msg-2" });
+    expect(record).toEqual({ count: 2, lastShownAt: Date.now(), shownMessageIds: ["msg-1", "msg-2"] });
   });
 
-  it("最終表示と同じメッセージIDからの再遭遇(パイプライン再起動による再抽出)は抑制せず、記録も変えない", () => {
+  it("表示済みと同じメッセージIDからの再遭遇(パイプライン再起動による再抽出)は抑制せず、記録も変えない", () => {
     surviving(["even though"], "msg-1");
     vi.advanceTimersByTime(1000);
 
@@ -102,8 +103,34 @@ describe("suppressRecentPickupTerms", () => {
     expect(record).toEqual({
       count: 1,
       lastShownAt: Date.now() - 1000,
-      lastShownMessageId: "msg-1",
+      shownMessageIds: ["msg-1"],
     });
+  });
+
+  it("クールダウンを挟んで複数の発言で表示した表現は、どの発言の再抽出(パイプライン再起動)でも抑制しない", () => {
+    // msg-1 で表示 → クールダウン経過後に msg-2 でも表示(CodeRabbit レビュー指摘の回帰テスト)
+    surviving(["even though"], "msg-1");
+    vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
+    surviving(["even though"], "msg-2");
+
+    // パイプライン再起動で両方の発言が再抽出される。最新の msg-2 だけでなく msg-1 側も表示を維持する
+    expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
+    expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
+  });
+
+  it("表示したメッセージIDの保持数には上限があり、古いIDから追い出す", () => {
+    // 上限+1回、クールダウンを挟みながら別々の発言で表示する
+    for (let i = 0; i <= MAX_SHOWN_MESSAGE_IDS_PER_ENTRY; i += 1) {
+      surviving(["even though"], `msg-${String(i)}`);
+      vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
+    }
+
+    const entries = storedEntries();
+    const record = entries[Object.keys(entries)[0]];
+    expect(record.shownMessageIds).toHaveLength(MAX_SHOWN_MESSAGE_IDS_PER_ENTRY);
+    // 最初の msg-0 は追い出され、以降の再抽出では(クールダウン経過後のため)通常規則で表示される
+    expect(record.shownMessageIds).not.toContain("msg-0");
+    expect(record.shownMessageIds).toContain(`msg-${String(MAX_SHOWN_MESSAGE_IDS_PER_ENTRY)}`);
   });
 
   it("語形変化した表現(picked up / pick up)は同一の表現キーとして抑制する", () => {

--- a/src/store/pickup-encounters.test.ts
+++ b/src/store/pickup-encounters.test.ts
@@ -1,0 +1,157 @@
+/**
+ * `pickup-encounters.ts`(Pick up の既出管理。issue #108)のテスト。
+ *
+ * 自動Pick upは同じ定型表現がチャットに流れるたびに毎回表示するため、表現キーごとの
+ * 遭遇記録を localStorage に持ち、最終表示からクールダウン期間内の再表示を決定的に抑制する。
+ * 検証項目:
+ * - 初回遭遇は表示し、遭遇記録(遭遇回数・最終表示日時・最終表示メッセージID)を保存する
+ * - クールダウン内の別メッセージでの再遭遇は抑制する(遭遇回数だけ加算する)
+ * - クールダウン経過後の再遭遇は再び表示する
+ * - 同一メッセージIDからの再抽出(言語設定変更等によるパイプライン再起動)は抑制しない
+ * - 語形変化("picked up" / "pick up")は同一の表現キーとして扱う
+ * - localStorage への永続化・破損データの扱い・エントリ数上限の整理
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildTermExpressionKey } from "@/lib/ai/pickup-ordinary-filter";
+import type { PickupTerm } from "@/lib/ai/schemas";
+import {
+  MAX_PICKUP_ENCOUNTER_ENTRIES,
+  PICKUP_ENCOUNTER_COOLDOWN_MS,
+  PICKUP_ENCOUNTER_STORAGE_KEY,
+  resetPickupEncountersForTests,
+  suppressRecentPickupTerms,
+} from "./pickup-encounters";
+
+/** テストデータ組み立てヘルパー。意味の文字列は抑制判定に影響しない */
+function terms(...termTexts: string[]): PickupTerm[] {
+  return termTexts.map((term) => ({ term, meaning: "テスト用の意味" }));
+}
+
+/** 抑制適用後に残った語句だけを取り出すヘルパー */
+function surviving(termTexts: string[], messageId: string): string[] {
+  return suppressRecentPickupTerms(terms(...termTexts), messageId).map((item) => item.term);
+}
+
+/** localStorage に保存された遭遇記録を読み出すヘルパー */
+function storedEntries(): Record<string, { count: number; lastShownAt: number; lastShownMessageId: string }> {
+  const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
+  if (raw === null) throw new Error("遭遇記録が localStorage に保存されていません");
+  return (JSON.parse(raw) as { entries: Record<string, { count: number; lastShownAt: number; lastShownMessageId: string }> })
+    .entries;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-04T12:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  window.localStorage.clear();
+  resetPickupEncountersForTests();
+});
+
+describe("suppressRecentPickupTerms", () => {
+  it("初回遭遇の表現は表示し、遭遇回数1・最終表示日時・最終表示メッセージIDを記録する", () => {
+    expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
+
+    const entries = storedEntries();
+    const keys = Object.keys(entries);
+    expect(keys).toHaveLength(1);
+    expect(entries[keys[0]]).toEqual({
+      count: 1,
+      lastShownAt: Date.now(),
+      lastShownMessageId: "msg-1",
+    });
+  });
+
+  it("最終表示からクールダウン内に別メッセージで再遭遇した表現は抑制し、遭遇回数だけ加算する", () => {
+    surviving(["even though"], "msg-1");
+    vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS - 1);
+
+    expect(surviving(["even though"], "msg-2")).toEqual([]);
+
+    // 抑制時は遭遇回数だけ加算し、最終表示日時・メッセージIDは更新しない(表示していないため)
+    const entries = storedEntries();
+    const record = entries[Object.keys(entries)[0]];
+    expect(record.count).toBe(2);
+    expect(record.lastShownMessageId).toBe("msg-1");
+  });
+
+  it("最終表示からクールダウンが経過した表現は再び表示し、最終表示日時・メッセージIDを更新する", () => {
+    surviving(["even though"], "msg-1");
+    vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
+
+    expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
+
+    const entries = storedEntries();
+    const record = entries[Object.keys(entries)[0]];
+    expect(record).toEqual({ count: 2, lastShownAt: Date.now(), lastShownMessageId: "msg-2" });
+  });
+
+  it("最終表示と同じメッセージIDからの再遭遇(パイプライン再起動による再抽出)は抑制せず、記録も変えない", () => {
+    surviving(["even though"], "msg-1");
+    vi.advanceTimersByTime(1000);
+
+    // 言語設定変更などでパイプラインが再起動すると同じ発言が再抽出される。
+    // 表示済みの表現が再生成で消えないよう、同じ遭遇の再表示として扱う
+    expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
+
+    const entries = storedEntries();
+    const record = entries[Object.keys(entries)[0]];
+    expect(record).toEqual({
+      count: 1,
+      lastShownAt: Date.now() - 1000,
+      lastShownMessageId: "msg-1",
+    });
+  });
+
+  it("語形変化した表現(picked up / pick up)は同一の表現キーとして抑制する", () => {
+    surviving(["picked up"], "msg-1");
+
+    expect(surviving(["pick up"], "msg-2")).toEqual([]);
+  });
+
+  it("抑制は該当する表現だけに作用し、同じメッセージの他の表現は表示する", () => {
+    surviving(["even though"], "msg-1");
+
+    expect(surviving(["even though", "malding"], "msg-2")).toEqual(["malding"]);
+  });
+
+  it("保存済みの遭遇記録を localStorage から復元して抑制する(ページ再読み込み相当)", () => {
+    surviving(["even though"], "msg-1");
+
+    // メモリ上の記録を破棄しても localStorage から復元されて抑制が維持される
+    resetPickupEncountersForTests();
+
+    expect(surviving(["even though"], "msg-2")).toEqual([]);
+  });
+
+  it("localStorage の保存データが壊れている場合は空の記録として扱い、抑制せずに表示する", () => {
+    window.localStorage.setItem(PICKUP_ENCOUNTER_STORAGE_KEY, "壊れたJSON{");
+
+    expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
+  });
+
+  it("エントリ数が上限を超えたら、最終表示日時が古いエントリから削除する", () => {
+    // 表現キーの正規化(数字の除去・語尾の変化)で衝突しないよう、番号を英字だけの綴りに変換する
+    // (使用する英字は s / d / g を含まず、ステム処理の接尾辞規則に一致しない)
+    const uniqueTerm = (index: number): string =>
+      `word${String(index).replace(/\d/g, (digit) => "klmnopqrtu"[Number(digit)])}`;
+
+    // 上限ちょうどまで、1件ずつ時刻をずらしながら記録する(最初の1件が最も古い)
+    for (let i = 0; i < MAX_PICKUP_ENCOUNTER_ENTRIES; i += 1) {
+      surviving([uniqueTerm(i)], `msg-${String(i)}`);
+      vi.advanceTimersByTime(1);
+    }
+    expect(Object.keys(storedEntries())).toHaveLength(MAX_PICKUP_ENCOUNTER_ENTRIES);
+
+    // 1件追加すると上限を超えるため、最も古い最初のエントリ(uniqueTerm(0))が削除される
+    surviving(["newest expression"], "msg-new");
+
+    const entries = storedEntries();
+    expect(Object.keys(entries)).toHaveLength(MAX_PICKUP_ENCOUNTER_ENTRIES);
+    expect(entries[buildTermExpressionKey(uniqueTerm(0))]).toBeUndefined();
+    expect(entries[buildTermExpressionKey(uniqueTerm(1))]).toBeDefined();
+  });
+});

--- a/src/store/pickup-encounters.ts
+++ b/src/store/pickup-encounters.ts
@@ -7,8 +7,9 @@
  * - キー: `lib/ai/pickup-ordinary-filter.ts` の `buildTermExpressionKey`(`stemForMatch` による
  *   レンマ正規化キー)。語形変化("picked up" / "pick up")を同一表現として扱う
  * - 抑制規則: 最終表示からクールダウン内の再遭遇は表示しない(遭遇回数だけ加算する)。
- *   ただし最終表示と同じメッセージIDからの再遭遇は「パイプライン再起動による同じ発言の再抽出」
- *   (`hidden-pickups.ts` に記載の再生成問題)なので、同じ遭遇の再表示として抑制せず記録も変えない
+ *   ただし表示済みのメッセージID(上限付きで保持)からの再遭遇は「パイプライン再起動による
+ *   同じ発言の再抽出」(`hidden-pickups.ts` に記載の再生成問題)なので、同じ遭遇の再表示として
+ *   抑制せず記録も変えない
  * - 適用範囲: 自動Pick up(`pickups.ts`)の順方向・逆方向のみ。手動Pick up(`manual-pickups.ts`)は
  *   ユーザーが明示的に選択した操作のため対象外。翻訳列にも影響しない
  * - 永続化: localStorage(`lib/settings.ts` と同じパターン)。学習状態はユーザーに属するため
@@ -35,14 +36,25 @@ export const PICKUP_ENCOUNTER_COOLDOWN_MS = 30 * 60 * 1000;
  */
 export const MAX_PICKUP_ENCOUNTER_ENTRIES = 2000;
 
+/**
+ * 表現キー1件あたりで保持する、表示したメッセージIDの上限。パイプライン再起動時に再抽出されるのは
+ * 画面に表示中の発言だけのため、同じ表現を表示した直近の発言をこの件数まで覚えていれば足りる。
+ * 追い出された古いIDの発言が再抽出された場合は通常のクールダウン規則で判定される(最終表示から
+ * クールダウンが経過していれば表示される)
+ */
+export const MAX_SHOWN_MESSAGE_IDS_PER_ENTRY = 10;
+
 /** 表現キー1件ぶんの遭遇記録 */
 const encounterRecordSchema = z.object({
   /** 遭遇回数(抑制した遭遇も含む)。Phase 2 以降で習熟度の入力に使う */
   count: z.number(),
   /** 最終表示日時(エポックミリ秒)。抑制した遭遇では更新しない */
   lastShownAt: z.number(),
-  /** 最終表示したメッセージID。パイプライン再起動による同じ発言の再抽出を抑制対象から外すために持つ */
-  lastShownMessageId: z.string(),
+  /**
+   * 表示したメッセージID(古い順、`MAX_SHOWN_MESSAGE_IDS_PER_ENTRY` 件まで)。
+   * パイプライン再起動による同じ発言の再抽出を抑制対象から外すために持つ
+   */
+  shownMessageIds: z.array(z.string()),
 });
 
 /** 保存形式。Phase 2(習熟状態)・Phase 3(SRS)での拡張に備えて version を持つ */
@@ -105,17 +117,21 @@ export function suppressRecentPickupTerms(terms: PickupTerm[], messageId: string
     const record = loaded.get(key);
     if (record === undefined) {
       // 初回遭遇: 表示して記録を作る
-      loaded.set(key, { count: 1, lastShownAt: now, lastShownMessageId: messageId });
+      loaded.set(key, { count: 1, lastShownAt: now, shownMessageIds: [messageId] });
       shown.push(item);
-    } else if (record.lastShownMessageId === messageId) {
-      // 最終表示と同じ発言からの再抽出(パイプライン再起動): 同じ遭遇の再表示として扱い、記録は変えない
+    } else if (record.shownMessageIds.includes(messageId)) {
+      // 表示済みの発言からの再抽出(パイプライン再起動): 同じ遭遇の再表示として扱い、記録は変えない
       shown.push(item);
     } else if (now - record.lastShownAt < PICKUP_ENCOUNTER_COOLDOWN_MS) {
-      // クールダウン内の再遭遇: 抑制する。遭遇回数だけ加算し、最終表示日時・メッセージIDは表示していないので変えない
+      // クールダウン内の再遭遇: 抑制する。遭遇回数だけ加算し、最終表示日時・表示したメッセージIDは表示していないので変えない
       loaded.set(key, { ...record, count: record.count + 1 });
     } else {
-      // クールダウン経過後の再遭遇: 再び表示する
-      loaded.set(key, { count: record.count + 1, lastShownAt: now, lastShownMessageId: messageId });
+      // クールダウン経過後の再遭遇: 再び表示し、表示したメッセージIDを上限付きで追記する
+      loaded.set(key, {
+        count: record.count + 1,
+        lastShownAt: now,
+        shownMessageIds: [...record.shownMessageIds, messageId].slice(-MAX_SHOWN_MESSAGE_IDS_PER_ENTRY),
+      });
       shown.push(item);
     }
   }

--- a/src/store/pickup-encounters.ts
+++ b/src/store/pickup-encounters.ts
@@ -1,0 +1,129 @@
+/**
+ * Pick up の既出管理(issue #108。ユーザー辞書構想 #107 の Phase 1)。
+ *
+ * 自動Pick upは同じ定型表現("even though" など)がチャットに流れるたびに毎回抽出・表示するため、
+ * 表現キーごとの遭遇記録を持ち、最終表示からクールダウン期間内の再表示を決定的に抑制する。
+ *
+ * - キー: `lib/ai/pickup-ordinary-filter.ts` の `buildTermExpressionKey`(`stemForMatch` による
+ *   レンマ正規化キー)。語形変化("picked up" / "pick up")を同一表現として扱う
+ * - 抑制規則: 最終表示からクールダウン内の再遭遇は表示しない(遭遇回数だけ加算する)。
+ *   ただし最終表示と同じメッセージIDからの再遭遇は「パイプライン再起動による同じ発言の再抽出」
+ *   (`hidden-pickups.ts` に記載の再生成問題)なので、同じ遭遇の再表示として抑制せず記録も変えない
+ * - 適用範囲: 自動Pick up(`pickups.ts`)の順方向・逆方向のみ。手動Pick up(`manual-pickups.ts`)は
+ *   ユーザーが明示的に選択した操作のため対象外。翻訳列にも影響しない
+ * - 永続化: localStorage(`lib/settings.ts` と同じパターン)。学習状態はユーザーに属するため
+ *   チャンネルをまたいで共有する。Phase 2(習熟状態)・Phase 3(SRS)でのスキーマ拡張に備えて
+ *   保存形式にバージョンを持たせる。保存データが壊れている場合は空の記録から再開する
+ *   (抑制が一時的に働かなくなるだけで表示機能は損なわれず、壊れた学習記録の復元は不可能なため)
+ * - この層は完全に決定的(LLM 非依存)
+ */
+import { buildTermExpressionKey } from "@/lib/ai/pickup-ordinary-filter";
+import type { PickupTerm } from "@/lib/ai/schemas";
+import { z } from "zod";
+
+export const PICKUP_ENCOUNTER_STORAGE_KEY = "chat-sensei:pickup-encounters";
+
+/**
+ * 再表示を抑制するクールダウン期間。抑制しすぎると学習機会を失うため(issue #107 の留意点)、
+ * 控えめな既定値として30分から始める(1配信セッション中に同じ定型表現が2回以上出れば再表示される)
+ */
+export const PICKUP_ENCOUNTER_COOLDOWN_MS = 30 * 60 * 1000;
+
+/**
+ * 保持する遭遇記録の上限。超過時は最終表示日時が古いエントリから削除する。
+ * 1エントリはおおむね100バイト弱のため、2000件でも localStorage の容量(一般に5MB)を圧迫しない
+ */
+export const MAX_PICKUP_ENCOUNTER_ENTRIES = 2000;
+
+/** 表現キー1件ぶんの遭遇記録 */
+const encounterRecordSchema = z.object({
+  /** 遭遇回数(抑制した遭遇も含む)。Phase 2 以降で習熟度の入力に使う */
+  count: z.number(),
+  /** 最終表示日時(エポックミリ秒)。抑制した遭遇では更新しない */
+  lastShownAt: z.number(),
+  /** 最終表示したメッセージID。パイプライン再起動による同じ発言の再抽出を抑制対象から外すために持つ */
+  lastShownMessageId: z.string(),
+});
+
+/** 保存形式。Phase 2(習熟状態)・Phase 3(SRS)での拡張に備えて version を持つ */
+const storedEncountersSchema = z.object({
+  version: z.literal(1),
+  entries: z.record(z.string(), encounterRecordSchema),
+});
+
+type EncounterRecord = z.infer<typeof encounterRecordSchema>;
+
+/**
+ * メモリ上の遭遇記録。初回利用時に localStorage から復元し(`ensureLoaded`)、以後は
+ * このマップを正本として更新のたびに書き戻す。null は未復元を表す
+ */
+let encounters: Map<string, EncounterRecord> | null = null;
+
+/** localStorage から遭遇記録を復元する。無い場合・壊れている場合は空の記録から再開する */
+function ensureLoaded(): Map<string, EncounterRecord> {
+  if (encounters !== null) return encounters;
+  encounters = new Map();
+  const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
+  if (raw === null) return encounters;
+  try {
+    const stored = storedEncountersSchema.parse(JSON.parse(raw));
+    encounters = new Map(Object.entries(stored.entries));
+  } catch {
+    // 壊れた記録は復元できず、失っても抑制が一時的に働かなくなるだけのため空から再開する(冒頭コメント参照)
+  }
+  return encounters;
+}
+
+/** 遭遇記録を localStorage に書き戻す。上限超過時は最終表示日時が古いエントリから削除する */
+function persist(loaded: Map<string, EncounterRecord>): void {
+  if (loaded.size > MAX_PICKUP_ENCOUNTER_ENTRIES) {
+    const excess = [...loaded.entries()]
+      .sort(([, a], [, b]) => a.lastShownAt - b.lastShownAt)
+      .slice(0, loaded.size - MAX_PICKUP_ENCOUNTER_ENTRIES);
+    for (const [key] of excess) loaded.delete(key);
+  }
+  window.localStorage.setItem(
+    PICKUP_ENCOUNTER_STORAGE_KEY,
+    JSON.stringify({ version: 1, entries: Object.fromEntries(loaded) }),
+  );
+}
+
+/**
+ * 抽出結果から、最終表示からクールダウン内の既出表現を落とし、遭遇記録を更新する。
+ * `pickups.ts` の決定的後段フィルタの後(表示リストへの追加前)に順方向・逆方向の両方で呼ぶ。
+ *
+ * @param terms 決定的フィルタ適用後の抽出結果
+ * @param messageId 抽出元のメッセージID(逆方向では訳文の元になった発言のID)
+ * @returns 表示する語句(抑制した語句を除いたもの)
+ */
+export function suppressRecentPickupTerms(terms: PickupTerm[], messageId: string): PickupTerm[] {
+  const loaded = ensureLoaded();
+  const now = Date.now();
+  const shown: PickupTerm[] = [];
+  for (const item of terms) {
+    const key = buildTermExpressionKey(item.term);
+    const record = loaded.get(key);
+    if (record === undefined) {
+      // 初回遭遇: 表示して記録を作る
+      loaded.set(key, { count: 1, lastShownAt: now, lastShownMessageId: messageId });
+      shown.push(item);
+    } else if (record.lastShownMessageId === messageId) {
+      // 最終表示と同じ発言からの再抽出(パイプライン再起動): 同じ遭遇の再表示として扱い、記録は変えない
+      shown.push(item);
+    } else if (now - record.lastShownAt < PICKUP_ENCOUNTER_COOLDOWN_MS) {
+      // クールダウン内の再遭遇: 抑制する。遭遇回数だけ加算し、最終表示日時・メッセージIDは表示していないので変えない
+      loaded.set(key, { ...record, count: record.count + 1 });
+    } else {
+      // クールダウン経過後の再遭遇: 再び表示する
+      loaded.set(key, { count: record.count + 1, lastShownAt: now, lastShownMessageId: messageId });
+      shown.push(item);
+    }
+  }
+  persist(loaded);
+  return shown;
+}
+
+/** テスト専用: メモリ上の記録を破棄し、次回利用時に localStorage から復元し直す */
+export function resetPickupEncountersForTests(): void {
+  encounters = null;
+}

--- a/src/store/pickups.test.ts
+++ b/src/store/pickups.test.ts
@@ -6,6 +6,7 @@
  * 空の結果で確定させるか、発言者名を除外名として渡すか、語句一覧をどの形で保持するか ―― だけを検証する。
  */
 import { afterEach, describe, expect, it } from "vitest";
+import { resetPickupEncountersForTests } from "./pickup-encounters";
 import { resetPickupStoreForTests, startPickupPipeline, usePickupStore } from "./pickups";
 import { createDeps, createMessage, flush } from "./pipeline-test-fixtures";
 import { resetPromptApiStoreForTests } from "./prompt-api";
@@ -18,6 +19,9 @@ afterEach(() => {
   resetPickupStoreForTests();
   resetTranslationStoreForTests();
   resetPromptApiStoreForTests();
+  // 既出管理(issue #108)の遭遇記録はテストをまたいで持ち越さない
+  window.localStorage.clear();
+  resetPickupEncountersForTests();
 });
 
 describe("startPickupPipeline", () => {
@@ -399,5 +403,112 @@ describe("startPickupPipeline(逆方向: 翻訳パイプラインの訳文を再
       terms: [{ term: "no cap", meaning: "嘘じゃない、マジで" }],
     });
     stop();
+  });
+});
+
+describe("startPickupPipeline(既出管理: クールダウン内の再表示抑制。issue #108)", () => {
+  it("順方向: 別の発言でクールダウン内に再抽出された同じ表現(語形変化を含む)を結果から落とす", async () => {
+    const { deps, emit } = createDeps({
+      promptResults: [
+        Promise.resolve(JSON.stringify({ terms: [{ term: "picked up", meaning: "拾った、覚えた" }] })),
+        Promise.resolve(
+          JSON.stringify({
+            terms: [
+              // 1件目の発言で表示済みの表現(語形違い)。クールダウン内のため抑制される
+              { term: "pick up", meaning: "拾う、覚える" },
+              { term: "malding", meaning: "ハゲるほどキレること" },
+            ],
+          }),
+        ),
+      ],
+    });
+
+    const stop = startPickupPipeline(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "I picked up some slang" }));
+    await flush();
+    emit(createMessage({ id: "msg-2", text: "pick up the pace, malding already?" }));
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "picked up", meaning: "拾った、覚えた" }],
+    });
+    expect(usePickupStore.getState().entries["msg-2"]).toEqual({
+      status: "done",
+      terms: [{ term: "malding", meaning: "ハゲるほどキレること" }],
+    });
+    stop();
+  });
+
+  it("逆方向: 別の発言の訳文からクールダウン内に再抽出された同じ表現を結果から落とす", async () => {
+    const { deps, emit } = createDeps({
+      detectedLanguage: "ja",
+      reversePromptResults: [
+        Promise.resolve(JSON.stringify({ terms: [{ term: "no cap", meaning: "嘘じゃない、マジで" }] })),
+        Promise.resolve(
+          JSON.stringify({
+            terms: [
+              // 1件目の訳文で表示済みの表現。クールダウン内のため抑制される
+              { term: "no cap", meaning: "嘘じゃない、マジで" },
+              { term: "fr", meaning: "for real の略。マジで" },
+            ],
+          }),
+        ),
+      ],
+    });
+    useTranslationStore.setState({
+      entries: {
+        "msg-1": { status: "done", segments: [{ type: "text", text: "that was insane, no cap" }] },
+        "msg-2": { status: "done", segments: [{ type: "text", text: "no cap it was crazy fr" }] },
+      },
+    });
+
+    const stop = startPickupPipeline(deps);
+    await flush();
+    emit(createMessage({ id: "msg-1", text: "やばかった、マジで" }));
+    await flush();
+    emit(createMessage({ id: "msg-2", text: "マジでやばかったって" }));
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "no cap", meaning: "嘘じゃない、マジで" }],
+    });
+    expect(usePickupStore.getState().entries["msg-2"]).toEqual({
+      status: "done",
+      terms: [{ term: "fr", meaning: "for real の略。マジで" }],
+    });
+    stop();
+  });
+
+  it("順方向で表示済みの表現は、パイプライン再起動(言語設定変更等)で同じ発言が再抽出されても消えない", async () => {
+    const promptResult = JSON.stringify({ terms: [{ term: "even though", meaning: "〜だけれども" }] });
+    const first = createDeps({ promptResults: [Promise.resolve(promptResult)] });
+
+    const stop1 = startPickupPipeline(first.deps);
+    await flush();
+    first.emit(createMessage({ id: "msg-1", text: "even though it rained we won" }));
+    await flush();
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "even though", meaning: "〜だけれども" }],
+    });
+    stop1();
+    resetPickupStoreForTests();
+
+    // 再起動後、同じ発言が再抽出される(hidden-pickups.ts に記載の再生成の挙動)。
+    // 最終表示と同じメッセージIDのため、クールダウン内でも抑制せずに表示する
+    const second = createDeps({ promptResults: [Promise.resolve(promptResult)] });
+    const stop2 = startPickupPipeline(second.deps);
+    await flush();
+    second.emit(createMessage({ id: "msg-1", text: "even though it rained we won" }));
+    await flush();
+
+    expect(usePickupStore.getState().entries["msg-1"]).toEqual({
+      status: "done",
+      terms: [{ term: "even though", meaning: "〜だけれども" }],
+    });
+    stop2();
   });
 });

--- a/src/store/pickups.ts
+++ b/src/store/pickups.ts
@@ -23,6 +23,8 @@
  *   語句(`filterLongPhraseTerms`。issue #104)、意味テキストに解説言語で使わない文字種が混ざった
  *   語句(`filterForeignScriptMeaningTerms`。issue #98)を決定的に落とす。
  *   順方向では文中に固有名詞的な語を含む句(`filterProperNounPhraseTerms`。issue #100)も落とす
+ * - 決定的フィルタの後、最終表示からクールダウン内の既出表現を既出管理(`pickup-encounters.ts`。
+ *   issue #108)で落とす(順方向・逆方向とも)。手動Pick up(`manual-pickups.ts`)は対象外
  * - Prompt API の利用可否は `prompt-api.ts` の共有ストアを参照する(翻訳列と共通)
  */
 import { createPickupBaseSessionFactory, pickUpExpressions } from "@/lib/ai/pickup";
@@ -46,6 +48,7 @@ import {
   type AutoPipelineJobContext,
   type PipelineEntry,
 } from "./auto-pipeline";
+import { suppressRecentPickupTerms } from "./pickup-encounters";
 import { useSettingsStore } from "./settings";
 import { getStreamInfo } from "./stream-info";
 import { useTranslationStore } from "./translations";
@@ -78,11 +81,18 @@ const pipeline = createAutoPipeline<PickupDone>({
   // 決定的に落とし(issue #95)、意味テキストに解説言語で使わない文字種が混ざった語句も落とす(issue #98)。
   // 言語設定はベースセッション生成時(createBaseSession)と同じく生成時点のストアの値を読めばよい
   runJob: async (pool, message, context) => {
+    if (message.id === null) {
+      // 共通ファクトリは ID の無い発言を投入しないため到達しない想定。暗黙に処理せず失敗させる(Fail-Fast)
+      throw new Error("ID の無い発言は Pick up の対象にできません");
+    }
     const result = await pickUpExpressions(pool, message.text, buildPickupJobOptions(message, context));
     const { learningLang, explainLang } = useSettingsStore.getState().settings;
     const terms = filterLongPhraseTerms(filterQuestionSentenceTerms(filterProperNounPhraseTerms(result.terms, learningLang)));
     return {
-      terms: filterForeignScriptMeaningTerms(filterOrdinaryTerms(terms, learningLang), explainLang, learningLang),
+      terms: suppressRecentPickupTerms(
+        filterForeignScriptMeaningTerms(filterOrdinaryTerms(terms, learningLang), explainLang, learningLang),
+        message.id,
+      ),
     };
   },
   // 逆方向: 翻訳パイプラインの訳文(翻訳列に表示されるもの)を待って再利用し、訳文を二重生成しない(issue #68)。
@@ -109,7 +119,10 @@ const pipeline = createAutoPipeline<PickupDone>({
     const { learningLang, explainLang } = useSettingsStore.getState().settings;
     const terms = filterLongPhraseTerms(filterQuestionSentenceTerms(filterTranslationArtifactTerms(result.terms, learningLang)));
     return {
-      terms: filterForeignScriptMeaningTerms(filterOrdinaryTerms(terms, learningLang), explainLang, learningLang),
+      terms: suppressRecentPickupTerms(
+        filterForeignScriptMeaningTerms(filterOrdinaryTerms(terms, learningLang), explainLang, learningLang),
+        message.id,
+      ),
     };
   },
 });


### PR DESCRIPTION
## Summary

自動Pick upが同じ定型表現("even though" など)をチャットに流れるたびに毎回表示するノイズを抑えるため、表現キーごとの遭遇記録を localStorage に持ち、最終表示から30分(クールダウン)以内の再表示を決定的に抑制します(ユーザー辞書構想 #107 の Phase 1)。

## 変更内容

- `src/lib/ai/pickup-ordinary-filter.ts`: 表現キーの組み立てを `buildTermExpressionKey` として公開しました。`stemForMatch` によるレンマ正規化キーで、語形変化("picked up" / "pick up")を同一表現として扱います
- `src/store/pickup-encounters.ts`(新規): 表現キーごとの遭遇記録(遭遇回数・最終表示日時・表示したメッセージID)を保持するストアです
  - 抑制規則: 最終表示からクールダウン(30分)以内の再遭遇は表示せず、遭遇回数だけ加算します。抑制しすぎによる学習機会の喪失(#107 の留意点)を避けるため、控えめな既定値から始めています
  - 表示済みのメッセージID(表現キーごとに上限10件)からの再遭遇は、言語設定変更等によるパイプライン再起動時の再抽出のため、同じ遭遇の再表示として抑制しません(`hidden-pickups.ts` に記載の再生成問題への対処)
  - 永続化: localStorage(`chat-sensei:pickup-encounters`)。学習状態はユーザーに属するためチャンネルをまたいで共有し、Phase 2/3 でのスキーマ拡張に備えてバージョンを持たせています。エントリ数は上限2000件で、超過時は最終表示日時が古い順に整理します
  - この層は完全に決定的(LLM 非依存)です
- `src/store/pickups.ts`: 決定的後段フィルタの後(表示リストへの追加前)に、順方向・逆方向の両方で抑制を適用しました。手動Pick up(`manual-pickups.ts`)と翻訳列には影響しません

## テスト

- `npm test`: 991件すべて成功
- `npm run lint` / `npm run type-check` / `npm run build`: エラー・警告なし
- CodeRabbitレビュー実施済み(指摘1件: 再起動時の再抽出で最新以外の表示済み発言が消える問題 → 表示したメッセージIDを上限付き配列で保持する形に修正済み)

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)