### PR TITLE
feat: Pick upの復習期日計算をFSRSに置き換える(ユーザー辞書 Phase 3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "shadcn": "^4.14.1",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.6.0",
+        "ts-fsrs": "^5.4.2",
         "tw-animate-css": "^1.4.0",
         "zod": "^4.4.3",
         "zustand": "^5.0.14"
@@ -10628,6 +10629,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-fsrs": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/ts-fsrs/-/ts-fsrs-5.4.2.tgz",
+      "integrity": "sha512-z4qop4pzTcyTzuJ566d9EaX/4bZZzhYfeaPImfVr+xcYT65c5oBgFDijUhCE/D+C78eaolHIhKRZ04/RwF+v2g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ts-morph": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "shadcn": "^4.14.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.6.0",
+    "ts-fsrs": "^5.4.2",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.4.3",
     "zustand": "^5.0.14"

--- a/src/lib/srs.test.ts
+++ b/src/lib/srs.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `srs.ts`(FSRSによる復習期日計算のラッパー。issue #113、ユーザー辞書構想 #107 の Phase 3)のテスト。
+ *
+ * Pick upの既出管理(`store/pickup-encounters.ts`)が使う復習期日計算を検証する。
+ * 検証項目:
+ * - 初回のGood評価でカードを作成し、復習期日が日単位の未来になる(分単位の学習ステップは使わない)
+ * - 評価を重ねるごとに復習間隔が伸びる(間隔反復)
+ * - Again評価(忘却シグナル)はGood評価より復習期日を近くする
+ * - 計算が決定的である(同じ入力から同じ結果が得られる。ファズ無効)
+ * - シリアライズ形式(数値のみ)が保存スキーマ(`srsCardSchema`)を満たす
+ */
+import { describe, expect, it } from "vitest";
+import { Rating, reviewSrsCard, srsCardSchema } from "./srs";
+
+/** テストの基準時刻(2026-09-04T12:00:00Z)。エポックミリ秒で扱う */
+const BASE_NOW = new Date("2026-09-04T12:00:00Z").getTime();
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+describe("reviewSrsCard", () => {
+  it("カードが無い表現への初回Good評価でカードを作成し、復習期日が1日以上先になる(分単位の学習ステップを使わない)", () => {
+    const card = reviewSrsCard(null, Rating.Good, BASE_NOW);
+
+    // ts-fsrs 既定の学習ステップ(1分→10分)を使うと✓マーク直後の抑制が数分になってしまうため、
+    // 学習ステップ無効(長期スケジュールのみ)で構成していることを検証する
+    expect(card.due).toBeGreaterThanOrEqual(BASE_NOW + DAY_MS);
+    // 初回評価の間隔として非常識に長くないことも確認する(暫定倍増規則の初回7日と同じ桁感)
+    expect(card.due).toBeLessThanOrEqual(BASE_NOW + 60 * DAY_MS);
+    expect(card.last_review).toBe(BASE_NOW);
+  });
+
+  it("復習期日が来るたびにGood評価を繰り返すと、復習間隔が単調に伸びる(間隔反復)", () => {
+    const first = reviewSrsCard(null, Rating.Good, BASE_NOW);
+    const firstInterval = first.due - BASE_NOW;
+
+    // 1回目の復習期日ちょうどに再度Good評価する
+    const second = reviewSrsCard(first, Rating.Good, first.due);
+    const secondInterval = second.due - first.due;
+
+    expect(secondInterval).toBeGreaterThan(firstInterval);
+  });
+
+  it("同じカード状態からの評価では、Again評価(忘れた)の復習期日がGood評価より近い", () => {
+    const card = reviewSrsCard(null, Rating.Good, BASE_NOW);
+    const reviewedAt = card.due;
+
+    const again = reviewSrsCard(card, Rating.Again, reviewedAt);
+    const good = reviewSrsCard(card, Rating.Good, reviewedAt);
+
+    expect(again.due).toBeLessThan(good.due);
+    // Againは忘却(lapse)として記録される
+    expect(again.lapses).toBe(card.lapses + 1);
+  });
+
+  it("同じ入力からは常に同じ結果が得られる(ファズ無効・決定的)", () => {
+    const first = reviewSrsCard(null, Rating.Good, BASE_NOW);
+    const second = reviewSrsCard(null, Rating.Good, BASE_NOW);
+
+    expect(second).toEqual(first);
+  });
+
+  it("計算結果は数値のみのシリアライズ形式で、保存スキーマを満たす(JSON経由の往復でも変わらない)", () => {
+    const card = reviewSrsCard(null, Rating.Good, BASE_NOW);
+
+    // localStorage への保存(JSON文字列化)と復元を経ても同じカードとして扱える
+    const restored: unknown = JSON.parse(JSON.stringify(card));
+    expect(srsCardSchema.parse(restored)).toEqual(card);
+
+    // 復元したカードを次回の評価入力として使える
+    const next = reviewSrsCard(srsCardSchema.parse(restored), Rating.Good, card.due);
+    expect(next.due).toBeGreaterThan(card.due);
+  });
+});

--- a/src/lib/srs.ts
+++ b/src/lib/srs.ts
@@ -1,0 +1,82 @@
+/**
+ * FSRS(Free Spaced Repetition Scheduler)による復習期日計算のラッパー(issue #113。
+ * ユーザー辞書構想 #107 の Phase 3)。
+ *
+ * Pick upの既出管理(`store/pickup-encounters.ts`)が表現キーごとに持つ学習状態のうち、
+ * 「知っている」マーク後の再表示間隔の計算を担う。Phase 2 の暫定規則(マーク回数で倍増)を
+ * ts-fsrs によるFSRSアルゴリズムの復習期日計算に置き換える。
+ *
+ * - 学習ステップ(`learning_steps` / `relearning_steps`)は無効にする。ts-fsrs 既定の
+ *   学習ステップ(1分→10分)を使うと初回マーク直後の抑制が数分になってしまうため、
+ *   日単位の長期スケジュールのみ使う
+ * - ファズ(復習期日のランダム化)は既定の無効のまま使い、計算を決定的に保つ
+ * - カードは localStorage に保存するため、日時をエポックミリ秒に変換した
+ *   数値のみのシリアライズ形式(`SrsCard`)で受け渡しする
+ * - この層は完全に決定的(LLM 非依存)
+ */
+import { createEmptyCard, fsrs, generatorParameters, State, type Card, type Grade } from "ts-fsrs";
+import { z } from "zod";
+
+export { Rating } from "ts-fsrs";
+
+/**
+ * FSRSカードのシリアライズ形式(数値のみ)。ts-fsrs の `Card` の日時(`due` / `last_review`)を
+ * エポックミリ秒に変換したもので、`store/pickup-encounters.ts` が localStorage に保存する
+ */
+export const srsCardSchema = z.object({
+  /** 次回復習期日(エポックミリ秒)。この日時より前の再遭遇は抑制する */
+  due: z.number(),
+  /** 記憶の安定度(FSRS内部状態。日数換算の記憶保持期間) */
+  stability: z.number(),
+  /** 表現の難易度(FSRS内部状態。1〜10) */
+  difficulty: z.number(),
+  /** 前回復習からの経過日数(ts-fsrs v6で削除予定の互換フィールド) */
+  elapsed_days: z.number(),
+  /** 前回計算した復習間隔(日数) */
+  scheduled_days: z.number(),
+  /** 学習ステップの現在位置(学習ステップ無効のため常に0) */
+  learning_steps: z.number(),
+  /** 評価(復習)を適用した累計回数 */
+  reps: z.number(),
+  /** 忘却(Again評価)の累計回数 */
+  lapses: z.number(),
+  /** カードの状態(ts-fsrs の `State`: New / Learning / Review / Relearning) */
+  state: z.enum(State),
+  /** 最後に評価を適用した日時(エポックミリ秒)。評価済みカードでは常に設定される */
+  last_review: z.number().nullable(),
+});
+
+export type SrsCard = z.infer<typeof srsCardSchema>;
+
+/** 学習ステップ無効(日単位の長期スケジュールのみ)・ファズ無効(決定的)のスケジューラ */
+const scheduler = fsrs(generatorParameters({ learning_steps: [], relearning_steps: [] }));
+
+/** ts-fsrs の `Card`(日時が `Date`)をシリアライズ形式(数値のみ)に変換する */
+function serializeCard(card: Card): SrsCard {
+  return {
+    due: card.due.getTime(),
+    stability: card.stability,
+    difficulty: card.difficulty,
+    elapsed_days: card.elapsed_days,
+    scheduled_days: card.scheduled_days,
+    learning_steps: card.learning_steps,
+    reps: card.reps,
+    lapses: card.lapses,
+    state: card.state,
+    last_review: card.last_review?.getTime() ?? null,
+  };
+}
+
+/**
+ * カードに評価を適用し、次回復習期日を計算した新しいカードを返す(引数のカードは変更しない)。
+ *
+ * @param card 前回までのカード。null は評価が一度も無い表現を表し、新規カードを作成して評価する
+ * @param rating 評価。「知っている」マークは `Rating.Good`、忘却シグナル(マーク済み表現の
+ *   意味確認)は `Rating.Again` を渡す
+ * @param now 評価日時(エポックミリ秒)
+ * @returns 評価を適用したカード(`due` が次回復習期日)
+ */
+export function reviewSrsCard(card: SrsCard | null, rating: Grade, now: number): SrsCard {
+  const result = scheduler.next(card ?? createEmptyCard(now), now, rating);
+  return serializeCard(result.card);
+}

--- a/src/store/pickup-encounters.test.ts
+++ b/src/store/pickup-encounters.test.ts
@@ -1,5 +1,5 @@
 /**
- * `pickup-encounters.ts`(Pick up の既出管理。issue #108)のテスト。
+ * `pickup-encounters.ts`(Pick up の既出管理。issue #108 / #110 / #113)のテスト。
  *
  * 自動Pick upは同じ定型表現がチャットに流れるたびに毎回表示するため、表現キーごとの
  * 遭遇記録を localStorage に持ち、最終表示からクールダウン期間内の再表示を決定的に抑制する。
@@ -9,14 +9,14 @@
  * - クールダウン経過後の再遭遇は再び表示する
  * - 同一メッセージIDからの再抽出(言語設定変更等によるパイプライン再起動)は抑制しない
  * - 語形変化("picked up" / "pick up")は同一の表現キーとして扱う
- * - localStorage への永続化・破損データの扱い・エントリ数上限の整理
+ * - 「知っている」マーク・意味確認がFSRSカード(issue #113)を更新し、復習期日前の再表示を抑制する
+ * - localStorage への永続化・破損データの扱い・エントリ数上限の整理・旧形式(version 1 / 2)からの移行
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { buildTermExpressionKey } from "@/lib/ai/pickup-ordinary-filter";
 import type { PickupTerm } from "@/lib/ai/schemas";
+import type { SrsCard } from "@/lib/srs";
 import {
-  KNOWN_REDISPLAY_BASE_MS,
-  KNOWN_REDISPLAY_MAX_MS,
   MAX_PICKUP_ENCOUNTER_ENTRIES,
   MAX_SHOWN_MESSAGE_IDS_PER_ENTRY,
   PICKUP_ENCOUNTER_COOLDOWN_MS,
@@ -37,7 +37,7 @@ function surviving(termTexts: string[], messageId: string): string[] {
   return suppressRecentPickupTerms(terms(...termTexts), messageId).map((item) => item.term);
 }
 
-/** 保存されている遭遇記録1件ぶんの形(version 2) */
+/** 保存されている遭遇記録1件ぶんの形(version 3) */
 interface StoredRecord {
   count: number;
   lastShownAt: number;
@@ -45,6 +45,7 @@ interface StoredRecord {
   knownCount: number;
   lastKnownAt: number | null;
   meaningCheckedCount: number;
+  srsCard: SrsCard | null;
 }
 
 /** localStorage に保存された遭遇記録を読み出すヘルパー */
@@ -60,6 +61,13 @@ function soleStoredRecord(): StoredRecord {
   const keys = Object.keys(entries);
   if (keys.length !== 1) throw new Error(`エントリが1件ではありません(${String(keys.length)}件)`);
   return entries[keys[0]];
+}
+
+/** 唯一のエントリのFSRSカードを取り出すヘルパー(カードが記録済みの前提で使う) */
+function soleSrsCard(): SrsCard {
+  const card = soleStoredRecord().srsCard;
+  if (card === null) throw new Error("FSRSカードが記録されていません");
+  return card;
 }
 
 beforeEach(() => {
@@ -84,6 +92,7 @@ describe("suppressRecentPickupTerms", () => {
       knownCount: 0,
       lastKnownAt: null,
       meaningCheckedCount: 0,
+      srsCard: null,
     });
   });
 
@@ -112,6 +121,7 @@ describe("suppressRecentPickupTerms", () => {
       knownCount: 0,
       lastKnownAt: null,
       meaningCheckedCount: 0,
+      srsCard: null,
     });
   });
 
@@ -130,6 +140,7 @@ describe("suppressRecentPickupTerms", () => {
       knownCount: 0,
       lastKnownAt: null,
       meaningCheckedCount: 0,
+      srsCard: null,
     });
   });
 
@@ -209,66 +220,55 @@ describe("suppressRecentPickupTerms", () => {
   });
 });
 
-describe("markPickupTermKnown(「知っている」マーク。issue #110)", () => {
-  it("マークすると knownCount と lastKnownAt を記録する(遭遇記録の他のフィールドは変えない)", () => {
+describe("markPickupTermKnown(「知っている」マーク。issue #110 / #113)", () => {
+  it("マークすると knownCount・lastKnownAt を記録し、Good評価のFSRSカードを作成する(遭遇記録の他のフィールドは変えない)", () => {
     surviving(["even though"], "msg-1");
     vi.advanceTimersByTime(1000);
 
     markPickupTermKnown("even though");
 
-    expect(soleStoredRecord()).toEqual({
-      count: 1,
-      lastShownAt: Date.now() - 1000,
-      shownMessageIds: ["msg-1"],
-      knownCount: 1,
-      lastKnownAt: Date.now(),
-      meaningCheckedCount: 0,
-    });
+    const record = soleStoredRecord();
+    expect(record.count).toBe(1);
+    expect(record.lastShownAt).toBe(Date.now() - 1000);
+    expect(record.shownMessageIds).toEqual(["msg-1"]);
+    expect(record.knownCount).toBe(1);
+    expect(record.lastKnownAt).toBe(Date.now());
+    expect(record.meaningCheckedCount).toBe(0);
+    // FSRSカードが作成され、復習期日はクールダウン(30分)より十分先の日単位になる
+    expect(soleSrsCard().due).toBeGreaterThan(Date.now() + PICKUP_ENCOUNTER_COOLDOWN_MS);
   });
 
-  it("マーク済みの表現は、クールダウンを過ぎていても再表示間隔(1回目は7日)内なら抑制し、遭遇回数だけ加算する", () => {
+  it("マーク済みの表現は、クールダウンを過ぎていても復習期日前なら抑制し、遭遇回数だけ加算する", () => {
     surviving(["even though"], "msg-1");
     markPickupTermKnown("even though");
-    // クールダウン(30分)はとうに過ぎているが、再表示間隔(7日)内
-    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS - 1);
+    // クールダウン(30分)はとうに過ぎているが、復習期日の直前
+    vi.setSystemTime(soleSrsCard().due - 1);
 
     expect(surviving(["even though"], "msg-2")).toEqual([]);
     expect(soleStoredRecord().count).toBe(2);
   });
 
-  it("マークから再表示間隔が経過した表現は再び表示する(忘却チェックの機会)", () => {
+  it("復習期日が来た表現は再び表示する(忘却チェックの機会)", () => {
     surviving(["even though"], "msg-1");
     markPickupTermKnown("even though");
-    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
+    vi.setSystemTime(soleSrsCard().due);
 
     expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
   });
 
-  it("再表示間隔はマーク回数で倍増する(2回目のマーク後は14日)", () => {
+  it("復習期日後に再マークすると、次の復習間隔が前回より伸びる(間隔反復)", () => {
     surviving(["even though"], "msg-1");
+    const firstMarkedAt = Date.now();
     markPickupTermKnown("even though");
-    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
+    const firstDue = soleSrsCard().due;
+
+    // 復習期日に再表示された表現をもう一度マークする
+    vi.setSystemTime(firstDue);
     surviving(["even though"], "msg-2");
     markPickupTermKnown("even though");
 
-    // 2回目のマークから7日(1回目の間隔)では、まだ14日の間隔内のため抑制する
-    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
-    expect(surviving(["even though"], "msg-3")).toEqual([]);
-
-    // 2回目のマークから14日経過で再表示する
-    vi.advanceTimersByTime(KNOWN_REDISPLAY_BASE_MS);
-    expect(surviving(["even though"], "msg-4")).toEqual(["even though"]);
-  });
-
-  it("再表示間隔には上限があり、何度マークしても上限を超えて延びない", () => {
-    surviving(["even though"], "msg-1");
-    // 上限(KNOWN_REDISPLAY_MAX_MS)を大きく超える回数マークする
-    for (let i = 0; i < 20; i += 1) {
-      markPickupTermKnown("even though");
-    }
-    vi.advanceTimersByTime(KNOWN_REDISPLAY_MAX_MS);
-
-    expect(surviving(["even though"], "msg-2")).toEqual(["even though"]);
+    expect(soleSrsCard().due - firstDue).toBeGreaterThan(firstDue - firstMarkedAt);
+    expect(soleStoredRecord().knownCount).toBe(2);
   });
 
   it("マーク済みでも、表示済みメッセージIDからの再抽出(パイプライン再起動)は抑制しない(画面の非表示は hidden-pickups が担う)", () => {
@@ -284,35 +284,37 @@ describe("markPickupTermKnown(「知っている」マーク。issue #110)", () 
     markPickupTermKnown("pick up");
     vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
 
-    // クールダウンは過ぎたが再表示間隔(7日)内のため抑制される
+    // クールダウンは過ぎたが復習期日(日単位)前のため抑制される
     expect(surviving(["picked up"], "msg-2")).toEqual([]);
   });
 
   it("遭遇記録が無い表現へのマークは、自動表示の記録が空のエントリを作って記録する", () => {
     markPickupTermKnown("even though");
 
-    expect(soleStoredRecord()).toEqual({
-      count: 0,
-      lastShownAt: 0,
-      shownMessageIds: [],
-      knownCount: 1,
-      lastKnownAt: Date.now(),
-      meaningCheckedCount: 0,
-    });
+    const record = soleStoredRecord();
+    expect(record.count).toBe(0);
+    expect(record.lastShownAt).toBe(0);
+    expect(record.shownMessageIds).toEqual([]);
+    expect(record.knownCount).toBe(1);
+    expect(record.lastKnownAt).toBe(Date.now());
+    expect(record.meaningCheckedCount).toBe(0);
+    expect(record.srsCard).not.toBeNull();
   });
 });
 
-describe("recordPickupMeaningChecked(意味を確認した回数の記録。issue #110)", () => {
-  it("記録すると meaningCheckedCount を加算する(抑制の挙動には影響しない)", () => {
+describe("recordPickupMeaningChecked(意味を確認した回数の記録。issue #110 / #113)", () => {
+  it("FSRSカードが無い表現への記録は meaningCheckedCount の加算のみで、カードを作らず抑制の挙動にも影響しない", () => {
     surviving(["even though"], "msg-1");
 
     recordPickupMeaningChecked("even though");
     recordPickupMeaningChecked("even though");
 
+    // 意味確認だけでは新たな抑制期間を作らない(カードはマーク時に初めて作られる)
     const record = soleStoredRecord();
     expect(record.meaningCheckedCount).toBe(2);
     expect(record.count).toBe(1);
     expect(record.lastKnownAt).toBeNull();
+    expect(record.srsCard).toBeNull();
   });
 
   it("遭遇記録が無い表現(手動Pick upだけの表現)にも、自動表示の記録が空のエントリを作って記録する", () => {
@@ -325,11 +327,27 @@ describe("recordPickupMeaningChecked(意味を確認した回数の記録。issu
       knownCount: 0,
       lastKnownAt: null,
       meaningCheckedCount: 1,
+      srsCard: null,
     });
+  });
+
+  it("FSRSカードがある(マーク済みの)表現の意味確認は忘却シグナルとしてAgain評価を適用し、復習期日を近づける", () => {
+    surviving(["even though"], "msg-1");
+    markPickupTermKnown("even though");
+    const dueBeforeLapse = soleSrsCard().due;
+
+    // 復習期日の途中で意味を確認した = 「知っている」はずの表現を忘れていた
+    vi.advanceTimersByTime(PICKUP_ENCOUNTER_COOLDOWN_MS);
+    recordPickupMeaningChecked("even though");
+
+    const card = soleSrsCard();
+    expect(card.due).toBeLessThan(dueBeforeLapse);
+    expect(card.lapses).toBe(1);
+    expect(soleStoredRecord().meaningCheckedCount).toBe(1);
   });
 });
 
-describe("保存形式の移行(version 1 → 2)", () => {
+describe("保存形式の移行(version 1 / 2 → 3)", () => {
   it("version 1 の保存データは既存の遭遇記録を保持したまま新フィールドの既定値を補って読み込む", () => {
     // Phase 1(PR #109)が保存した version 1 形式
     window.localStorage.setItem(
@@ -343,10 +361,10 @@ describe("保存形式の移行(version 1 → 2)", () => {
     // クールダウン内のため v1 の記録に基づいて抑制される(記録が引き継がれている証拠)
     expect(surviving(["even though"], "msg-new")).toEqual([]);
 
-    // 書き戻しは version 2 形式で、新フィールドは既定値が補われている
+    // 書き戻しは version 3 形式で、新フィールドは既定値が補われている
     const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
     expect(raw).not.toBeNull();
-    expect((JSON.parse(raw as string) as { version: number }).version).toBe(2);
+    expect((JSON.parse(raw as string) as { version: number }).version).toBe(3);
     expect(storedEntries()["even though"]).toEqual({
       count: 4,
       lastShownAt: Date.now() - 1000,
@@ -354,6 +372,71 @@ describe("保存形式の移行(version 1 → 2)", () => {
       knownCount: 0,
       lastKnownAt: null,
       meaningCheckedCount: 0,
+      srsCard: null,
+    });
+  });
+
+  it("version 2 のマーク済みエントリは、マーク日時にGood評価を1回適用したFSRSカードを合成して抑制を引き継ぐ", () => {
+    // Phase 2(PR #111)が保存した version 2 形式。1時間前に「知っている」マーク済み
+    const markedAt = Date.now() - 60 * 60 * 1000;
+    window.localStorage.setItem(
+      PICKUP_ENCOUNTER_STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        entries: {
+          "even though": {
+            count: 3,
+            lastShownAt: markedAt,
+            shownMessageIds: ["msg-old"],
+            knownCount: 1,
+            lastKnownAt: markedAt,
+            meaningCheckedCount: 0,
+          },
+        },
+      }),
+    );
+
+    // 旧形式の再表示間隔(7日)相当の抑制が、合成したFSRSカードの復習期日として引き継がれる
+    expect(surviving(["even though"], "msg-new")).toEqual([]);
+
+    const raw = window.localStorage.getItem(PICKUP_ENCOUNTER_STORAGE_KEY);
+    expect(raw).not.toBeNull();
+    expect((JSON.parse(raw as string) as { version: number }).version).toBe(3);
+    const card = soleSrsCard();
+    // 合成カードの復習期日はマーク日時から日単位で先(クールダウンより長い抑制が維持される)
+    expect(card.due).toBeGreaterThan(markedAt + PICKUP_ENCOUNTER_COOLDOWN_MS);
+    expect(card.last_review).toBe(markedAt);
+  });
+
+  it("version 2 の未マークエントリはFSRSカードを合成せず、クールダウン規則だけを引き継ぐ", () => {
+    window.localStorage.setItem(
+      PICKUP_ENCOUNTER_STORAGE_KEY,
+      JSON.stringify({
+        version: 2,
+        entries: {
+          "even though": {
+            count: 3,
+            lastShownAt: Date.now() - 1000,
+            shownMessageIds: ["msg-old"],
+            knownCount: 0,
+            lastKnownAt: null,
+            meaningCheckedCount: 2,
+          },
+        },
+      }),
+    );
+
+    // クールダウン内のため抑制される(v2の記録が引き継がれている証拠)
+    expect(surviving(["even though"], "msg-new")).toEqual([]);
+
+    expect(soleStoredRecord()).toEqual({
+      count: 4,
+      lastShownAt: Date.now() - 1000,
+      shownMessageIds: ["msg-old"],
+      knownCount: 0,
+      lastKnownAt: null,
+      meaningCheckedCount: 2,
+      srsCard: null,
     });
   });
 });

--- a/src/store/pickup-encounters.ts
+++ b/src/store/pickup-encounters.ts
@@ -1,5 +1,5 @@
 /**
- * Pick up の既出管理と習熟状態(issue #108 / #110。ユーザー辞書構想 #107 の Phase 1・2)。
+ * Pick up の既出管理と習熟状態(issue #108 / #110 / #113。ユーザー辞書構想 #107 の Phase 1〜3)。
  *
  * 自動Pick upは同じ定型表現("even though" など)がチャットに流れるたびに毎回抽出・表示するため、
  * 表現キーごとの遭遇記録・習熟状態を持ち、再表示を決定的に抑制する。
@@ -9,22 +9,26 @@
  * - 抑制規則(判定順):
  *   1. 表示済みのメッセージID(上限付きで保持)からの再遭遇は「パイプライン再起動による同じ発言の
  *      再抽出」(`hidden-pickups.ts` に記載の再生成問題)なので、同じ遭遇の再表示として抑制せず記録も変えない
- *   2. 「知っている」マーク済みの表現は、最終マークから再表示間隔(マーク回数で倍増、上限あり)内は
- *      表示しない(遭遇回数だけ加算する)。恒久非表示にはせず、間隔が明けたら忘却チェックの機会として
- *      再表示する。この倍増規則は Phase 3 で FSRS / SM-2 による復習期日計算に置き換える前提の暫定規則
+ *   2. FSRSカード(`lib/srs.ts`。issue #113)を持つ表現は、次回復習期日(`due`)前は表示しない
+ *      (遭遇回数だけ加算する)。恒久非表示にはせず、期日が来たら忘却チェックの機会として再表示する
  *   3. 最終表示からクールダウン内の再遭遇は表示しない(遭遇回数だけ加算する)
- * - 習熟状態の記録(issue #110): 「知っている」マーク(`markPickupTermKnown`。UIの✓ボタンから呼ぶ)と、
- *   意味を確認した回数(`recordPickupMeaningChecked`。手動Pick upの意味生成完了時に呼ぶ)
+ * - 習熟状態の記録(issue #110 / #113):
+ *   - 「知っている」マーク(`markPickupTermKnown`。UIの✓ボタンから呼ぶ): マーク回数・最終マーク日時を
+ *     記録し、FSRSカードに `Rating.Good` を適用して次回復習期日を計算する
+ *   - 意味を確認した回数(`recordPickupMeaningChecked`。手動Pick upの意味生成完了時に呼ぶ): 回数を
+ *     記録する。FSRSカードを持つ(マーク済みの)表現では忘却シグナルとして `Rating.Again` も適用する。
+ *     カードが無い表現ではカードを作らない(意味確認だけで新たな抑制期間を作らないため)
  * - 適用範囲: 抑制は自動Pick up(`pickups.ts`)の順方向・逆方向のみ。手動Pick up(`manual-pickups.ts`)は
  *   ユーザーが明示的に選択した操作のため抑制対象外(記録のみ行う)。翻訳列にも影響しない
  * - 永続化: localStorage(`lib/settings.ts` と同じパターン)。学習状態はユーザーに属するため
- *   チャンネルをまたいで共有する。保存形式はバージョンを持ち、version 1(Phase 1)のデータは
- *   既定値を補って明示的に移行する。保存データが壊れている場合は空の記録から再開する
+ *   チャンネルをまたいで共有する。保存形式はバージョンを持ち、旧形式(version 1・2)のデータは
+ *   既定値・合成カードを補って明示的に移行する。保存データが壊れている場合は空の記録から再開する
  *   (抑制が一時的に働かなくなるだけで表示機能は損なわれず、壊れた学習記録の復元は不可能なため)
  * - この層は完全に決定的(LLM 非依存)
  */
 import { buildTermExpressionKey } from "@/lib/ai/pickup-ordinary-filter";
 import type { PickupTerm } from "@/lib/ai/schemas";
+import { Rating, reviewSrsCard, srsCardSchema } from "@/lib/srs";
 import { z } from "zod";
 
 export const PICKUP_ENCOUNTER_STORAGE_KEY = "chat-sensei:pickup-encounters";
@@ -49,22 +53,9 @@ export const MAX_PICKUP_ENCOUNTER_ENTRIES = 2000;
  */
 export const MAX_SHOWN_MESSAGE_IDS_PER_ENTRY = 10;
 
-/**
- * 「知っている」マーク後の再表示間隔の基準値(1回目のマーク後は7日)。マーク回数ごとに倍増する
- * (7日 → 14日 → 28日…)。恒久非表示にすると忘却に気付けないため、間隔反復学習的に間隔を空けて
- * 再表示する(issue #110。Phase 3 で FSRS / SM-2 による復習期日計算に置き換える前提の暫定規則)
- */
-export const KNOWN_REDISPLAY_BASE_MS = 7 * 24 * 60 * 60 * 1000;
-
-/**
- * 「知っている」マーク後の再表示間隔の上限(56日 = 基準値の8倍)。何度マークしても
- * これ以上は延びない。Phase 3 の復習期日計算の導入までの暫定的な安全弁
- */
-export const KNOWN_REDISPLAY_MAX_MS = 56 * 24 * 60 * 60 * 1000;
-
-/** 表現キー1件ぶんの遭遇記録・習熟状態(version 2) */
+/** 表現キー1件ぶんの遭遇記録・習熟状態(version 3) */
 const encounterRecordSchema = z.object({
-  /** 遭遇回数(抑制した遭遇も含む)。Phase 3(SRS)で習熟度の入力に使う */
+  /** 遭遇回数(抑制した遭遇も含む) */
   count: z.number(),
   /** 最終表示日時(エポックミリ秒)。抑制した遭遇では更新しない。自動表示の記録が無い場合は 0 */
   lastShownAt: z.number(),
@@ -73,18 +64,32 @@ const encounterRecordSchema = z.object({
    * パイプライン再起動による同じ発言の再抽出を抑制対象から外すために持つ
    */
   shownMessageIds: z.array(z.string()),
-  /** 「知っている」マークを押した回数(issue #110)。再表示間隔の倍増と Phase 3 の入力に使う */
+  /** 「知っている」マークを押した回数(issue #110) */
   knownCount: z.number(),
   /** 最後に「知っている」マークを押した日時(エポックミリ秒)。未マークは null */
   lastKnownAt: z.number().nullable(),
-  /** 意味を確認した(手動Pick upで意味を調べた)回数(issue #110)。Phase 3 の入力に使う */
+  /** 意味を確認した(手動Pick upで意味を調べた)回数(issue #110) */
   meaningCheckedCount: z.number(),
+  /**
+   * FSRSカード(issue #113)。`due`(次回復習期日)前の再遭遇を抑制する。
+   * 「知っている」マークで作成・更新され、評価が一度も無い表現は null
+   */
+  srsCard: srsCardSchema.nullable(),
 });
 
-/** 現行の保存形式(version 2)。Phase 3(SRS)での拡張に備えて version を持つ */
+/** 現行の保存形式(version 3) */
 const storedEncountersSchema = z.object({
-  version: z.literal(2),
+  version: z.literal(3),
   entries: z.record(z.string(), encounterRecordSchema),
+});
+
+/** Phase 2(PR #111)が保存していた旧形式(version 2)の記録。読み込み時に合成カードを補って移行する */
+const encounterRecordV2Schema = encounterRecordSchema.omit({ srsCard: true });
+
+/** Phase 2(PR #111)が保存していた旧形式(version 2) */
+const storedEncountersV2Schema = z.object({
+  version: z.literal(2),
+  entries: z.record(z.string(), encounterRecordV2Schema),
 });
 
 /** Phase 1(PR #109)が保存していた旧形式(version 1)。読み込み時に既定値を補って移行する */
@@ -97,9 +102,23 @@ const storedEncountersV1Schema = z.object({
 });
 
 type EncounterRecord = z.infer<typeof encounterRecordSchema>;
+type EncounterRecordV2 = z.infer<typeof encounterRecordV2Schema>;
 
-/** version 1 の記録に Phase 2 で追加したフィールドの既定値。移行と新規エントリの作成で共通に使う */
-const RECORD_V2_DEFAULTS = { knownCount: 0, lastKnownAt: null, meaningCheckedCount: 0 } as const;
+/** 旧形式の記録に Phase 2・3 で追加したフィールドの既定値。移行と新規エントリの作成で共通に使う */
+const RECORD_DEFAULTS = { knownCount: 0, lastKnownAt: null, meaningCheckedCount: 0, srsCard: null } as const;
+
+/**
+ * version 2 の記録を現行形式へ移行する。マーク済み(`lastKnownAt` あり)のエントリは、
+ * マーク日時に `Rating.Good` を1回適用したFSRSカードを合成する(暫定倍増規則が与えていた
+ * 再表示間隔の近似。マーク済み表現の抑制が移行で消えないようにするため)。未マークのエントリは
+ * カード無し(クールダウン規則のみ)として引き継ぐ
+ */
+function migrateRecordV2(record: EncounterRecordV2): EncounterRecord {
+  return {
+    ...record,
+    srsCard: record.lastKnownAt !== null ? reviewSrsCard(null, Rating.Good, record.lastKnownAt) : null,
+  };
+}
 
 /**
  * メモリ上の遭遇記録。初回利用時に localStorage から復元し(`ensureLoaded`)、以後は
@@ -108,14 +127,18 @@ const RECORD_V2_DEFAULTS = { knownCount: 0, lastKnownAt: null, meaningCheckedCou
 let encounters: Map<string, EncounterRecord> | null = null;
 
 /**
- * 保存データ(JSON パース済み)を現行形式の記録へ変換する。version 1 の記録は Phase 2 で
- * 追加したフィールドの既定値を補って明示的に移行する。どの形式にも合わなければ例外を投げる
+ * 保存データ(JSON パース済み)を現行形式の記録へ変換する。version 2 の記録は合成カードを、
+ * version 1 の記録は追加フィールドの既定値を補って明示的に移行する。どの形式にも合わなければ例外を投げる
  */
 function parseStoredEncounters(raw: unknown): Map<string, EncounterRecord> {
   const current = storedEncountersSchema.safeParse(raw);
   if (current.success) return new Map(Object.entries(current.data.entries));
+  const v2 = storedEncountersV2Schema.safeParse(raw);
+  if (v2.success) {
+    return new Map(Object.entries(v2.data.entries).map(([key, record]) => [key, migrateRecordV2(record)]));
+  }
   const v1 = storedEncountersV1Schema.parse(raw);
-  return new Map(Object.entries(v1.entries).map(([key, record]) => [key, { ...record, ...RECORD_V2_DEFAULTS }]));
+  return new Map(Object.entries(v1.entries).map(([key, record]) => [key, { ...record, ...RECORD_DEFAULTS }]));
 }
 
 /** localStorage から遭遇記録を復元する。無い場合・壊れている場合は空の記録から再開する */
@@ -142,16 +165,8 @@ function persist(loaded: Map<string, EncounterRecord>): void {
   }
   window.localStorage.setItem(
     PICKUP_ENCOUNTER_STORAGE_KEY,
-    JSON.stringify({ version: 2, entries: Object.fromEntries(loaded) }),
+    JSON.stringify({ version: 3, entries: Object.fromEntries(loaded) }),
   );
-}
-
-/**
- * 「知っている」マークからの再表示間隔。マーク回数ごとに基準値(7日)を倍増し、上限で頭打ちにする。
- * `knownCount` が 0(未マーク)の場合は呼ばない前提(呼び出し側で lastKnownAt の null を先に判定する)
- */
-function knownRedisplayIntervalMs(knownCount: number): number {
-  return Math.min(KNOWN_REDISPLAY_BASE_MS * 2 ** (knownCount - 1), KNOWN_REDISPLAY_MAX_MS);
 }
 
 /**
@@ -162,7 +177,7 @@ function knownRedisplayIntervalMs(knownCount: number): number {
 function ensureRecord(loaded: Map<string, EncounterRecord>, key: string): EncounterRecord {
   const existing = loaded.get(key);
   if (existing !== undefined) return existing;
-  const created: EncounterRecord = { count: 0, lastShownAt: 0, shownMessageIds: [], ...RECORD_V2_DEFAULTS };
+  const created: EncounterRecord = { count: 0, lastShownAt: 0, shownMessageIds: [], ...RECORD_DEFAULTS };
   loaded.set(key, created);
   return created;
 }
@@ -184,17 +199,17 @@ export function suppressRecentPickupTerms(terms: PickupTerm[], messageId: string
     const record = loaded.get(key);
     if (record === undefined) {
       // 初回遭遇: 表示して記録を作る
-      loaded.set(key, { count: 1, lastShownAt: now, shownMessageIds: [messageId], ...RECORD_V2_DEFAULTS });
+      loaded.set(key, { count: 1, lastShownAt: now, shownMessageIds: [messageId], ...RECORD_DEFAULTS });
       shown.push(item);
     } else if (record.shownMessageIds.includes(messageId)) {
       // 表示済みの発言からの再抽出(パイプライン再起動): 同じ遭遇の再表示として扱い、記録は変えない。
       // マーク済みの表現でも同様に返す(押した行の画面上の非表示は hidden-pickups が担う)
       shown.push(item);
     } else if (
-      (record.lastKnownAt !== null && now - record.lastKnownAt < knownRedisplayIntervalMs(record.knownCount)) ||
+      (record.srsCard !== null && now < record.srsCard.due) ||
       now - record.lastShownAt < PICKUP_ENCOUNTER_COOLDOWN_MS
     ) {
-      // 「知っている」マークからの再表示間隔内、またはクールダウン内の再遭遇: 抑制する。
+      // FSRSカードの復習期日前、またはクールダウン内の再遭遇: 抑制する。
       // 遭遇回数だけ加算し、最終表示日時・表示したメッセージIDは表示していないので変えない
       loaded.set(key, { ...record, count: record.count + 1 });
     } else {
@@ -213,26 +228,31 @@ export function suppressRecentPickupTerms(terms: PickupTerm[], messageId: string
 }
 
 /**
- * 表現に「知っている」マークを付ける(issue #110)。マーク回数と最終マーク日時を記録し、
- * 以後の自動Pick upを再表示間隔(マーク回数で倍増、上限あり)のあいだ抑制する。
- * Pick up列の✓ボタン(`page.tsx`)から呼ぶ。押した行の画面上の非表示は呼び出し側が
- * `hidden-pickups.ts` で行う(この関数は学習状態の記録と以後の抑制だけを担う)
+ * 表現に「知っている」マークを付ける(issue #110 / #113)。マーク回数と最終マーク日時を記録し、
+ * FSRSカードに `Rating.Good` を適用して次回復習期日を計算する。以後の自動Pick upは
+ * 復習期日(`due`)まで抑制される。Pick up列の✓ボタン(`page.tsx`)から呼ぶ。
+ * 押した行の画面上の非表示は呼び出し側が `hidden-pickups.ts` で行う
+ * (この関数は学習状態の記録と以後の抑制だけを担う)
  */
 export function markPickupTermKnown(term: string): void {
   const loaded = ensureLoaded();
+  const now = Date.now();
   const record = ensureRecord(loaded, buildTermExpressionKey(term));
   loaded.set(buildTermExpressionKey(term), {
     ...record,
     knownCount: record.knownCount + 1,
-    lastKnownAt: Date.now(),
+    lastKnownAt: now,
+    srsCard: reviewSrsCard(record.srsCard, Rating.Good, now),
   });
   persist(loaded);
 }
 
 /**
- * 表現の意味を確認した(手動Pick upで意味を調べた)ことを記録する(issue #110)。
- * 手動Pick up(`manual-pickups.ts`)の意味生成が完了した時点で呼ぶ。抑制の挙動には影響せず、
- * Phase 3(SRS)の習熟度計算の入力として回数だけを蓄積する
+ * 表現の意味を確認した(手動Pick upで意味を調べた)ことを記録する(issue #110 / #113)。
+ * 手動Pick up(`manual-pickups.ts`)の意味生成が完了した時点で呼ぶ。回数を蓄積するほか、
+ * FSRSカードを持つ(マーク済みの)表現では「知っているはずの表現を忘れていた」忘却シグナルとして
+ * `Rating.Again` を適用し、復習期日を近づける。カードが無い表現ではカードを作らない
+ * (意味確認だけで新たな抑制期間を作らないため)
  */
 export function recordPickupMeaningChecked(term: string): void {
   const loaded = ensureLoaded();
@@ -240,6 +260,7 @@ export function recordPickupMeaningChecked(term: string): void {
   loaded.set(buildTermExpressionKey(term), {
     ...record,
     meaningCheckedCount: record.meaningCheckedCount + 1,
+    srsCard: record.srsCard !== null ? reviewSrsCard(record.srsCard, Rating.Again, Date.now()) : null,
   });
   persist(loaded);
 }


### PR DESCRIPTION
## Summary

「知っている」マーク後の再表示間隔を、Phase 2 の暫定規則(マーク回数で倍増 7日→上限56日)から FSRS(`ts-fsrs`)による復習期日計算に置き換えます。issue #113 のスコープ決定(期日計算の置き換えのみ・既存シグナルを評価入力に使う・再提示は現行のPick up列で自然に行う)に沿った実装です。

## 変更内容

- **`src/lib/srs.ts`(新設)**: FSRSによる復習期日計算のラッパー。学習ステップ無効(ts-fsrs 既定の1分→10分ステップを使うとマーク直後の抑制が数分になってしまうため、日単位の長期スケジュールのみ)・ファズ無効(決定的)で構成し、localStorage 保存用に日時をエポックミリ秒へ変換した数値のみのシリアライズ形式(`SrsCard`)で受け渡しします
- **`src/store/pickup-encounters.ts`**: 抑制規則2(マーク後の倍増間隔)を「FSRSカードの復習期日(`due`)前なら抑制」に置き換え。規則1(表示済みメッセージID)・規則3(30分クールダウン)は変更していません
  - 「知っている」✓マーク → `Rating.Good` を適用して次回復習期日を計算
  - マーク済み表現の意味確認(手動Pick up) → 忘却シグナルとして `Rating.Again` を適用し復習期日を近づける。カードが無い表現ではカードを作らない(意味確認だけで新たな抑制期間を作らないため)
  - 暫定規則の定数(`KNOWN_REDISPLAY_BASE_MS` / `KNOWN_REDISPLAY_MAX_MS`)を削除
- **保存形式 version 3 への移行**: version 2 のマーク済みエントリは、マーク日時に `Rating.Good` を1回適用した合成カードで抑制を引き継ぎます(旧倍増規則の初回7日に対し日単位の近似)。未マークエントリと version 1 はカード無しで移行します

## テスト

- `src/lib/srs.test.ts`(新設): 初回Good評価の期日が日単位になること・間隔反復で伸びること・AgainがGoodより期日を近づけること・決定性・JSON往復
- `src/store/pickup-encounters.test.ts`: 復習期日前の抑制/期日到来での再表示・再マークでの間隔伸長・意味確認のAgain適用・version 1/2 → 3 移行を追加更新
- Lint(警告ゼロ)・型チェック・全テスト(1017件)・ビルド・CodeRabbitレビュー(指摘ゼロ)を実施済み

Closes #113
Refs #107 (Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX4pbS2JLSzzL4u7iaLCrH