### PR TITLE
feat: Pick upに「知っている」マークと意味確認回数の記録を追加する(ユーザー辞書 Phase 2)

### DIFF
--- a/src/app/[channel]/page.test.tsx
+++ b/src/app/[channel]/page.test.tsx
@@ -24,6 +24,7 @@ import { resetBotFilterStoreForTests, useBotFilterStore } from "@/store/bot-filt
 import { resetChatConnectionStoreForTests, useChatConnectionStore } from "@/store/chat-connection";
 import { resetHiddenPickupStoreForTests } from "@/store/hidden-pickups";
 import { resetPickupAnnouncementStoreForTests } from "@/store/pickup-announcements";
+import { PICKUP_ENCOUNTER_STORAGE_KEY, resetPickupEncountersForTests } from "@/store/pickup-encounters";
 import { resetManualPickupStoreForTests, useManualPickupStore } from "@/store/manual-pickups";
 import { resetPickupStoreForTests, usePickupStore } from "@/store/pickups";
 import { resetPromptApiStoreForTests, usePromptApiStore } from "@/store/prompt-api";
@@ -146,6 +147,7 @@ afterEach(() => {
   resetAvatarsForTests();
   resetBadgesForTests();
   window.localStorage.clear();
+  resetPickupEncountersForTests();
 });
 
 describe("ChannelPage(3カラム構成)", () => {
@@ -704,6 +706,86 @@ describe("ChannelPage(Pick up列)", () => {
 
     expect(within(pickupColumn).queryByText(/gg/i)).not.toBeInTheDocument();
     expect(within(pickupColumn).getByText("no re")).toBeInTheDocument();
+  });
+
+  it('「知っている」ボタンを押すと、その語句が表示から消え、ユーザー辞書に knownCount が記録される(issue #110)', async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: {
+        "msg-1": {
+          status: "done",
+          terms: [
+            { term: "gg", meaning: "good game の略、お疲れ" },
+            { term: "no re", meaning: "再戦なし" },
+          ],
+        },
+      },
+    });
+
+    render(<ChannelPage />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Mark "gg" as known' }));
+
+    // 押した語句だけが表示から消える(削除ボタンと同じ非表示集合を使うため再生成でも復活しない)
+    expect(within(pickupColumn).queryByText("gg")).not.toBeInTheDocument();
+    expect(within(pickupColumn).getByText("no re")).toBeInTheDocument();
+
+    // ユーザー辞書(pickup-encounters)に「知っている」が記録される
+    const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw as string) as {
+      entries: Record<string, { knownCount: number; lastKnownAt: number | null }>;
+    };
+    const records = Object.values(stored.entries);
+    expect(records).toHaveLength(1);
+    expect(records[0].knownCount).toBe(1);
+    expect(records[0].lastKnownAt).not.toBeNull();
+  });
+
+  it('「知っている」を押すと、スクリーンリーダー向けの通知リージョンに「Marked "<語句>" as known」が表示される', async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: { "msg-1": { status: "done", terms: [{ term: "gg", meaning: "お疲れ" }] } },
+    });
+
+    render(<ChannelPage />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Mark "gg" as known' }));
+
+    expect(screen.getByRole("status", { name: "Pick up updates" })).toHaveTextContent('Marked "gg" as known');
+  });
+
+  it("最後の語句を「知っている」で消すと、行コンテナへフォーカスが移る(削除ボタンと同じフォーカス退避)", async () => {
+    const user = userEvent.setup();
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    usePickupStore.setState({
+      entries: { "msg-1": { status: "done", terms: [{ term: "gg", meaning: "お疲れ" }] } },
+    });
+
+    render(<ChannelPage />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    const row = within(pickupColumn).getByRole("listitem");
+    await user.click(within(pickupColumn).getByRole("button", { name: 'Mark "gg" as known' }));
+
+    expect(row).toHaveFocus();
+  });
+
+  it("手動Pick upの行には「知っている」ボタンを出さない(調べた語句は「知っている」と矛盾するため)", () => {
+    useChatConnectionStore.setState({ messages: [サンプル発言] });
+    useManualPickupStore.setState({
+      entries: { "msg-1": [{ status: "done", term: "no re", meaning: "リマッチは無しという挨拶" }] },
+    });
+
+    render(<ChannelPage />);
+
+    const pickupColumn = screen.getByRole("region", { name: "Pick up" });
+    expect(within(pickupColumn).getByRole("button", { name: 'Remove "no re"' })).toBeInTheDocument();
+    expect(within(pickupColumn).queryByRole("button", { name: 'Mark "no re" as known' })).not.toBeInTheDocument();
   });
 });
 

--- a/src/app/[channel]/page.tsx
+++ b/src/app/[channel]/page.tsx
@@ -48,7 +48,7 @@
 
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { ChevronsDownIcon, EyeIcon, EyeOffIcon, XIcon } from "lucide-react";
+import { CheckIcon, ChevronsDownIcon, EyeIcon, EyeOffIcon, XIcon } from "lucide-react";
 import { BotFilterDialog } from "@/components/bot-filter-dialog";
 import { ManualPickupOverlay, MESSAGE_TEXT_ATTRIBUTE, RAW_IRC_COLUMN_NAME } from "@/components/manual-pickup";
 import { StreamInfoPanel } from "@/components/stream-info-panel";
@@ -65,7 +65,8 @@ import { hydrateBotFilterStore } from "@/store/bot-filter";
 import { isConnectingOrConnected, useChatConnectionStore } from "@/store/chat-connection";
 import type { PipelineEntry } from "@/store/auto-pipeline";
 import { hidePickupTerm, isPickupTermHidden, useHiddenPickupStore } from "@/store/hidden-pickups";
-import { announcePickupRemoval, usePickupAnnouncementStore } from "@/store/pickup-announcements";
+import { announcePickupKnown, announcePickupRemoval, usePickupAnnouncementStore } from "@/store/pickup-announcements";
+import { markPickupTermKnown } from "@/store/pickup-encounters";
 import { addManualPickup, removeManualPickup, useManualPickupStore } from "@/store/manual-pickups";
 import { startPickupPipeline, usePickupStore, warmUpPickupPipeline, type PickupDone } from "@/store/pickups";
 import { usePromptApiStore, type PromptApiStatus } from "@/store/prompt-api";
@@ -519,7 +520,17 @@ const PickupTerms = memo(function PickupTerms({
   return (
     <dl className="flex flex-col gap-0.5">
       {visibleTerms.map((term) => (
-        <PickupTermRow key={term.term} term={term.term} onRemove={() => hidePickupTerm(messageId, term.term)}>
+        <PickupTermRow
+          key={term.term}
+          term={term.term}
+          onRemove={() => hidePickupTerm(messageId, term.term)}
+          // 「知っている」(issue #110): ユーザー辞書に記録して以後の自動Pick upを再表示間隔のあいだ抑制し、
+          // 押した行は削除ボタンと同じ非表示集合で消す(パイプライン再起動による再生成でも復活しない)
+          onMarkKnown={() => {
+            markPickupTermKnown(term.term);
+            hidePickupTerm(messageId, term.term);
+          }}
+        >
           <dd className="text-muted-foreground">{term.meaning}</dd>
         </PickupTermRow>
       ))}
@@ -527,35 +538,55 @@ const PickupTerms = memo(function PickupTerms({
   );
 });
 
+/** Pick up列の行内アクションボタン(✓・×)で共通の、hover時にだけ表示するスタイル */
+const PICKUP_ACTION_BUTTON_CLASS =
+  "ml-1 align-middle opacity-0 group-hover/term:opacity-100 focus:opacity-100 pointer-coarse:opacity-100";
+
 /**
- * Pick up列の語句1件の行(語句 + hover時の削除ボタン + 意味などの内容)。
- * 自動抽出分(PickupTerms)と手動Pick up分(ManualPickupTerms)で見た目・削除ボタンの挙動を揃えるための共通部品。
- * 削除ボタンは hover 時(またはフォーカス時)に表示し、hover が無いタッチ端末では常に表示する(issue #71 と同じ)。
- * `children` には意味(dd)や生成状態の表示を渡す。
+ * Pick up列の語句1件の行(語句 + hover時のアクションボタン + 意味などの内容)。
+ * 自動抽出分(PickupTerms)と手動Pick up分(ManualPickupTerms)で見た目・ボタンの挙動を揃えるための共通部品。
+ * ボタンは hover 時(またはフォーカス時)に表示し、hover が無いタッチ端末では常に表示する(issue #71 と同じ)。
+ * `onMarkKnown` を渡すと「知っている」ボタン(✓。issue #110)を削除ボタンの前に表示する
+ * (手動Pick upは「調べた=知らない」操作のため渡さない)。`children` には意味(dd)や生成状態の表示を渡す。
  */
 function PickupTermRow({
   term,
   onRemove,
+  onMarkKnown,
   children,
 }: {
   term: string;
   /** 削除ボタンが押されたときの処理(自動分は非表示集合へ追加、手動分はストアから削除) */
   onRemove: () => void;
+  /** 「知っている」ボタンが押されたときの処理(自動分のみ。ユーザー辞書への記録 + 非表示集合へ追加) */
+  onMarkKnown?: () => void;
   children: React.ReactNode;
 }) {
   return (
     <div className="group/term flex flex-wrap items-baseline gap-x-2">
       {/* 「チャットから拾い上げた語彙」が目に留まるよう、語句をゴールド + 破線下線で強調する(issue #87)。
-          破線下線は inline-flex の削除ボタンには波及しない */}
+          破線下線は inline-flex のアクションボタンには波及しない */}
       <dt className="font-semibold text-pickup underline decoration-dashed decoration-pickup/50 underline-offset-4">
         {term}
+        {onMarkKnown !== undefined && (
+          <Button
+            variant="ghost"
+            size="icon-xs"
+            aria-label={`Mark "${term}" as known`}
+            data-pickup-action="known"
+            className={PICKUP_ACTION_BUTTON_CLASS}
+            onClick={(event) => handlePickupActionClick(event, onMarkKnown, () => announcePickupKnown(term))}
+          >
+            <CheckIcon />
+          </Button>
+        )}
         <Button
           variant="ghost"
           size="icon-xs"
           aria-label={`Remove "${term}"`}
-          data-pickup-remove
-          className="ml-1 align-middle opacity-0 group-hover/term:opacity-100 focus:opacity-100 pointer-coarse:opacity-100"
-          onClick={(event) => handleRemoveClick(event, term, onRemove)}
+          data-pickup-action="remove"
+          className={PICKUP_ACTION_BUTTON_CLASS}
+          onClick={(event) => handlePickupActionClick(event, onRemove, () => announcePickupRemoval(term))}
         >
           <XIcon />
         </Button>
@@ -566,21 +597,28 @@ function PickupTermRow({
 }
 
 /**
- * Pick up列の削除ボタンが押されたときの共通処理(issue #73)。
- * 押されたボタン自身は unmount されてフォーカスが body に落ちるため、削除前に同じ発言の行
- * (`role="listitem"`)内の削除ボタン一覧から次(無ければ前)のボタンを探し、削除後にそこへ
+ * Pick up列のアクションボタン(削除・「知っている」)が押されたときの共通処理(issue #73 / #110)。
+ * 押された行のボタンは unmount されてフォーカスが body に落ちるため、実行前に同じ発言の行
+ * (`role="listitem"`)内のアクションボタン一覧から次(無ければ前)のボタンを探し、実行後にそこへ
  * フォーカスを移す。どちらも無ければ行コンテナ(tabIndex={-1})へ退避し、Tab 移動が
- * ページ先頭からやり直しになるのを防ぐ。あわせてスクリーンリーダーへ削除を通知する。
- * 移動先のボタン・行コンテナの DOM ノードは削除後も同一のまま残るため、削除前に取得した
- * 参照へそのままフォーカスしてよい。
+ * ページ先頭からやり直しになるのを防ぐ。あわせて `announce` でスクリーンリーダーへ通知する。
+ * 移動先のボタン・行コンテナの DOM ノードは実行後も同一のまま残るため、実行前に取得した
+ * 参照へそのままフォーカスしてよい。押した語句の✓と×は一緒に消えるため、移動先の候補は
+ * 同じ種類(data-pickup-action の値が同じ)のボタンに絞る(語句1件につき各種類1個なので、
+ * 隣は必ず別の語句の同種ボタンになる)。
  */
-function handleRemoveClick(event: React.MouseEvent<HTMLButtonElement>, term: string, onRemove: () => void): void {
+function handlePickupActionClick(
+  event: React.MouseEvent<HTMLButtonElement>,
+  action: () => void,
+  announce: () => void,
+): void {
   const row = event.currentTarget.closest<HTMLElement>('[role="listitem"]');
-  const buttons = row === null ? [] : Array.from(row.querySelectorAll<HTMLElement>("[data-pickup-remove]"));
+  const kind = event.currentTarget.getAttribute("data-pickup-action") ?? "";
+  const buttons = row === null ? [] : Array.from(row.querySelectorAll<HTMLElement>(`[data-pickup-action="${kind}"]`));
   const index = buttons.indexOf(event.currentTarget);
   const focusTarget = buttons[index + 1] ?? buttons[index - 1] ?? row;
-  onRemove();
-  announcePickupRemoval(term);
+  action();
+  announce();
   focusTarget?.focus();
 }
 

--- a/src/store/manual-pickups.test.ts
+++ b/src/store/manual-pickups.test.ts
@@ -385,6 +385,24 @@ describe("意味を確認した回数の記録(issue #110)", () => {
     expect(records[0].knownCount).toBe(0);
   });
 
+  it("生成完了前に削除・クリアされた場合は記録しない(ユーザーは意味を見ていないため。CodeRabbit レビュー指摘)", async () => {
+    let resolveMeaning!: (meaning: string) => void;
+    const deps = createDeps({
+      generateMeaning: () =>
+        new Promise<string>((resolve) => {
+          resolveMeaning = resolve;
+        }),
+    });
+    const promise = addManualPickup("msg-1", "no re", "gg no re chat", deps);
+
+    // 生成中にチャンネル切替などでクリアされ、その後に結果が遅れて届く
+    clearManualPickups();
+    resolveMeaning("遅れて届いた意味");
+    await promise;
+
+    expect(window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY)).toBeNull();
+  });
+
   it("意味の生成に失敗した場合は記録しない(意味を確認できていないため)", async () => {
     const deps = createDeps({
       generateMeaning: vi.fn(async () => {

--- a/src/store/manual-pickups.test.ts
+++ b/src/store/manual-pickups.test.ts
@@ -16,6 +16,7 @@ import {
   useManualPickupStore,
   type ManualPickupDeps,
 } from "./manual-pickups";
+import { PICKUP_ENCOUNTER_STORAGE_KEY, resetPickupEncountersForTests } from "./pickup-encounters";
 import { flush } from "./pipeline-test-fixtures";
 import { resetPromptApiStoreForTests, usePromptApiStore } from "./prompt-api";
 import { resetSettingsStoreForTests, useSettingsStore } from "./settings";
@@ -57,6 +58,9 @@ function createDeps(overrides: Partial<ManualPickupDeps> = {}): ManualPickupDeps
 
 afterEach(() => {
   resetManualPickupStoreForTests();
+  // 意味確認回数の記録(issue #110)はテストをまたいで持ち越さない
+  window.localStorage.clear();
+  resetPickupEncountersForTests();
 });
 
 describe("manual-pickups ストア", () => {
@@ -360,5 +364,36 @@ describe("getDefineTermPool: プール差し替え時の破棄(issue #75)", () =
     await flush();
 
     expect(defineTermMockState.createdBaseSessions[0].destroyCount).toBe(1);
+  });
+});
+
+describe("意味を確認した回数の記録(issue #110)", () => {
+  it("意味の生成が完了(done)したら、表現キーの meaningCheckedCount に記録する", async () => {
+    const deps = createDeps();
+
+    await addManualPickup("msg-1", "hold my beer", "hold my beer, watch this", deps);
+
+    const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    const stored = JSON.parse(raw as string) as {
+      entries: Record<string, { meaningCheckedCount: number; knownCount: number }>;
+    };
+    const records = Object.values(stored.entries);
+    expect(records).toHaveLength(1);
+    expect(records[0].meaningCheckedCount).toBe(1);
+    // 意味を調べた操作は「知っている」の記録ではない
+    expect(records[0].knownCount).toBe(0);
+  });
+
+  it("意味の生成に失敗した場合は記録しない(意味を確認できていないため)", async () => {
+    const deps = createDeps({
+      generateMeaning: vi.fn(async () => {
+        throw new Error("モデルがクラッシュしました");
+      }),
+    });
+
+    await addManualPickup("msg-1", "hold my beer", "hold my beer, watch this", deps);
+
+    expect(window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY)).toBeNull();
   });
 });

--- a/src/store/manual-pickups.ts
+++ b/src/store/manual-pickups.ts
@@ -190,9 +190,13 @@ export async function addManualPickup(
   try {
     const meaning = await deps.generateMeaning(trimmed, messageText, controller.signal);
     replaceEntry(messageId, trimmed, { status: "done", term: trimmed, meaning });
-    // 意味の生成が完了した = ユーザーが意味を確認した、としてユーザー辞書に記録する(issue #110)。
-    // 失敗・中断時は意味を確認できていないため記録しない
-    recordPickupMeaningChecked(trimmed);
+    // 意味が画面に表示された = ユーザーが意味を確認した、としてユーザー辞書に記録する(issue #110)。
+    // 生成完了前に削除・クリアされていた場合は replaceEntry のガードで結果が捨てられ表示されないため、
+    // done として実際に反映されたことを確かめてから記録する(失敗・中断時も記録しない)
+    const reflected = useManualPickupStore
+      .getState()
+      .entries[messageId]?.some((entry) => entry.term === trimmed && entry.status === "done");
+    if (reflected === true) recordPickupMeaningChecked(trimmed);
   } catch (error) {
     // 削除・クリアによる中断はエントリ自体が消えているため、replaceEntry のガードで何も反映されない。
     // プール差し替え(設定変更・配信情報の更新)で破棄されたジョブは、内部文言ではなく

--- a/src/store/manual-pickups.ts
+++ b/src/store/manual-pickups.ts
@@ -19,6 +19,7 @@ import { createDefineTermBaseSessionFactory, defineTerm } from "@/lib/ai/define-
 import { createSessionPool, SessionPoolDisposedError, type SessionPool } from "@/lib/ai/session-pool";
 import { sharedPromptJobQueue } from "./auto-pipeline";
 import { normalizePickupTerm } from "./hidden-pickups";
+import { recordPickupMeaningChecked } from "./pickup-encounters";
 import { usePromptApiStore, type PromptApiStatus } from "./prompt-api";
 import { useSettingsStore } from "./settings";
 import { streamInfoPromptKey } from "@/lib/twitch/stream-info";
@@ -189,6 +190,9 @@ export async function addManualPickup(
   try {
     const meaning = await deps.generateMeaning(trimmed, messageText, controller.signal);
     replaceEntry(messageId, trimmed, { status: "done", term: trimmed, meaning });
+    // 意味の生成が完了した = ユーザーが意味を確認した、としてユーザー辞書に記録する(issue #110)。
+    // 失敗・中断時は意味を確認できていないため記録しない
+    recordPickupMeaningChecked(trimmed);
   } catch (error) {
     // 削除・クリアによる中断はエントリ自体が消えているため、replaceEntry のガードで何も反映されない。
     // プール差し替え(設定変更・配信情報の更新)で破棄されたジョブは、内部文言ではなく

--- a/src/store/pickup-announcements.test.ts
+++ b/src/store/pickup-announcements.test.ts
@@ -7,6 +7,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  announcePickupKnown,
   announcePickupRemoval,
   resetPickupAnnouncementStoreForTests,
   usePickupAnnouncementStore,
@@ -40,5 +41,13 @@ describe("announcePickupRemoval", () => {
     resetPickupAnnouncementStoreForTests();
     expect(usePickupAnnouncementStore.getState().message).toBe("");
     expect(usePickupAnnouncementStore.getState().seq).toBe(0);
+  });
+});
+
+describe("announcePickupKnown", () => {
+  it('通知すると「Marked "<語句>" as known」のメッセージと通知番号の増加が反映される(issue #110)', () => {
+    announcePickupKnown("gg");
+    expect(usePickupAnnouncementStore.getState().message).toBe('Marked "gg" as known');
+    expect(usePickupAnnouncementStore.getState().seq).toBe(1);
   });
 });

--- a/src/store/pickup-announcements.ts
+++ b/src/store/pickup-announcements.ts
@@ -26,6 +26,11 @@ export function announcePickupRemoval(term: string): void {
   usePickupAnnouncementStore.setState((state) => ({ message: `Removed "${term}"`, seq: state.seq + 1 }));
 }
 
+/** 語句への「知っている」マーク(issue #110)をスクリーンリーダーへ通知する。✓ボタンから呼ぶ */
+export function announcePickupKnown(term: string): void {
+  usePickupAnnouncementStore.setState((state) => ({ message: `Marked "${term}" as known`, seq: state.seq + 1 }));
+}
+
 /** テスト専用: ストアを初期状態に戻す。各テストの afterEach で呼び出すこと */
 export function resetPickupAnnouncementStoreForTests(): void {
   usePickupAnnouncementStore.setState({ message: "", seq: 0 });

--- a/src/store/pickup-encounters.test.ts
+++ b/src/store/pickup-encounters.test.ts
@@ -15,10 +15,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTermExpressionKey } from "@/lib/ai/pickup-ordinary-filter";
 import type { PickupTerm } from "@/lib/ai/schemas";
 import {
+  KNOWN_REDISPLAY_BASE_MS,
+  KNOWN_REDISPLAY_MAX_MS,
   MAX_PICKUP_ENCOUNTER_ENTRIES,
   MAX_SHOWN_MESSAGE_IDS_PER_ENTRY,
   PICKUP_ENCOUNTER_COOLDOWN_MS,
   PICKUP_ENCOUNTER_STORAGE_KEY,
+  markPickupTermKnown,
+  recordPickupMeaningChecked,
   resetPickupEncountersForTests,
   suppressRecentPickupTerms,
 } from "./pickup-encounters";
@@ -33,12 +37,29 @@ function surviving(termTexts: string[], messageId: string): string[] {
   return suppressRecentPickupTerms(terms(...termTexts), messageId).map((item) => item.term);
 }
 
+/** 保存されている遭遇記録1件ぶんの形(version 2) */
+interface StoredRecord {
+  count: number;
+  lastShownAt: number;
+  shownMessageIds: string[];
+  knownCount: number;
+  lastKnownAt: number | null;
+  meaningCheckedCount: number;
+}
+
 /** localStorage に保存された遭遇記録を読み出すヘルパー */
-function storedEntries(): Record<string, { count: number; lastShownAt: number; shownMessageIds: string[] }> {
+function storedEntries(): Record<string, StoredRecord> {
   const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
   if (raw === null) throw new Error("遭遇記録が localStorage に保存されていません");
-  return (JSON.parse(raw) as { entries: Record<string, { count: number; lastShownAt: number; shownMessageIds: string[] }> })
-    .entries;
+  return (JSON.parse(raw) as { entries: Record<string, StoredRecord> }).entries;
+}
+
+/** 保存された遭遇記録から、唯一のエントリを取り出すヘルパー(エントリが1件の前提で使う) */
+function soleStoredRecord(): StoredRecord {
+  const entries = storedEntries();
+  const keys = Object.keys(entries);
+  if (keys.length !== 1) throw new Error(`エントリが1件ではありません(${String(keys.length)}件)`);
+  return entries[keys[0]];
 }
 
 beforeEach(() => {
@@ -56,13 +77,13 @@ describe("suppressRecentPickupTerms", () => {
   it("初回遭遇の表現は表示し、遭遇回数1・最終表示日時・表示したメッセージIDを記録する", () => {
     expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
 
-    const entries = storedEntries();
-    const keys = Object.keys(entries);
-    expect(keys).toHaveLength(1);
-    expect(entries[keys[0]]).toEqual({
+    expect(soleStoredRecord()).toEqual({
       count: 1,
       lastShownAt: Date.now(),
       shownMessageIds: ["msg-1"],
+      knownCount: 0,
+      lastKnownAt: null,
+      meaningCheckedCount: 0,
     });
   });
 
@@ -73,8 +94,7 @@ describe("suppressRecentPickupTerms", () => {
     expect(surviving(["even though"], "msg-2")).toEqual([]);
 
     // 抑制時は遭遇回数だけ加算し、最終表示日時・表示したメッセージIDは更新しない(表示していないため)
-    const entries = storedEntries();
-    const record = entries[Object.keys(entries)[0]];
+    const record = soleStoredRecord();
     expect(record.count).toBe(2);
     expect(record.shownMessageIds).toEqual(["msg-1"]);
   });
@@ -85,9 +105,14 @@ describe("suppressRecentPickupTerms", () => {
 
     expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
 
-    const entries = storedEntries();
-    const record = entries[Object.keys(entries)[0]];
-    expect(record).toEqual({ count: 2, lastShownAt: Date.now(), shownMessageIds: ["msg-1", "msg-2"] });
+    expect(soleStoredRecord()).toEqual({
+      count: 2,
+      lastShownAt: Date.now(),
+      shownMessageIds: ["msg-1", "msg-2"],
+      knownCount: 0,
+      lastKnownAt: null,
+      meaningCheckedCount: 0,
+    });
   });
 
   it("表示済みと同じメッセージIDからの再遭遇(パイプライン再起動による再抽出)は抑制せず、記録も変えない", () => {
@@ -98,12 +123,13 @@ describe("suppressRecentPickupTerms", () => {
     // 表示済みの表現が再生成で消えないよう、同じ遭遇の再表示として扱う
     expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
 
-    const entries = storedEntries();
-    const record = entries[Object.keys(entries)[0]];
-    expect(record).toEqual({
+    expect(soleStoredRecord()).toEqual({
       count: 1,
       lastShownAt: Date.now() - 1000,
       shownMessageIds: ["msg-1"],
+      knownCount: 0,
+      lastKnownAt: null,
+      meaningCheckedCount: 0,
     });
   });
 
@@ -180,5 +206,154 @@ describe("suppressRecentPickupTerms", () => {
     expect(Object.keys(entries)).toHaveLength(MAX_PICKUP_ENCOUNTER_ENTRIES);
     expect(entries[buildTermExpressionKey(uniqueTerm(0))]).toBeUndefined();
     expect(entries[buildTermExpressionKey(uniqueTerm(1))]).toBeDefined();
+  });
+});
+
+describe("markPickupTermKnown(「知っている」マーク。issue #110)", () => {
+  it("マークすると knownCount と lastKnownAt を記録する(遭遇記録の他のフィールドは変えない)", () => {
+    surviving(["even though"], "msg-1");
+    vi.advanceTimersByTime(1000);
+
+    markPickupTermKnown("even though");
+
+    expect(soleStoredRecord()).toEqual({
+      count: 1,
+      lastShownAt: Date.now() - 1000,
+      shownMessageIds: ["msg-1"],
+      knownCount: 1,
+      lastKnownAt: Date.now(),
+      meaningCheckedCount: 0,
+    });
+  });
+
+  it("マーク済みの表現は、クールダウンを過ぎていても再表示間隔(1回目は7日)内なら抑制し、遭遇回数だけ加算する", () => {
+    surviving(["even though"], "msg-1");
+    markPickupTermKnown("even though");
+    // クールダウン(30分)はとうに過ぎているが、再表示間隔(7日)内
+    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS - 1);
+
+    expect(surviving(["even though"], "msg-2")).toEqual([]);
+    expect(soleStoredRecord().count).toBe(2);
+  });
+
+  it("マークから再表示間隔が経過した表現は再び表示する(忘却チェックの機会)", () => {
+    surviving(["even though"], "msg-1");
+    markPickupTermKnown("even though");
+    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
+
+    expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
+  });
+
+  it("再表示間隔はマーク回数で倍増する(2回目のマーク後は14日)", () => {
+    surviving(["even though"], "msg-1");
+    markPickupTermKnown("even though");
+    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
+    surviving(["even though"], "msg-2");
+    markPickupTermKnown("even though");
+
+    // 2回目のマークから7日(1回目の間隔)では、まだ14日の間隔内のため抑制する
+    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
+    expect(surviving(["even though"], "msg-3")).toEqual([]);
+
+    // 2回目のマークから14日経過で再表示する
+    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
+    expect(surviving(["even though"], "msg-4")).toEqual(["even though"]);
+  });
+
+  it("再表示間隔には上限があり、何度マークしても上限を超えて延びない", () => {
+    surviving(["even though"], "msg-1");
+    // 上限(KNOWN_REDISPLAY_MAX_MS)を大きく超える回数マークする
+    for (let i = 0; i < 20; i += 1) {
+      markPickupTermKnown("even though");
+    }
+    vi.advanceTimersByTime(KNOWN_REDISPLAY_MAX_MS);
+
+    expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
+  });
+
+  it("マーク済みでも、表示済みメッセージIDからの再抽出(パイプライン再起動)は抑制しない(画面の非表示は hidden-pickups が担う)", () => {
+    surviving(["even though"], "msg-1");
+    markPickupTermKnown("even though");
+    vi.advanceTimersByTime(1000);
+
+    expect(surviving(["even though"], "msg-1")).toEqual(["even though"]);
+  });
+
+  it("語形変化した表現(picked up / pick up)へのマークも同一の表現キーに記録する", () => {
+    surviving(["picked up"], "msg-1");
+    markPickupTermKnown("pick up");
+    vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
+
+    // クールダウンは過ぎたが再表示間隔(7日)内のため抑制される
+    expect(surviving(["picked up"], "msg-2")).toEqual([]);
+  });
+
+  it("遭遇記録が無い表現へのマークは、自動表示の記録が空のエントリを作って記録する", () => {
+    markPickupTermKnown("even though");
+
+    expect(soleStoredRecord()).toEqual({
+      count: 0,
+      lastShownAt: 0,
+      shownMessageIds: [],
+      knownCount: 1,
+      lastKnownAt: Date.now(),
+      meaningCheckedCount: 0,
+    });
+  });
+});
+
+describe("recordPickupMeaningChecked(意味を確認した回数の記録。issue #110)", () => {
+  it("記録すると meaningCheckedCount を加算する(抑制の挙動には影響しない)", () => {
+    surviving(["even though"], "msg-1");
+
+    recordPickupMeaningChecked("even though");
+    recordPickupMeaningChecked("even though");
+
+    const record = soleStoredRecord();
+    expect(record.meaningCheckedCount).toBe(2);
+    expect(record.count).toBe(1);
+    expect(record.lastKnownAt).toBeNull();
+  });
+
+  it("遭遇記録が無い表現(手動Pick upだけの表現)にも、自動表示の記録が空のエントリを作って記録する", () => {
+    recordPickupMeaningChecked("hold my beer");
+
+    expect(soleStoredRecord()).toEqual({
+      count: 0,
+      lastShownAt: 0,
+      shownMessageIds: [],
+      knownCount: 0,
+      lastKnownAt: null,
+      meaningCheckedCount: 1,
+    });
+  });
+});
+
+describe("保存形式の移行(version 1 → 2)", () => {
+  it("version 1 の保存データは既存の遭遇記録を保持したまま新フィールドの既定値を補って読み込む", () => {
+    // Phase 1(PR #109)が保存した version 1 形式
+    window.localStorage.setItem(
+      PICKUP_ENCOUNTER_STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        entries: { "even though": { count: 3, lastShownAt: Date.now() - 1000, shownMessageIds: ["msg-old"] } },
+      }),
+    );
+
+    // クールダウン内のため v1 の記録に基づいて抑制される(記録が引き継がれている証拠)
+    expect(surviving(["even though"], "msg-new")).toEqual([]);
+
+    // 書き戻しは version 2 形式で、新フィールドは既定値が補われている
+    const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect((JSON.parse(raw as string) as { version: number }).version).toBe(2);
+    expect(storedEntries()["even though"]).toEqual({
+      count: 4,
+      lastShownAt: Date.now() - 1000,
+      shownMessageIds: ["msg-old"],
+      knownCount: 0,
+      lastKnownAt: null,
+      meaningCheckedCount: 0,
+    });
   });
 });

--- a/src/store/pickup-encounters.ts
+++ b/src/store/pickup-encounters.ts
@@ -1,20 +1,25 @@
 /**
- * Pick up の既出管理(issue #108。ユーザー辞書構想 #107 の Phase 1)。
+ * Pick up の既出管理と習熟状態(issue #108 / #110。ユーザー辞書構想 #107 の Phase 1・2)。
  *
  * 自動Pick upは同じ定型表現("even though" など)がチャットに流れるたびに毎回抽出・表示するため、
- * 表現キーごとの遭遇記録を持ち、最終表示からクールダウン期間内の再表示を決定的に抑制する。
+ * 表現キーごとの遭遇記録・習熟状態を持ち、再表示を決定的に抑制する。
  *
  * - キー: `lib/ai/pickup-ordinary-filter.ts` の `buildTermExpressionKey`(`stemForMatch` による
  *   レンマ正規化キー)。語形変化("picked up" / "pick up")を同一表現として扱う
- * - 抑制規則: 最終表示からクールダウン内の再遭遇は表示しない(遭遇回数だけ加算する)。
- *   ただし表示済みのメッセージID(上限付きで保持)からの再遭遇は「パイプライン再起動による
- *   同じ発言の再抽出」(`hidden-pickups.ts` に記載の再生成問題)なので、同じ遭遇の再表示として
- *   抑制せず記録も変えない
- * - 適用範囲: 自動Pick up(`pickups.ts`)の順方向・逆方向のみ。手動Pick up(`manual-pickups.ts`)は
- *   ユーザーが明示的に選択した操作のため対象外。翻訳列にも影響しない
+ * - 抑制規則(判定順):
+ *   1. 表示済みのメッセージID(上限付きで保持)からの再遭遇は「パイプライン再起動による同じ発言の
+ *      再抽出」(`hidden-pickups.ts` に記載の再生成問題)なので、同じ遭遇の再表示として抑制せず記録も変えない
+ *   2. 「知っている」マーク済みの表現は、最終マークから再表示間隔(マーク回数で倍増、上限あり)内は
+ *      表示しない(遭遇回数だけ加算する)。恒久非表示にはせず、間隔が明けたら忘却チェックの機会として
+ *      再表示する。この倍増規則は Phase 3 で FSRS / SM-2 による復習期日計算に置き換える前提の暫定規則
+ *   3. 最終表示からクールダウン内の再遭遇は表示しない(遭遇回数だけ加算する)
+ * - 習熟状態の記録(issue #110): 「知っている」マーク(`markPickupTermKnown`。UIの✓ボタンから呼ぶ)と、
+ *   意味を確認した回数(`recordPickupMeaningChecked`。手動Pick upの意味生成完了時に呼ぶ)
+ * - 適用範囲: 抑制は自動Pick up(`pickups.ts`)の順方向・逆方向のみ。手動Pick up(`manual-pickups.ts`)は
+ *   ユーザーが明示的に選択した操作のため抑制対象外(記録のみ行う)。翻訳列にも影響しない
  * - 永続化: localStorage(`lib/settings.ts` と同じパターン)。学習状態はユーザーに属するため
- *   チャンネルをまたいで共有する。Phase 2(習熟状態)・Phase 3(SRS)でのスキーマ拡張に備えて
- *   保存形式にバージョンを持たせる。保存データが壊れている場合は空の記録から再開する
+ *   チャンネルをまたいで共有する。保存形式はバージョンを持ち、version 1(Phase 1)のデータは
+ *   既定値を補って明示的に移行する。保存データが壊れている場合は空の記録から再開する
  *   (抑制が一時的に働かなくなるだけで表示機能は損なわれず、壊れた学習記録の復元は不可能なため)
  * - この層は完全に決定的(LLM 非依存)
  */
@@ -44,32 +49,74 @@ export const MAX_PICKUP_ENCOUNTER_ENTRIES = 2000;
  */
 export const MAX_SHOWN_MESSAGE_IDS_PER_ENTRY = 10;
 
-/** 表現キー1件ぶんの遭遇記録 */
+/**
+ * 「知っている」マーク後の再表示間隔の基準値(1回目のマーク後は7日)。マーク回数ごとに倍増する
+ * (7日 → 14日 → 28日…)。恒久非表示にすると忘却に気付けないため、間隔反復学習的に間隔を空けて
+ * 再表示する(issue #110。Phase 3 で FSRS / SM-2 による復習期日計算に置き換える前提の暫定規則)
+ */
+export const KNOWN_REDISPLAY_BASE_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * 「知っている」マーク後の再表示間隔の上限(56日 = 基準値の8倍)。何度マークしても
+ * これ以上は延びない。Phase 3 の復習期日計算の導入までの暫定的な安全弁
+ */
+export const KNOWN_REDISPLAY_MAX_MS = 56 * 24 * 60 * 60 * 1000;
+
+/** 表現キー1件ぶんの遭遇記録・習熟状態(version 2) */
 const encounterRecordSchema = z.object({
-  /** 遭遇回数(抑制した遭遇も含む)。Phase 2 以降で習熟度の入力に使う */
+  /** 遭遇回数(抑制した遭遇も含む)。Phase 3(SRS)で習熟度の入力に使う */
   count: z.number(),
-  /** 最終表示日時(エポックミリ秒)。抑制した遭遇では更新しない */
+  /** 最終表示日時(エポックミリ秒)。抑制した遭遇では更新しない。自動表示の記録が無い場合は 0 */
   lastShownAt: z.number(),
   /**
    * 表示したメッセージID(古い順、`MAX_SHOWN_MESSAGE_IDS_PER_ENTRY` 件まで)。
    * パイプライン再起動による同じ発言の再抽出を抑制対象から外すために持つ
    */
   shownMessageIds: z.array(z.string()),
+  /** 「知っている」マークを押した回数(issue #110)。再表示間隔の倍増と Phase 3 の入力に使う */
+  knownCount: z.number(),
+  /** 最後に「知っている」マークを押した日時(エポックミリ秒)。未マークは null */
+  lastKnownAt: z.number().nullable(),
+  /** 意味を確認した(手動Pick upで意味を調べた)回数(issue #110)。Phase 3 の入力に使う */
+  meaningCheckedCount: z.number(),
 });
 
-/** 保存形式。Phase 2(習熟状態)・Phase 3(SRS)での拡張に備えて version を持つ */
+/** 現行の保存形式(version 2)。Phase 3(SRS)での拡張に備えて version を持つ */
 const storedEncountersSchema = z.object({
-  version: z.literal(1),
+  version: z.literal(2),
   entries: z.record(z.string(), encounterRecordSchema),
 });
 
+/** Phase 1(PR #109)が保存していた旧形式(version 1)。読み込み時に既定値を補って移行する */
+const storedEncountersV1Schema = z.object({
+  version: z.literal(1),
+  entries: z.record(
+    z.string(),
+    z.object({ count: z.number(), lastShownAt: z.number(), shownMessageIds: z.array(z.string()) }),
+  ),
+});
+
 type EncounterRecord = z.infer<typeof encounterRecordSchema>;
+
+/** version 1 の記録に Phase 2 で追加したフィールドの既定値。移行と新規エントリの作成で共通に使う */
+const RECORD_V2_DEFAULTS = { knownCount: 0, lastKnownAt: null, meaningCheckedCount: 0 } as const;
 
 /**
  * メモリ上の遭遇記録。初回利用時に localStorage から復元し(`ensureLoaded`)、以後は
  * このマップを正本として更新のたびに書き戻す。null は未復元を表す
  */
 let encounters: Map<string, EncounterRecord> | null = null;
+
+/**
+ * 保存データ(JSON パース済み)を現行形式の記録へ変換する。version 1 の記録は Phase 2 で
+ * 追加したフィールドの既定値を補って明示的に移行する。どの形式にも合わなければ例外を投げる
+ */
+function parseStoredEncounters(raw: unknown): Map<string, EncounterRecord> {
+  const current = storedEncountersSchema.safeParse(raw);
+  if (current.success) return new Map(Object.entries(current.data.entries));
+  const v1 = storedEncountersV1Schema.parse(raw);
+  return new Map(Object.entries(v1.entries).map(([key, record]) => [key, { ...record, ...RECORD_V2_DEFAULTS }]));
+}
 
 /** localStorage から遭遇記録を復元する。無い場合・壊れている場合は空の記録から再開する */
 function ensureLoaded(): Map<string, EncounterRecord> {
@@ -78,8 +125,7 @@ function ensureLoaded(): Map<string, EncounterRecord> {
   const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
   if (raw === null) return encounters;
   try {
-    const stored = storedEncountersSchema.parse(JSON.parse(raw));
-    encounters = new Map(Object.entries(stored.entries));
+    encounters = parseStoredEncounters(JSON.parse(raw));
   } catch {
     // 壊れた記録は復元できず、失っても抑制が一時的に働かなくなるだけのため空から再開する(冒頭コメント参照)
   }
@@ -96,8 +142,29 @@ function persist(loaded: Map<string, EncounterRecord>): void {
   }
   window.localStorage.setItem(
     PICKUP_ENCOUNTER_STORAGE_KEY,
-    JSON.stringify({ version: 1, entries: Object.fromEntries(loaded) }),
+    JSON.stringify({ version: 2, entries: Object.fromEntries(loaded) }),
   );
+}
+
+/**
+ * 「知っている」マークからの再表示間隔。マーク回数ごとに基準値(7日)を倍増し、上限で頭打ちにする。
+ * `knownCount` が 0(未マーク)の場合は呼ばない前提(呼び出し側で lastKnownAt の null を先に判定する)
+ */
+function knownRedisplayIntervalMs(knownCount: number): number {
+  return Math.min(KNOWN_REDISPLAY_BASE_MS * 2 ** (knownCount - 1), KNOWN_REDISPLAY_MAX_MS);
+}
+
+/**
+ * 表現キーの記録を取得し、無ければ「自動表示の記録が空」のエントリを作って返す。
+ * `markPickupTermKnown` / `recordPickupMeaningChecked` は表示済み・手動選択済みの語句から呼ばれるため
+ * 通常は記録が存在するが、上限整理(`persist`)で削除された直後などに欠けていても失敗させない
+ */
+function ensureRecord(loaded: Map<string, EncounterRecord>, key: string): EncounterRecord {
+  const existing = loaded.get(key);
+  if (existing !== undefined) return existing;
+  const created: EncounterRecord = { count: 0, lastShownAt: 0, shownMessageIds: [], ...RECORD_V2_DEFAULTS };
+  loaded.set(key, created);
+  return created;
 }
 
 /**
@@ -117,17 +184,23 @@ export function suppressRecentPickupTerms(terms: PickupTerm[], messageId: string
     const record = loaded.get(key);
     if (record === undefined) {
       // 初回遭遇: 表示して記録を作る
-      loaded.set(key, { count: 1, lastShownAt: now, shownMessageIds: [messageId] });
+      loaded.set(key, { count: 1, lastShownAt: now, shownMessageIds: [messageId], ...RECORD_V2_DEFAULTS });
       shown.push(item);
     } else if (record.shownMessageIds.includes(messageId)) {
-      // 表示済みの発言からの再抽出(パイプライン再起動): 同じ遭遇の再表示として扱い、記録は変えない
+      // 表示済みの発言からの再抽出(パイプライン再起動): 同じ遭遇の再表示として扱い、記録は変えない。
+      // マーク済みの表現でも同様に返す(押した行の画面上の非表示は hidden-pickups が担う)
       shown.push(item);
-    } else if (now - record.lastShownAt < PICKUP_ENCOUNTER_COOLDOWN_MS) {
-      // クールダウン内の再遭遇: 抑制する。遭遇回数だけ加算し、最終表示日時・表示したメッセージIDは表示していないので変えない
+    } else if (
+      (record.lastKnownAt !== null && now - record.lastKnownAt < knownRedisplayIntervalMs(record.knownCount)) ||
+      now - record.lastShownAt < PICKUP_ENCOUNTER_COOLDOWN_MS
+    ) {
+      // 「知っている」マークからの再表示間隔内、またはクールダウン内の再遭遇: 抑制する。
+      // 遭遇回数だけ加算し、最終表示日時・表示したメッセージIDは表示していないので変えない
       loaded.set(key, { ...record, count: record.count + 1 });
     } else {
-      // クールダウン経過後の再遭遇: 再び表示し、表示したメッセージIDを上限付きで追記する
+      // 抑制期間を過ぎた再遭遇: 再び表示し、表示したメッセージIDを上限付きで追記する
       loaded.set(key, {
+        ...record,
         count: record.count + 1,
         lastShownAt: now,
         shownMessageIds: [...record.shownMessageIds, messageId].slice(-MAX_SHOWN_MESSAGE_IDS_PER_ENTRY),
@@ -137,6 +210,38 @@ export function suppressRecentPickupTerms(terms: PickupTerm[], messageId: string
   }
   persist(loaded);
   return shown;
+}
+
+/**
+ * 表現に「知っている」マークを付ける(issue #110)。マーク回数と最終マーク日時を記録し、
+ * 以後の自動Pick upを再表示間隔(マーク回数で倍増、上限あり)のあいだ抑制する。
+ * Pick up列の✓ボタン(`page.tsx`)から呼ぶ。押した行の画面上の非表示は呼び出し側が
+ * `hidden-pickups.ts` で行う(この関数は学習状態の記録と以後の抑制だけを担う)
+ */
+export function markPickupTermKnown(term: string): void {
+  const loaded = ensureLoaded();
+  const record = ensureRecord(loaded, buildTermExpressionKey(term));
+  loaded.set(buildTermExpressionKey(term), {
+    ...record,
+    knownCount: record.knownCount + 1,
+    lastKnownAt: Date.now(),
+  });
+  persist(loaded);
+}
+
+/**
+ * 表現の意味を確認した(手動Pick upで意味を調べた)ことを記録する(issue #110)。
+ * 手動Pick up(`manual-pickups.ts`)の意味生成が完了した時点で呼ぶ。抑制の挙動には影響せず、
+ * Phase 3(SRS)の習熟度計算の入力として回数だけを蓄積する
+ */
+export function recordPickupMeaningChecked(term: string): void {
+  const loaded = ensureLoaded();
+  const record = ensureRecord(loaded, buildTermExpressionKey(term));
+  loaded.set(buildTermExpressionKey(term), {
+    ...record,
+    meaningCheckedCount: record.meaningCheckedCount + 1,
+  });
+  persist(loaded);
 }
 
 /** テスト専用: メモリ上の記録を破棄し、次回利用時に localStorage から復元し直す */


### PR DESCRIPTION
## Summary

表現キーごとの学習状態(習熟状態)を記録し、Phase 3(SRS)の入力となるデータを蓄積します(ユーザー辞書構想 #107 の Phase 2)。

## 変更内容

### 「知っている」マーク

- `src/app/[channel]/page.tsx`: 自動Pick upの語句の行に✓ボタンを追加しました。押すとユーザー辞書に記録し、その行は削除ボタンと同じ非表示集合(`hidden-pickups.ts`)で消します(パイプライン再起動による再生成でも復活しません)
- **恒久非表示にはしません**。忘却に備え、マークから再表示間隔が明けたら忘却チェックの機会として再び表示します。間隔はマーク回数で倍増(7日 → 14日 → 28日 → 56日で上限)する決定的な暫定規則で、Phase 3 で FSRS / SM-2 による復習期日計算に置き換える前提です
- アクセシビリティは削除ボタンと同等です: aria-label(`Mark "<語句>" as known`)、同種ボタンへのフォーカス退避、スクリーンリーダー通知(`Marked "<語句>" as known`)
- 手動Pick upの行には✓ボタンを出しません(「調べた=知らない」操作のため)

### 意味を確認した回数

- `src/store/manual-pickups.ts`: 手動Pick upの意味生成が完了し表示に反映された時点を「意味を確認した」とみなし、表現キーごとに `meaningCheckedCount` を記録します。生成の失敗・中断時、および生成完了前に削除・クリアされた場合は記録しません

### 保存形式(version 2)

- `src/store/pickup-encounters.ts`: 保存形式を version 2 に拡張しました(`knownCount` / `lastKnownAt` / `meaningCheckedCount` を追加)。Phase 1(PR #109)の version 1 データは既存の遭遇記録を保持したまま既定値を補って明示的に移行します
- 抑制の判定順: 表示済みメッセージIDからの再抽出(再起動) → 「知っている」の再表示間隔 → クールダウン(30分)。この層は完全に決定的(LLM 非依存)です

## テスト

- `npm test`: 1010件すべて成功
- `npm run lint` / `npm run type-check` / `npm run build`: エラー・警告なし
- CodeRabbitレビュー実施済み(指摘1件: 生成完了前に削除・クリアされた手動Pick upでも意味確認が記録される → done の反映を確かめてから記録する形に修正済み)

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)